### PR TITLE
Added API call to retrieve series of gqueries for both presets and scena...

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -4,7 +4,7 @@ module Api
       respond_to :json
 
       before_filter :find_scenario, :only => [:update, :sandbox]
-      before_filter :find_preset_or_scenario, :only => :show
+      before_filter :find_preset_or_scenario, :only => [:show, :dashboard]
 
       # GET /api/v3/scenarios/:id
       #
@@ -13,6 +13,20 @@ module Api
       #
       def show
         render json: ScenarioPresenter.new(self, @scenario, params[:detailed])
+      end
+
+      def dashboard
+        presenter = nil
+        
+        Scenario.transaction do
+          presenter = ScenarioDashboardPresenter.new(self, @scenario, params)
+        end
+        
+        if presenter.errors.any?
+          render json: { errors: presenter.errors }, status: 422
+        else
+          render json: presenter
+        end
       end
 
       # GET /api/v3/scenarios/templates

--- a/app/models/api/v3/scenario_dashboard_presenter.rb
+++ b/app/models/api/v3/scenario_dashboard_presenter.rb
@@ -1,0 +1,107 @@
+module Api
+  module V3
+    class ScenarioDashboardPresenter
+      def initialize(controller, scenario, params)
+        @controller = controller
+        @scenario = scenario
+        @requested_queries = params[:gqueries] || []
+        @detailed = params[:detailed].present?
+
+        @errors  = []
+        @results = {}
+
+        if assert_valid_gqueries!
+          @results = perform_gqueries!
+        end
+      end
+
+      # The scenario update and query results ready for JSON.
+      #
+      # @return [Hash]
+      #
+      def as_json(*)
+        { scenario: ScenarioPresenter.new(@controller, @scenario, @detailed),
+          gqueries: @results }
+      end
+
+      # Returns all of the errors with the user request. For interop with the
+      # Rails Responder.
+      #
+      # @return [Array<String>]
+      #
+      def errors
+        @errors
+      end
+
+      #######
+      private
+      #######
+
+      # Returns an array of Gquery objects which the user has requested to be
+      # performed.
+      #
+      # @return [Array<Gquery>]
+      #
+      def queries
+        @requested_queries.map { |key| Gquery.get(key) }.compact
+      end
+
+      # Checks each of the gquery keys requested by the user, and asserts that
+      # the query exists. Adds messages to the errors object and returns false
+      # if a query is not present.
+      #
+      # @return [true, false]
+      #
+      def assert_valid_gqueries!
+        return true if queries.length == @requested_queries.length
+
+        (@requested_queries - queries.map(&:key)).each do |key|
+          @errors.push("Gquery #{ key } does not exist")
+        end
+
+        false
+      end
+
+      # Performs the queries requested. Adds messages to the errors object if
+      # one or more queries fail.
+      #
+      # @return [Hash{String => Array<Numeric>}]
+      #
+      def perform_gqueries!
+        gql = @scenario.gql
+
+        queries.each_with_object(Hash.new) do |query, results|
+          present = perform_query(gql, :present, query)
+          future  = perform_query(gql, :future,  query)
+
+          results[query.key] = {
+            present: present, future: future, unit: query.unit
+          }
+        end
+      rescue Exception => exception
+        # An error while setting up the graph.
+        @errors.push(exception.message)
+      end
+
+      # Performs an individual query.
+      #
+      # @param [Gql::Gql] gql    The graph to be queries.
+      # @param [Symbol]   period One of :present or :future
+      # @param [Gquery]   query  The query to be performed.
+      #
+      # @return [Numeric, false]
+      #   Returns the query result, or nil if there was an error. Some gqueries
+      #  return boolean values, so false must be preserved
+      #
+      def perform_query(gql, period, query)
+        gql.public_send(:"query_#{ period }", query)
+      rescue Exception => exception
+        # TODO Exception is *way* too low level to be rescued; we could do
+        #      with a GraphError exception for "acceptable" graph errors.
+        @errors.push("#{ query.key }/#{ period } - #{ exception.message }")
+        nil
+      end
+
+    end # ScenarioDashboardPresenter
+  end # V3
+end # Api

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Etm::Application.routes.draw do
       resources :scenarios, :only => [:show, :create, :update] do
         member do
           get :sandbox
+          put :dashboard
         end
         get :templates, :on => :collection
         resources :converters, :only => :show do


### PR DESCRIPTION
...rios

Added API call to retrieve one or more gqueries for a scenario or a preset.
Call has been implemented as a PUT request to avoid IE's URL length limit
issues that would come with a more appropriate implementation as a GET
request.

Call will be primarily used from etcentral to retrieve dashboard info on
presets.

Example:

PUT etengine.dev/api/v3/scenarios/80/dashboard
- 'gqueries': an array of gqueries to run
- 'detailed': optional boolean. If true then the `scenario` object response
  will contain extra information such as `description`, `user_values` and
  `use_fce`
