### PR TITLE
Made cost method return 0.0 when dividing by 0

### DIFF
--- a/app/models/qernel/converter_api/cost.rb
+++ b/app/models/qernel/converter_api/cost.rb
@@ -269,6 +269,8 @@ class Qernel::ConverterApi
   #
   def variable_operation_and_maintenance_costs_per_typical_input
     fetch(:variable_operation_and_maintenance_costs_per_typical_input) do
+      return 0.0 if input_capacity.zero?
+
       (variable_operation_and_maintenance_costs_per_full_load_hour +
       variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour) /
       (input_capacity * 3600.0)


### PR DESCRIPTION
Made `variable_operation_and_maintenance_costs_per_typical_input` return 0.0 when dividing by 0.

<a href="https://github.com/quintel/etengine/blob/master/app/models/qernel/converter_api/cost.rb#L270-L277"a> Here <a/> we could have the situation that we divide 0 by 0, returning `NaN` when all terms in the fraction are 0. This is the case in the present scenario for electric vehicles, and the reason why the `total_cost` method in that case also returns `NaN`. This PR fixes that.

@antw , I'm assigning you to make sure this doesn't disrupt ETE's functioning and/or structure. :smile: 

Credits to @grdw !

