### PR TITLE
Detailed Fertilizer Modelling

### DIFF
--- a/app/models/flexibility_order.rb
+++ b/app/models/flexibility_order.rb
@@ -3,6 +3,7 @@ class FlexibilityOrder < ActiveRecord::Base
     power_to_power
     electric_vehicle
     power_to_gas
+    power_to_gas_industry
     power_to_heat
     export
   ).map(&:freeze).freeze

--- a/config/converter_positions.yml
+++ b/config/converter_positions.yml
@@ -2223,11 +2223,11 @@
   :x: 2100
   :y: 9400
 :industry_locally_available_hydrogen_before_p2g:
-  :x: 100
-  :y: 9000
+  :x: 320
+  :y: 11480
 :industry_locally_available_hydrogen_after_p2g:
-  :x: 100
-  :y: 9020
+  :x: 160
+  :y: 11640
 :industry_other_food_burner_coal:
   :x: 1160
   :y: 13800
@@ -2258,3 +2258,12 @@
 :industry_other_paper_heater_electricity:
   :x: 1140
   :y: 16680
+:industry_chemicals_fertilizers_haber_bosch_process_hydrogen:
+  :x: 40
+  :y: 11480
+:industry_flexibility_p2g_electricity:
+  :x: 580
+  :y: 11640
+:industry_chemicals_fertilizers_steam_methane_reformer_hydrogen:
+  :x: 580
+  :y: 11480

--- a/spec/controllers/api/v3/flexibility_orders_controller_spec.rb
+++ b/spec/controllers/api/v3/flexibility_orders_controller_spec.rb
@@ -52,7 +52,8 @@ describe Api::V3::FlexibilityOrdersController do
     get :get, scenario_id: -1
 
     expect(JSON.parse(response.body)['order']).to eq(%w(
-      power_to_power electric_vehicle power_to_gas power_to_heat export
+      power_to_power electric_vehicle power_to_gas
+      power_to_gas_industry power_to_heat export
     ))
   end
 end


### PR DESCRIPTION
This PR features converter postitions for the nodes introduced in https://github.com/quintel/etsource/pull/1162

Additionally, it includes the default order of the flexibility options.