### PR TITLE
Marginal heat costs

### DIFF
--- a/app/models/qernel/converter_api/cost.rb
+++ b/app/models/qernel/converter_api/cost.rb
@@ -170,6 +170,22 @@ class Qernel::ConverterApi
   end
   unit_for_calculation "marginal_costs", 'euro / MWh'
 
+  # Calculates the marginal costs for a plant in euro per MWh produced
+  # heat. This is the same as the variable costs per typical input 
+  # divided through heat_output_conversion (times SECS_PER_HOUR to 
+  # convert from euro / MJ to euro / MWh).
+  # The marginal costs are the **extra** costs made if an **extra** unit
+  # of heat is produced. It is, in essence, the slope of the cost 
+  # curve where cost (in euro) is plotted versus total production (in MWh).
+  #
+  # @return [Float] marginal costs per MWh (produced heat)
+  #
+  def marginal_heat_costs
+    variable_costs_per_typical_input * 
+    SECS_PER_HOUR / heat_output_conversion
+  end
+  unit_for_calculation "marginal_heat_costs", 'euro / MWh'
+
   ##################
   # Variable Costs #
   ##################

--- a/spec/models/qernel/converter_api/cost_spec.rb
+++ b/spec/models/qernel/converter_api/cost_spec.rb
@@ -146,6 +146,13 @@ module Qernel
       end
     end
 
+    describe '#marginal_heat_costs' do
+      it "should calculate correctly when values are given" do
+        @c.with variable_costs_per_typical_input: 100, heat_output_conversion: 0.5
+        @c.converter_api.send(:marginal_heat_costs).should == 720000.0
+      end
+    end
+
     describe '#variable_costs' do
       it "should calculate correctly when values are given" do
         @c.with variable_costs_per_typical_input: 300, typical_input: 2


### PR DESCRIPTION
This new method calculates the marginal costs for heating technologies. This is needed directly to rank the sources providing heat for the central heat network in order of priority in ETMoses.

The method only works for heating technologies (technologies which have a heat_output_capacity).

For CHPs, this method over-estimates the costs as it assigns all costs to the output of heat, although there is also electricity produced. For more details on a more robust method see https://github.com/quintel/etengine/issues/844

The method implemented here is a good starting point, however, and I don't think it will lead to fall-out because nothing else depends on it.