### PR TITLE
Allow download of Merit Order load curves through ET-Engine

### DIFF
--- a/app/controllers/data/merit_controller.rb
+++ b/app/controllers/data/merit_controller.rb
@@ -1,0 +1,22 @@
+class Data::MeritController < Data::BaseController
+  layout 'application'
+
+  def index
+  end
+
+  def download
+
+    moi = Qernel::Plugins::MeritOrder::MeritOrderInjector.new(@gql.future_graph, true)
+    moi.setup_items
+
+    contents = CSV.generate do |csv|
+      moi.m.load_curves.each do |row|
+        csv << row
+      end
+    end
+
+    send_data(contents, type: 'test/csv', filename: 'load_curves.csv')
+
+  end
+
+end

--- a/app/views/data/merit/index.html.haml
+++ b/app/views/data/merit/index.html.haml
@@ -1,0 +1,8 @@
+= render "data/shared/data_subnav"
+
+%h1
+  Merit Order
+
+%p
+  = link_to "Download CSV with load curves for the current scenario",
+    data_merit_download_path

--- a/app/views/data/shared/_data_subnav.html.haml
+++ b/app/views/data/shared/_data_subnav.html.haml
@@ -6,6 +6,7 @@
     %li= link_to 'Carriers',       data_carriers_path
     %li= link_to 'Converters',     data_converters_path
     %li= link_to "Inputs",         data_inputs_path
+    %li= link_to "Merit",          data_merit_path
     %li.dropdown
       %a.dropdown-toggle{:href => '#', 'data-toggle' => 'dropdown'} Layout
       %ul.dropdown-menu

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Etm::Application.routes.draw do
         end
       end
 
+
       resources :converters, :only => [:index, :show]
       resources :carriers, :only => [:index, :show]
       resource  :area, :as => :area, :only => :show
@@ -92,6 +93,9 @@ Etm::Application.routes.draw do
       match '/gql/search' => "gql#search", :as => :gql_search
       match '/gql/log' => "gql#log", :as => :gql_log
       match '/gql/warnings' => "gql#warnings", :as => :gql_warnings
+
+      match '/merit' => 'merit#index'
+      match '/merit/download' => 'merit#download', as: :merit_download
 
       match 'search' => 'search#index', :as => :search
     end


### PR DESCRIPTION
I strongly believe the MeritOrderInjector should be refactored. Currently, I adjusted it slightly, and I am re-using it in the merit_controller.
