### PR TITLE
Add "dependent_supply_of_carrier" to Link

### DIFF
--- a/app/models/qernel/link.rb
+++ b/app/models/qernel/link.rb
@@ -23,6 +23,7 @@ module Qernel
     delegated_calculation :primary_demand_of
     delegated_calculation :primary_demand_of_carrier
     delegated_calculation :sustainability_share
+    delegated_calculation :dependent_supply_of_carrier
 
     # Accessors ----------------------------------------------------------------
 


### PR DESCRIPTION
Like "primary_demand_of" and "sustainability_share", it takes the value of the right-hand (supplier) converter, reducing that value according to the slot conversion and link share.

Requested by @ChaelKruip.
