### PR TITLE
Made demand_curve method Public.

### DIFF
--- a/app/models/qernel/graph_api.rb
+++ b/app/models/qernel/graph_api.rb
@@ -123,11 +123,7 @@ class GraphApi
     demand_curve(demand).count { |point| point > capacity }
   end
 
-  #######
-  private
-  #######
-
-  # Internal: Takes the merit order load curve, and multiplies each point by the
+  # Public: Takes the merit order load curve, and multiplies each point by the
   # demand of the converter, yielding the load on the converter over time.
   #
   # An optional +demand+ parameter can be used to build the curve, instead of
@@ -142,6 +138,10 @@ class GraphApi
       .load_profile(:total_demand)
       .values.map { |point| point * demand }
   end
+
+  #######
+  private
+  #######
 
   # Demand of electricity of the energy sector itself 
   # (not included in final_demand_for_electricity)


### PR DESCRIPTION
The `demand_curve` method is used to determine the peak electricity demand. In order for the result of this method to be consistent with the `loss_of_load_expectation` method, the demand curve needs to be scaled by the same demand as the one in the `loss_of_laod_expectation` and we have to be able to set the optional `demand` parameter  by a Gquery. For this to work, I made the `demand_curve` method Public.
