### PR TITLE
Bump mysql2 gem version to 0.3.21

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
     minitest (5.9.1)
     msgpack (0.5.8)
     multi_json (1.10.1)
-    mysql2 (0.3.15)
+    mysql2 (0.3.21)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.1)


### PR DESCRIPTION
Rationale: Incompatibility of old gem version with newer mysql version