### PR TITLE
Capacity methods refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'rubel',         '>= 0.0.3',       github:  'quintel/rubel'
 gem 'merit',         '>=0.1.0',        git:     'git@github.com:quintel/merit.git'
 gem 'turbine-graph', '>=0.1',          require: 'turbine'
 gem 'refinery',      ref: 'a0dcae9',   git:     'git@github.com:quintel/refinery.git'
-gem 'atlas',         ref: 'cbe663f',   git:     'git@github.com:quintel/atlas.git'
+gem 'atlas',         ref: '03209a2',   git:     'git@github.com:quintel/atlas.git'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,8 +32,8 @@ GIT
 
 GIT
   remote: git@github.com:quintel/atlas.git
-  revision: cbe663f82c194f6ff712531ae9ed1d7ebd050cdc
-  ref: cbe663f
+  revision: 03209a2e32ed4673487724e205e6ec53d2b003c3
+  ref: 03209a2
   specs:
     atlas (0.0.2)
       activemodel (~> 3.2.12)

--- a/app/models/api/v3/README.mdown
+++ b/app/models/api/v3/README.mdown
@@ -444,7 +444,7 @@ If the scenario_id is missing then the controller will use the latest scenario.
         "groups": ["electricity_production", "central_production"],
         "data": {
             "operational": {
-                "typical_nominal_input_capacity": {
+                "input_capacity": {
                     "present": 162.60162601626,
                     "future": 162.60162601626
                 },

--- a/app/models/qernel/converter_api/attributes.rb
+++ b/app/models/qernel/converter_api/attributes.rb
@@ -21,8 +21,7 @@ module Qernel
         :land_use_per_unit => ['', ''],
         :part_ets => ['Do emissions have to be paid for through the ETS?', 'yes=1 / no=0'],
         :technical_lifetime => ['Technical lifetime', 'year'],
-        :typical_nominal_input_capacity => ['', 'MWinput'],
-        :typical_effective_input_capacity => ['', 'MWinput']
+        :typical_input_capacity => ['', 'MWinput']
       },
 
       :cost => {

--- a/app/models/qernel/converter_api/capacity_production.rb
+++ b/app/models/qernel/converter_api/capacity_production.rb
@@ -13,7 +13,7 @@ class Qernel::ConverterApi
   #
   def nominal_capacity_electricity_output_per_unit
     fetch_and_rescue(:nominal_capacity_electricity_output_per_unit) do
-      nominal_input_capacity * electricity_output_conversion
+      input_capacity * electricity_output_conversion
     end
   end
   unit_for_calculation "nominal_capacity_electricity_output_per_unit", 'MW'
@@ -22,7 +22,7 @@ class Qernel::ConverterApi
   #
   def nominal_capacity_heat_output_per_unit
     fetch_and_rescue(:nominal_capacity_heat_output_per_unit) do
-      nominal_input_capacity * heat_output_conversion
+      input_capacity * heat_output_conversion
     end
   end
   unit_for_calculation "nominal_capacity_heat_output_per_unit", 'MW'
@@ -31,7 +31,7 @@ class Qernel::ConverterApi
   #
   def nominal_capacity_cooling_output_per_unit
     fetch_and_rescue(:nominal_capacity_cooling_output_per_unit) do
-      nominal_input_capacity * cooling_output_conversion
+      input_capacity * cooling_output_conversion
     end
   end
   unit_for_calculation "nominal_capacity_cooling_output_per_unit", 'MW'
@@ -79,7 +79,7 @@ class Qernel::ConverterApi
 
   def typical_electricity_production_capacity
     fetch_and_rescue(:typical_electricity_production_capacity) do
-      electricity_output_conversion * nominal_input_capacity
+      electricity_output_conversion * input_capacity
     end
   end
   unit_for_calculation "typical_electricity_production_capacity", 'MW'
@@ -93,7 +93,7 @@ class Qernel::ConverterApi
 
   def installed_production_capacity_in_mw_electricity
     fetch_and_rescue(:installed_production_capacity_in_mw_electricity) do
-      electricity_output_conversion * nominal_input_capacity * number_of_units
+      electricity_output_conversion * input_capacity * number_of_units
     end
   end
   unit_for_calculation "installed_production_capacity_in_mw_electricity", 'MW'
@@ -129,8 +129,8 @@ class Qernel::ConverterApi
 
   ###instead of heat_production_in_mw, check for NIL in sum function!
   def installed_production_capacity_in_mw_heat
-    if nominal_input_capacity && number_of_units
-      heat_output_conversion * nominal_input_capacity * number_of_units
+    if input_capacity && number_of_units
+      heat_output_conversion * input_capacity * number_of_units
     end
   end
   unit_for_calculation "installed_production_capacity_in_mw_heat", 'MW'
@@ -146,8 +146,8 @@ class Qernel::ConverterApi
   unit_for_calculation "production_based_on_number_of_heat_units", 'MJ'
 
   def typical_heat_production_per_unit
-    if nominal_input_capacity
-      heat_output_conversion * nominal_input_capacity * full_load_seconds
+    if input_capacity
+      heat_output_conversion * input_capacity * full_load_seconds
     end
   end
   unit_for_calculation "typical_heat_production_per_unit", 'MJ'

--- a/app/models/qernel/converter_api/conversion.rb
+++ b/app/models/qernel/converter_api/conversion.rb
@@ -28,7 +28,7 @@ class Qernel::ConverterApi
   #
   # Calculation methods to go from plant/year to another unit:
   # * plant:           DEFAULT unit, so no conversion needed
-  # * mw_input:        divide by method nominal_input_capacity
+  # * mw_input:        divide by method input_capacity
   # * mw_electricity:  divide by attribute electricity_output_capacity
   # * mw_heat:         divide by attribute heat_output_capacity
   # * converter:       multiply by number_of_units
@@ -152,7 +152,7 @@ class Qernel::ConverterApi
 
     # MW capacity
     when :mw_input
-      cost / nominal_input_capacity.to_f
+      cost / input_capacity.to_f
     when :mw_electricity
       cost / electricity_output_capacity.to_f
     when :mw_heat

--- a/app/models/qernel/converter_api/cost.rb
+++ b/app/models/qernel/converter_api/cost.rb
@@ -11,28 +11,29 @@ class Qernel::ConverterApi
   # Input Capacity #
   ##################
 
-  # Calculates the input capacity of a typical plant, based on
-  # the output capacity in MW.
-  # If the converter has an electrical efficiency and capacity this is used
-  # to calculate the input capacity. Otherwise it checks for a heat capacity
-  # and heat efficiency. If this can also not be found it will try cooling.
-  # Finally it will try the attribute typical_nominal_input_capacity
-  # (currently only used for electric transport). If all return nil 0.0 will
-  # be used. This should only happen for statistical converters.
+  # Calculates the input capacity of a typical plant, based on the output
+  # capacity in MW.
+  #
+  # If the converter has an electrical efficiency and capacity this is used to
+  # calculate the input capacity. Otherwise it checks for a heat capacity and
+  # heat efficiency. If this can also not be found it will try cooling.
+  #
+  # Finally it will try the attribute typical_input_capacity (currently only
+  # used for electric transport). If all return nil 0.0 will be used. This
+  # should only happen for statistical converters.
   #
   # @return [Float] Input capacity of a typical plant in MWinput
   #
   # DEBT: move to another file when cleaning up Converter API
-  #
-  def nominal_input_capacity
-    fetch_and_rescue(:nominal_input_capacity) do
-      electric_based_nominal_input_capacity ||
-        heat_based_nominal_input_capacity ||
-          cooling_based_nominal_input_capacity ||
-            typical_nominal_input_capacity || 0.0
+  def input_capacity
+    fetch_and_rescue(:input_capacity) do
+      electric_based_input_capacity ||
+        heat_based_input_capacity ||
+        cooling_based_input_capacity ||
+        typical_input_capacity || 0.0
     end
   end
-  unit_for_calculation "nominal_input_capacity", 'MWinput'
+  unit_for_calculation "input_capacity", 'MWinput'
 
   ###################
   # Chart functions #
@@ -272,7 +273,7 @@ class Qernel::ConverterApi
     fetch_and_rescue(:variable_operation_and_maintenance_costs_per_typical_input) do
       (variable_operation_and_maintenance_costs_per_full_load_hour +
       variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour) /
-      (nominal_input_capacity * 3600.0)
+      (input_capacity * 3600.0)
     end
   end
   unit_for_calculation "variable_operation_and_maintenance_costs_per_typical_input", 'euro / MJ'
@@ -297,8 +298,8 @@ class Qernel::ConverterApi
   #
   # DEBT: move to another file when cleaning up Converter API
   #
-  def electric_based_nominal_input_capacity
-    fetch_and_rescue(:electric_based_nominal_input_capacity) do
+  def electric_based_input_capacity
+    fetch_and_rescue(:electric_based_input_capacity) do
       if electricity_output_conversion && electricity_output_conversion > 0
         electricity_output_capacity / electricity_output_conversion
       else
@@ -306,7 +307,7 @@ class Qernel::ConverterApi
       end
     end
   end
-  unit_for_calculation "electric_based_nominal_input_capacity", 'MWinput'
+  unit_for_calculation "electric_based_input_capacity", 'MWinput'
 
   # This method calculates the input capacity of a plant based on the
   # heat output capacity and heat efficiency of the converter
@@ -315,8 +316,8 @@ class Qernel::ConverterApi
   #
   # DEBT: move to another file when cleaning up Converter API
   #
-  def heat_based_nominal_input_capacity
-    fetch_and_rescue(:heat_based_nominal_input_capacity) do
+  def heat_based_input_capacity
+    fetch_and_rescue(:heat_based_input_capacity) do
       if heat_output_conversion && heat_output_conversion > 0
         heat_output_capacity / heat_output_conversion
       else
@@ -324,7 +325,7 @@ class Qernel::ConverterApi
       end
     end
   end
-  unit_for_calculation "heat_based_nominal_input_capacity", 'MWinput'
+  unit_for_calculation "heat_based_input_capacity", 'MWinput'
 
   # This method calculates the input capacity of one plant based on the
   # heat capacity of the plant and the cooling efficiency.
@@ -338,8 +339,8 @@ class Qernel::ConverterApi
   #
   # DEBT: move to another file when cleaning up Converter API
   #
-  def cooling_based_nominal_input_capacity
-    fetch_and_rescue(:cooling_based_nominal_input_capacity) do
+  def cooling_based_input_capacity
+    fetch_and_rescue(:cooling_based_input_capacity) do
       if cooling_output_conversion && cooling_output_conversion > 0
         heat_output_capacity / cooling_output_conversion
       else
@@ -347,7 +348,7 @@ class Qernel::ConverterApi
       end
     end
   end
-  unit_for_calculation "cooling_based_nominal_input_capacity", 'MWinput'
+  unit_for_calculation "cooling_based_input_capacity", 'MWinput'
 
   # Calculates the typical electricity output of one plant of this type
   #
@@ -389,7 +390,7 @@ class Qernel::ConverterApi
   #
   def typical_input
     fetch_and_rescue(:typical_input) do
-      nominal_input_capacity * full_load_seconds
+      input_capacity * full_load_seconds
     end
   end
   unit_for_calculation "typical_input", 'MJ / year'

--- a/app/models/qernel/converter_api/helper_calculations.rb
+++ b/app/models/qernel/converter_api/helper_calculations.rb
@@ -11,11 +11,11 @@ class Qernel::ConverterApi
     else
       fetch_and_rescue(:number_of_units) do
         # #to_i also checks if it is nil
-        if nominal_input_capacity.nil? || nominal_input_capacity.zero? ||
+        if input_capacity.nil? || input_capacity.zero? ||
               full_load_seconds.nil? || full_load_seconds.zero?
           0
         else
-          (demand || preset_demand) / (nominal_input_capacity * full_load_seconds)
+          (demand || preset_demand) / (input_capacity * full_load_seconds)
         end
       end
     end

--- a/app/models/qernel/converter_api/network.rb
+++ b/app/models/qernel/converter_api/network.rb
@@ -10,7 +10,7 @@ class Qernel::ConverterApi
   def peak_load_in_mw
     fetch_and_rescue(:peak_load_in_mw) do
       (electricity_output_conversion + electricity_input_conversion) *
-        nominal_input_capacity * number_of_units
+        input_capacity * number_of_units
     end
   end
   unit_for_calculation "peak_load_in_mw", 'MW'
@@ -31,7 +31,7 @@ class Qernel::ConverterApi
 
   def peak_load_capacity_per_unit
     fetch_and_rescue(:peak_load_units_capacity_per_unit) do
-      ( (electricity_input_conversion || 0.0) - (electricity_output_conversion|| 0.0) ) * (nominal_input_capacity|| 0.0)
+      ( (electricity_input_conversion || 0.0) - (electricity_output_conversion|| 0.0) ) * (input_capacity|| 0.0)
     end
   end
   unit_for_calculation "peak_load_capacity_per_unit", 'MW'

--- a/app/models/qernel/method_meta_data.rb
+++ b/app/models/qernel/method_meta_data.rb
@@ -36,11 +36,10 @@ module Qernel
           :primary_demand_of_sustainable => {}
         },
         :technical => {
-          :nominal_input_capacity => {},
-          :electric_based_nominal_input_capacity => {label: '', unit: 'MWinput'},
-          :heat_based_nominal_input_capacity => {label: '', unit: 'MWinput'},
-          :cooling_based_nominal_input_capacity => {label: '', unit: 'MWinput'},
-          :nominal_input_capacity => {},
+          :input_capacity => {},
+          :electric_based_input_capacity => {label: '', unit: 'MWinput'},
+          :heat_based_input_capacity => {label: '', unit: 'MWinput'},
+          :cooling_based_input_capacity => {label: '', unit: 'MWinput'},
           :number_of_units => {}
         },
         :costs_per_plant => {

--- a/app/models/qernel/plugins/merit_order/merit_order_injector.rb
+++ b/app/models/qernel/plugins/merit_order/merit_order_injector.rb
@@ -58,7 +58,7 @@ module Qernel::Plugins
 
           # TODO: should this be moved to gem, too?
           converter.demand = fls *
-                             converter.nominal_input_capacity *
+                             converter.input_capacity *
                              dispatchable.number_of_units
 
         end
@@ -103,7 +103,7 @@ module Qernel::Plugins
             key: p.key,
             marginal_costs: c.variable_costs_per(:mwh_electricity),
             output_capacity_per_unit:
-              c.electricity_output_conversion * c.nominal_input_capacity,
+              c.electricity_output_conversion * c.input_capacity,
             number_of_units: c.number_of_units,
             availability: c.availability,
             fixed_costs_per_unit: c.send(:fixed_costs),

--- a/spec/models/qernel/converter_api/cost_spec.rb
+++ b/spec/models/qernel/converter_api/cost_spec.rb
@@ -8,7 +8,7 @@ module Qernel
       @c = Qernel::Converter.new(id:1)
     end
 
-    describe '#nominal_input_capacity' do
+    describe '#input_capacity' do
       #
       # e-eff  h-eff  e-cap  h-cap  expected outcome
       #  0.4    nil    800    nil     2000
@@ -24,19 +24,19 @@ module Qernel
 
       it "should calculate correctly when only electrical capacity and electrical efficiency are given" do
         @c.with electricity_output_conversion: 0.4, electricity_output_capacity: 800
-        @c.converter_api.nominal_input_capacity.should == 2000
+        @c.converter_api.input_capacity.should == 2000
       end
 
       it "should calculate correctly when only heat capacity and heat efficiency are given" do
         @c.with heat_output_conversion: 0.1, heat_output_capacity: 400
-        @c.converter_api.nominal_input_capacity.should == 4000
+        @c.converter_api.input_capacity.should == 4000
       end
 
       it "should return zero when capacity and conversion are both zero" do
         @c.with electricity_output_capacity: 0, electricity_output_conversion: 0
-        @c.converter_api.nominal_input_capacity.should == 0
+        @c.converter_api.input_capacity.should == 0
         @c.with heat_output_capacity: 0, heat_and_cold_output_conversion: 0
-        @c.converter_api.nominal_input_capacity.should == 0
+        @c.converter_api.input_capacity.should == 0
       end
 
       it "should raise error when incomplete" do
@@ -45,14 +45,14 @@ module Qernel
                   electricity_output_capacity: nil,
                   heat_and_cold_output_conversion: nil,
                   heat_output_capacity: 400
-          expect { @c.converter_api.nominal_input_capacity }.to raise_error
+          expect { @c.converter_api.input_capacity }.to raise_error
         end
       end
 
       it "should raise error when capicity-e/eff-e != capacity-h/eff-h" do
         pending "Data validations of Converters upon loading / importing" do
           @c.with heat_output_capacity: 400, electricity_output_capacity: 1000, heat_and_cold_output_conversion: 0.2, electricity_output_conversion: 0.4
-          expect { @c.converter_api.nominal_input_capacity }.to raise_error
+          expect { @c.converter_api.input_capacity }.to raise_error
         end
       end
 
@@ -215,7 +215,7 @@ module Qernel
       it "should calculate when everything is set" do
         @c.with variable_operation_and_maintenance_costs_per_full_load_hour: 500, 
         variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour: 400,
-        nominal_input_capacity: 2
+        input_capacity: 2
         @c.converter_api.send(:variable_operation_and_maintenance_costs_per_typical_input).should == 0.125
       end
       

--- a/spec/models/qernel/plugins/merit_order/merit_order_injector_spec.rb
+++ b/spec/models/qernel/plugins/merit_order/merit_order_injector_spec.rb
@@ -36,7 +36,7 @@ module Qernel::Plugins::MeritOrder
         @converter_api.stub(:load_profile_key=){ true }
         @converter_api.stub(:variable_costs_per){ 1 }
         @converter_api.stub(:electricity_output_conversion){ 1 }
-        @converter_api.stub(:nominal_input_capacity){ 1 }
+        @converter_api.stub(:input_capacity){ 1 }
         @converter_api.stub(:number_of_units){ 1 }
         @converter_api.stub(:availability){ 1 }
         @converter_api.stub(:fixed_costs){ 1 }


### PR DESCRIPTION
Cleanup of capacity calculation methods as requested in #623. This must be merged at the same time as quintel/etsource#656.
- `effective_input_capacity` is gone (use `input_capacity` instead)
- `nominal_input_capacity` renamed to `input_capacity`
- removed some old, unused aliases and methods
- tidied up some other methods in the capacity_production.rb file
