### PR TITLE
Added task to filter scenarios on inputs and extract e-mail addresses

### DIFF
--- a/lib/tasks/chp_filter.rake
+++ b/lib/tasks/chp_filter.rake
@@ -5,6 +5,7 @@ task :chp_filter => [:environment] do
   date    = ENV['date'] || "01/01/2009"
   email   = ENV['email'] && ENV['email'].upcase=='TRUE'
   file    = ENV['file']
+  list    = ENV['list'] && ENV['list'].upcase=='TRUE'
 
   unless key && !key.blank?
     puts 'Missing key'
@@ -16,6 +17,15 @@ task :chp_filter => [:environment] do
   selection = valid_scenarios.select { |scen| scen.user_values.keys.delete_if { |h_key| not(exclude.blank?) ? Regexp.new(exclude).match(h_key.to_s) : false }.select { |h_key| Regexp.new(key).match(h_key.to_s)}.count > 0 }
   users = selection.collect { |scen| scen.user_id }.uniq
   active_users = users.select { |user| User.exists?(user) }
+  
+  if list
+    selection.each do |scen| 
+      occurrences = scen.user_values.keys.select { |h_key| Regexp.new(key).match(h_key.to_s) }
+      occurrences.each {|entry| puts "#{ scen.id }: Value for #{ entry } = #{ scen.user_values[entry] }" }
+      puts "-----"
+    end
+    # puts "Value for #{key} = #{ scen.user_values[scen.user_values.keys.select { |h_key| Regexp.new(key).match(key) }.first] }"
+  end
   
   puts "Selected scenarios  : #{selection.count}"
   puts "# of users affected : #{active_users.count}"


### PR DESCRIPTION
Task to filter scenarios based on presence of certain key or pattern in
user_values. Optionally, you can exclude another (wider) key/pattern that
contains the key/pattern as well as filter by date. The task only selects
scenarios that are related to registered users. By providing email and
file arguments, a list of e-mail addresses is provided.

**Usage**

`rake chp_filter key=<key/pattern> [exclude=<key/pattern>][date=<date>] \
[email=TRUE file=<outputfile>][list=TRUE]` 

**Examples**

`rake chp_filter key=_chp_ exclude=_micro_chp_ date=01-01-2012 email=TRUE \
  file=./addresses.txt`

_This example extracts the e-mail addresses from all scenarios that have inputs
that include '_chp_', but excluding inputs that include '_micro_chp_'.
Scenarios last updated before 01/01/2012 are excluded. The output is saved to
the file 'addresses.txt' in the current directory_
