### PR TITLE
intuitive slider caps

### DIFF
--- a/app/models/qernel/converter_api/capacity_production.rb
+++ b/app/models/qernel/converter_api/capacity_production.rb
@@ -87,6 +87,13 @@ class Qernel::ConverterApi
   end
   unit_for_calculation "typical_electricity_production_per_unit", 'MJ'
 
+  def maximum_yearly_electricity_production_per_unit
+    fetch(:typical_electricity_production_per_unit) do
+      typical_electricity_production_capacity * availability * 8760 * 3600
+    end
+  end
+  unit_for_calculation "maximum_yearly_electricity_production_per_unit", 'MJ'
+
   def installed_production_capacity_in_mw_electricity
     fetch(:installed_production_capacity_in_mw_electricity) do
       electricity_output_conversion * input_capacity * number_of_units


### PR DESCRIPTION
Defined a converter method to calculate the typical annual electricity production of a technology if it would run all year. This helps clean up the queries that determine the slider caps for these technologies. 

See https://github.com/quintel/etsource/issues/863 and https://github.com/quintel/etsource/pull/889
