### PR TITLE
Reinstated warning regarding production server. Fixes #633

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -80,8 +80,10 @@
               %a.close x
               %p= msg
 
-        - if live_server?
-          .alert-message.error This is the production server!
+      - if live_server?
+        .alert.alert-danger This is the production server!
+      - else
+        .alert.alert-success This is a local or beta server
 
       #content= yield
       #footer


### PR DESCRIPTION
Message was indented one level too far and incorrect Bootstrap classes were used. Also added green alert message in case one is working with a local or beta instance.
