### PR TITLE
Scaled scenarios

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -31,6 +31,16 @@ module Api
         render json: @scenarios
       end
 
+      def scaled
+        scenarios = Scenario.joins(:scaler)
+
+        @scenarios = scenarios.map do |scenario|
+          ScenarioPresenter.new(self, scenario, params)
+        end
+
+        render json: @scenarios
+      end
+
       def dashboard
         presenter = nil
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Etm::Application.routes.draw do
           put  :dashboard
         end
         collection do
+          get  :scaled
           post :merge
         end
         get :templates, :on => :collection

--- a/spec/controllers/api/v3/scenarios_controller_spec.rb
+++ b/spec/controllers/api/v3/scenarios_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Api::V3::ScenariosController do
   let(:scenario) { FactoryGirl.create(:scenario) }
   let(:scenarios) { 5.times.map { FactoryGirl.create(:scenario) } }
-  
+
   before do
     Input.stub(:records).and_return({
       'foo' => FactoryGirl.build(:input, key: :foo),
@@ -31,6 +31,20 @@ describe Api::V3::ScenariosController do
       assigns(:scenarios).each do |scenario|
         expect(scenario).to be_a(Api::V3::ScenarioPresenter)
       end
+    end
+  end
+
+  describe "GET scaled.json" do
+    before do
+      get :scaled, format: :json
+    end
+
+    it "responds succesfully" do
+      expect(response).to be_success
+    end
+
+    it 'assigns scenarios with an array' do
+      assigns(:scenarios).should be_a(Array)
     end
   end
 

--- a/spec/models/nasty_cache_spec.rb
+++ b/spec/models/nasty_cache_spec.rb
@@ -17,14 +17,6 @@ describe NastyCache do
     @cache.set("to_be_expired", "foo")
   }
 
-  describe "SingleTon" do
-    it 'is the same instance every time' do
-      a = NastyCache.instance
-      b = NastyCache.instance
-      a.should == b
-    end
-  end
-
   specify { @cache.get("new_key").should be_nil }
 
   it "should set and get" do
@@ -33,7 +25,7 @@ describe NastyCache do
   end
 
   it "should fetch a block" do
-    @cache.fetch("foo2") do 
+    @cache.fetch("foo2") do
       'bar'
     end
     @cache.get("foo2").should == "bar"


### PR DESCRIPTION
For Etmoses to generate a list of all scaled scenarios for the select box on the import page.

* Doesn't take into account the scaled scenario's from a specific user.
* Just gives all scenarios with a set of scaling attributes
* @antw Question: some of the scaled scenarios can contain private information. Is that automatically held into account or should the query be adapted?
