### PR TITLE
Add ConverterApi#loss_of_load_probability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'rubel',         '>= 0.0.3',       github:  'quintel/rubel'
 gem 'merit',         '>=0.1.0',        github:  'quintel/merit'
 gem 'turbine-graph', '>=0.1',          require: 'turbine'
 gem 'refinery',      ref: 'a0dcae9',   github:  'quintel/refinery'
-gem 'atlas',         ref: '5351aff',   github:  'quintel/atlas'
+gem 'atlas',         ref: 'f82357e',   github:  'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: 5351aff5894367f383036b2ef3658bb219f599f9
-  ref: 5351aff
+  revision: f82357e4f8ceb80d005657977b2010474aa7e50a
+  ref: f82357e
   specs:
     atlas (0.0.2)
       activemodel
@@ -179,7 +179,7 @@ GEM
     mime-types (1.25.1)
     minitest (4.7.5)
     msgpack (0.5.7)
-    multi_json (1.8.2)
+    multi_json (1.8.4)
     mysql2 (0.3.14)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)


### PR DESCRIPTION
**not ready for merge yet**. @jorisberkhout needs to review this first.

... and the "demand_curve" helper methods. The latter returns the load
on the converter for each hour in the year, while the loss of load
probability returns what proportion of those hours exceed a given
production capacity limit.

   V(some_converter, loss_of_load_probability(10))
   V(some_converter, loss_of_load_probability(Q(some_query)))
