### PR TITLE
Weighted carrier cost uses cost_per_mj if present

### DIFF
--- a/app/models/qernel/recursive_factor/weighted_carrier.rb
+++ b/app/models/qernel/recursive_factor/weighted_carrier.rb
@@ -21,11 +21,13 @@ module Qernel::RecursiveFactor::WeightedCarrier
     if link
       if (link.carrier.electricity? || link.carrier.steam_hot_water?)
         0.0
+      elsif link.carrier.cost_per_mj || right_dead_end?
+        link.carrier.cost_per_mj
       else
-        right_dead_end? ? link.carrier.cost_per_mj : nil
+        nil # continue to the right
       end
     else
-      nil
+      nil # continue to the right
     end
   end
 


### PR DESCRIPTION
Instead of traversing all the way to the right-most carrier, stop early
if a traversal path encounters a carrier with a cost_per_mj defined.

Closes #707
