### PR TITLE
Remove energy_import_steam_hot_water from input_defaults.rb

### DIFF
--- a/lib/tasks/input_defaults.rb
+++ b/lib/tasks/input_defaults.rb
@@ -60,7 +60,6 @@ INPUT_DEFAULTS = {
 :employment_economic_multiplier => 1.0,
 :employment_fraction_production => 50.0,
 :employment_local_fraction => 20.0,
-:energy_import_steam_hot_water_preset_demands => 0.0,
 :energy_mixer_for_gas_power_fuel_bio_oil_share => 0.0,
 :energy_mixer_for_gas_power_fuel_crude_oil_share => 18.1761405,
 :energy_mixer_for_gas_power_fuel_natural_gas_share => 81.8238595,


### PR DESCRIPTION
See also https://github.com/quintel/etsource/pull/756.
Closes https://github.com/quintel/etsource/issues/748.
