### PR TITLE
Local datasets exporter inheritance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'rubel',         ref: 'e36554a',   github:  'quintel/rubel'
 gem 'quintel_merit', ref: 'b9a2147',   github:  'quintel/merit'
 gem 'turbine-graph', '>=0.1',          require: 'turbine'
 gem 'refinery',      ref: '58c1138',   github: 'quintel/refinery'
-gem 'atlas',         ref: '47c8087',   github: 'quintel/atlas'
+gem 'atlas',         ref: '537bf9a',   github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: 47c80878ea4552d88186bdf5012bb8af2dbf8b9b
-  ref: 47c8087
+  revision: 537bf9ad029a0afe70f4f393dcfdc3bd919bf432
+  ref: 537bf9a
   specs:
     atlas (1.0.0)
       activemodel (~> 4.0)

--- a/app/models/etsource/atlas_loader.rb
+++ b/app/models/etsource/atlas_loader.rb
@@ -58,7 +58,7 @@ module Etsource
 
           runner.calculate
 
-          contents = dump(Atlas::Exporter.dump(runner.refinery_graph))
+          contents = dump(Atlas::FullExporter.dump(runner.refinery_graph))
           location = data_path(dataset_key)
 
           FileUtils.mkdir_p(location.dirname)


### PR DESCRIPTION
Use Atlas::FullExporter (because Atlas::Exporter is an abstract base now)

Ref quintel/atlas@88a590aab1e0ec5cc
Ref quintel/atlas#66
