### PR TITLE
Changed has_energy_storage into has_electricity_storage

### DIFF
--- a/app/models/qernel/area.rb
+++ b/app/models/qernel/area.rb
@@ -32,7 +32,7 @@ module Qernel
       :has_climate,
       :has_coastline,
       :has_cold_network,
-      :has_energy_storage,
+      :has_electricity_storage,
       :has_employment,
       :has_lignite,
       :has_merit_order,


### PR DESCRIPTION
In order to be consistent, this dependable attribute has been renamed to `has_electricity_storage`. This change is associated with similar changes (and commits) to respectively **etmodel** and **etsource**.
### CAUTION

Following the update of these three repositories, the dependent on attribute of the associated sidebar and chart needs to be updated as well!!
