### PR TITLE
libv8 update from 3.16.14.15 -> 3.16.14.17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.2)
-    libv8 (3.16.14.15)
+    libv8 (3.16.14.17)
     listen (2.7.1)
       celluloid (>= 0.15.2)
       celluloid-io (>= 0.15.0)
@@ -389,4 +389,4 @@ RUBY VERSION
    ruby 2.1.9p490
 
 BUNDLED WITH
-   1.13.6
+   1.13.7


### PR DESCRIPTION
@grdw here ;) 

I was fixing Dorine's laptop and came across an issue with `libv8` as is usual with new laptops. Instead of trying to find some patchy `brew` fix I decided to bump the gem version which seems to work just fine.