### PR TITLE
Converter_positions for nodes introduced by refineries modelling improvement

### DIFF
--- a/app/models/qernel/converter_api/recursive_methods.rb
+++ b/app/models/qernel/converter_api/recursive_methods.rb
@@ -37,4 +37,9 @@ class Qernel::ConverterApi
   end
   unit_for_calculation "weighted_carrier_co2_per_mj", 'kg'
 
+    def weighted_carrier_co2_per_mj_incl_losses
+    converter.weighted_carrier_co2_per_mj_incl_losses
+  end
+  unit_for_calculation "weighted_carrier_co2_per_mj_incl_losses", 'kg'
+
 end

--- a/app/models/qernel/converter_api/recursive_methods.rb
+++ b/app/models/qernel/converter_api/recursive_methods.rb
@@ -37,9 +37,4 @@ class Qernel::ConverterApi
   end
   unit_for_calculation "weighted_carrier_co2_per_mj", 'kg'
 
-  def weighted_carrier_co2_per_mj_incl_losses
-    converter.weighted_carrier_co2_per_mj_incl_losses
-  end
-  unit_for_calculation "weighted_carrier_co2_per_mj_incl_losses", 'kg'
-
 end

--- a/app/models/qernel/converter_api/recursive_methods.rb
+++ b/app/models/qernel/converter_api/recursive_methods.rb
@@ -37,7 +37,7 @@ class Qernel::ConverterApi
   end
   unit_for_calculation "weighted_carrier_co2_per_mj", 'kg'
 
-    def weighted_carrier_co2_per_mj_incl_losses
+  def weighted_carrier_co2_per_mj_incl_losses
     converter.weighted_carrier_co2_per_mj_incl_losses
   end
   unit_for_calculation "weighted_carrier_co2_per_mj_incl_losses", 'kg'

--- a/app/models/qernel/recursive_factor/weighted_carrier.rb
+++ b/app/models/qernel/recursive_factor/weighted_carrier.rb
@@ -47,22 +47,4 @@ module Qernel::RecursiveFactor::WeightedCarrier
     end
   end
 
-  # This method is the same as weighted_carrier_cost_per_mj, except
-  # it takes into account losses. Therefore, the resulting factor
-  # is not normalized to 1. It can only be used with the demand
-  # of a converter (not with its primary demand).
-  def weighted_carrier_co2_per_mj_incl_losses
-    fetch(:weighted_carrier_co2_per_mj) do
-      recursive_factor(:weighted_carrier_co2_per_mj_incl_losses_factor)
-    end
-  end
-
-  def weighted_carrier_co2_per_mj_incl_losses_factor(link)
-    if right_dead_end? and link
-      link.carrier.co2_conversion_per_mj
-    else
-      nil
-    end
-  end
-
 end

--- a/app/models/qernel/recursive_factor/weighted_carrier.rb
+++ b/app/models/qernel/recursive_factor/weighted_carrier.rb
@@ -14,7 +14,7 @@ module Qernel::RecursiveFactor::WeightedCarrier
   end
 
   def weighted_carrier_cost_per_mj_factor(link)
-    # because electricity and steam_hot_water are calculated seperately 
+    # because electricity and steam_hot_water are calculated seperately
     # these are excluded from this calculation
     # old: if right_dead_end? and link
     # new: always 0 for elec and steam_hw
@@ -40,6 +40,24 @@ module Qernel::RecursiveFactor::WeightedCarrier
   end
 
   def weighted_carrier_co2_per_mj_factor(link)
+    if right_dead_end? and link
+      link.carrier.co2_conversion_per_mj
+    else
+      nil
+    end
+  end
+
+  # This method is the same as weighted_carrier_cost_per_mj, except
+  # it takes into account losses. Therefore, the resulting factor
+  # is not normalized to 1. It can only be used with the demand
+  # of a converter (not with its primary demand).
+  def weighted_carrier_co2_per_mj_incl_losses
+    fetch(:weighted_carrier_co2_per_mj) do
+      recursive_factor(:weighted_carrier_co2_per_mj_incl_losses_factor)
+    end
+  end
+
+  def weighted_carrier_co2_per_mj_incl_losses_factor(link)
     if right_dead_end? and link
       link.carrier.co2_conversion_per_mj
     else

--- a/config/converter_positions.yml
+++ b/config/converter_positions.yml
@@ -801,17 +801,17 @@
   :x: 3200
   :y: 10720
 :energy_export_diesel:
-  :x: 2320
-  :y: 10720
+  :x: 3200
+  :y: 11320
 :energy_export_gasoline:
-  :x: 2320
-  :y: 10600
+  :x: 3200
+  :y: 11200
 :energy_export_kerosene:
-  :x: 2320
-  :y: 10660
+  :x: 3200
+  :y: 11260
 :energy_export_lpg:
-  :x: 2320
-  :y: 10780
+  :x: 3200
+  :y: 11380
 :energy_export_greengas:
   :x: 3200
   :y: 11080
@@ -2237,3 +2237,27 @@
 :industry_useful_demand_for_other_machinery_crude_oil:
   :x: 720
   :y: 14500
+:industry_refinery_transformation_crude_oil:
+  :x: 480
+  :y: 10780
+:energy_production_oil_products:
+  :x: 2460
+  :y: 11260
+:energy_production_refinery_gas:
+  :x: 2460
+  :y: 11200
+:industry_locally_available_crude_oil_non_energetic_for_chemical:
+  :x: 2020
+  :y: 11420
+:energy_export_oil_products:
+  :x: 3200
+  :y: 11500
+:industry_locally_available_refinery_gas_for_chemical:
+  :x: 2020
+  :y: 11360
+:energy_export_heavy_fuel_oil:
+  :x: 3200
+  :y: 11440
+:energy_import_heavy_fuel_oil:
+  :x: 7200
+  :y: 6540


### PR DESCRIPTION
This PR features converter_positions for the nodes introduced in https://github.com/quintel/etsource/pull/1154

The only relevant commit in this PR is https://github.com/quintel/etengine/commit/4c15f3dbd40174208ac4b610c343c9761f684891; the rest need not be merged, it was a fix for https://github.com/quintel/etengine/issues/860 which was closed by https://github.com/quintel/etsource/pull/1154 .