### PR TITLE
New converter group to correctly calculate total electricity demand

### DIFF
--- a/app/models/qernel/graph_api.rb
+++ b/app/models/qernel/graph_api.rb
@@ -69,12 +69,18 @@ class GraphApi
     graph.group_converters(:final_demand_group).map(&:converter_api).map(&:input_of_electricity).compact.sum
   end
 
+  # Demand of electricity for all converters which do not belong
+  # to the final_demand_group but nevertheless consume electricity.
+  def non_final_demand_for_electricity
+    graph.group_converters(:non_final_electricity_demand_converters).map(&:converter_api).map(&:input_of_electricity).compact.sum
+  end
+
   # Public: The demand of electricity in the entire graph, including use in the
   # energy sector and losses caused by no exports.
   #
   # Returns a numeric.
   def total_demand_for_electricity
-    final_demand_for_electricity +
+    final_demand_for_electricity + non_final_demand_for_electricity +
     electricity_losses_if_export_is_zero
   end
 


### PR DESCRIPTION
Currently, <a href="https://github.com/quintel/mechanical_turk/blob/master/spec/merit_order/merit_order_spec.rb#L68-L73"a>this merit order mech_turk test<a/> fails because the calculation of the total electricity demand is incomplete. Even with MO on and matching the demand, if the demand is too low, electricity will still be imported. This PR along with one for ETSource fixes that and adds the converters which belong to the herewith newly created `non_final_demand_electricity_converters` group to the total electricity demand calculation.

See https://github.com/quintel/etsource/pull/1103 