### PR TITLE
Derived datasets: Preparations for migrating scenarios

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'rubel',         ref: 'e36554a',   github:  'quintel/rubel'
 gem 'quintel_merit', ref: 'b9a2147',   github:  'quintel/merit'
 gem 'turbine-graph', '>=0.1',          require: 'turbine'
 gem 'refinery',      ref: '58c1138',   github: 'quintel/refinery'
-gem 'atlas',         ref: 'b76cba4',   github: 'quintel/atlas'
+gem 'atlas',         ref: 'c346a75',   github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: b76cba44f59b9f5a2592a267998c673daf980823
-  ref: b76cba4
+  revision: c346a75fadc70f6038459b3b03b8b373169fcd90
+  ref: c346a75
   specs:
     atlas (1.0.0)
       activemodel (~> 4.0)

--- a/app/models/etsource/reloader.rb
+++ b/app/models/etsource/reloader.rb
@@ -31,6 +31,13 @@ module Etsource
         true
       end
 
+      def stop!
+        if @listener
+          @listener.stop
+          @listener = nil
+        end
+      end
+
       def reload!
         Rails.cache.clear
 

--- a/app/models/gql/gql.rb
+++ b/app/models/gql/gql.rb
@@ -263,10 +263,12 @@ module Gql
     end
 
     def update_graphs
-      # 2011-08-15: the present has to be prepared first. otherwise
-      # updating the future won't work (we need the present values)
-      update_present
-      update_future
+      with_disabled_dataset_fetch_cache do
+        # 2011-08-15: the present has to be prepared first. otherwise
+        # updating the future won't work (we need the present values)
+        update_present
+        update_future
+      end
     end
 
     def calculate_graphs
@@ -335,8 +337,19 @@ module Gql
     private
 
     def apply_initializer_inputs
-      set_initializer_inputs(:present)
-      set_initializer_inputs(:future)
+      with_disabled_dataset_fetch_cache do
+        set_initializer_inputs(:present)
+        set_initializer_inputs(:future)
+      end
+    end
+
+    def with_disabled_dataset_fetch_cache
+      present.graph.cache_dataset_fetch = false
+      future.graph.cache_dataset_fetch = false
+      yield
+    ensure
+      present.graph.cache_dataset_fetch = true
+      future.graph.cache_dataset_fetch = true
     end
 
     def set_initializer_inputs(graph)

--- a/app/models/qernel/dataset_attributes.rb
+++ b/app/models/qernel/dataset_attributes.rb
@@ -201,13 +201,20 @@ module Qernel::DatasetAttributes
       if observe_get
         # in debug mode we call #log with a block, which stores the value
         # in the log and returns it back.
-        log(:method, attr_name) { dataset_attributes[attr_name] = yield }
+        log(:method, attr_name) { fetch_set(attr_name, yield) }
       else
         # if not in debug mode, simply yield the value. Do not log the exceptions
         # but simply return the rescue_with value
-        dataset_attributes[attr_name] = yield
+        fetch_set(attr_name, yield)
       end
     end
+  end
+
+  def fetch_set(attr_name, value)
+    if graph && graph.cache_dataset_fetch?
+      dataset_attributes[attr_name] = value
+    end
+    value
   end
 
   def log(type, attr_name, value = nil, &block)

--- a/app/models/qernel/demand_driven_converter_api.rb
+++ b/app/models/qernel/demand_driven_converter_api.rb
@@ -58,6 +58,7 @@ module Qernel
           return 0.0 if heat_links.empty?
 
           tech_share = sum_unless_empty(heat_links.map(&:share)) || 0
+          tech_share = 0.0 if tech_share.abs < 1e-6
           units      = tech_share * (area.number_of_residences || 0)
           supplied   = households_supplied_per_unit
 

--- a/app/models/qernel/graph.rb
+++ b/app/models/qernel/graph.rb
@@ -405,9 +405,7 @@ class Graph
   end
 
   def initializer_inputs
-    decorated_inputs.
-      sort_by { |input, _| input.priority }.
-      reverse
+    decorated_inputs.sort_by { |input, _| [-input.priority, input.key] }
   end
 
   def decorated_inputs

--- a/app/models/qernel/graph.rb
+++ b/app/models/qernel/graph.rb
@@ -48,7 +48,7 @@ class Graph
   end
 
   attr_reader :converters, :logger
-  attr_writer :goals
+  attr_writer :goals, :cache_dataset_fetch
 
   attr_accessor :dataset,
                 :finished_converters,
@@ -64,6 +64,8 @@ class Graph
     @links_by_group      = {}
 
     self.converters = converters
+
+    self.cache_dataset_fetch = true
   end
 
   # Public: Returns the plugin identified by the given +name+ which was used
@@ -412,6 +414,10 @@ class Graph
     (area.init || {}).map do |input_key, input_value|
       [Input.fetch(input_key), input_value]
     end
+  end
+
+  def cache_dataset_fetch?
+    @cache_dataset_fetch
   end
 
 public

--- a/app/models/scenario/user_updates.rb
+++ b/app/models/scenario/user_updates.rb
@@ -93,7 +93,7 @@ module Scenario::UserUpdates
   def inputs
     @inputs ||=
       combined_values.map { |key, _| Input.get(key) }.
-      compact.sort_by(&:priority).reverse
+      compact.sort_by { |input| [-input.priority, input.key] }
   end
 
   # Internal: A hash of inputs, and the values to be set on the named graph.

--- a/spec/controllers/api/v3/scenarios_controller_spec.rb
+++ b/spec/controllers/api/v3/scenarios_controller_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 describe Api::V3::ScenariosController do
   let(:scenario) { FactoryGirl.create(:scenario) }
   let(:scenarios) { 5.times.map { FactoryGirl.create(:scenario) } }
-  
+
   before do
     Input.stub(:records).and_return({
-      'foo' => FactoryGirl.build(:input, key: :foo),
-      'bar' => FactoryGirl.build(:input, key: :bar)
+      'foo' => FactoryGirl.build(:input, key: :foo, priority: 0),
+      'bar' => FactoryGirl.build(:input, key: :bar, priority: 0)
     })
 
     Input.stub(:all).and_return(Input.records.values)

--- a/spec/requests/api/v3/api_spec.rb
+++ b/spec/requests/api/v3/api_spec.rb
@@ -90,7 +90,9 @@ describe "API v3scenario life cycle", :etsource_fixture do
     put url, :gqueries => ['foo_demand']
 
     result = JSON.parse(response.body)['gqueries']
-    result['foo_demand']['future'].should == 10.0
+    # First, set to 10 by applying foo_demand = 10
+    # Then, set to 30 by applying input_3 = 30
+    result['foo_demand']['future'].should == 30.0
 
     # ---- reset -----------------------------------------------------------------
 

--- a/spec/requests/api/v3/update_input_spec.rb
+++ b/spec/requests/api/v3/update_input_spec.rb
@@ -15,15 +15,15 @@ describe 'Updating inputs with API v3' do
   before do
     Input.stub(:records).and_return({
       'balanced_one' =>
-        FactoryGirl.build(:input, start_value: 100.0, key: 'balanced_one', share_group: 'grouped'),
+        FactoryGirl.build(:input, start_value: 100.0, key: 'balanced_one', share_group: 'grouped', priority: 0),
       'balanced_two' =>
-        FactoryGirl.build(:input, start_value: 0.0, key: 'balanced_two', share_group: 'grouped'),
+        FactoryGirl.build(:input, start_value: 0.0, key: 'balanced_two', share_group: 'grouped', priority: 0),
       'unrelated_one' =>
-        FactoryGirl.build(:input, key: 'unrelated_one', share_group: 'diode'),
+        FactoryGirl.build(:input, key: 'unrelated_one', share_group: 'diode', priority: 0),
       'unrelated_two' =>
-        FactoryGirl.build(:input, key: 'unrelated_two', share_group: 'diode'),
+        FactoryGirl.build(:input, key: 'unrelated_two', share_group: 'diode', priority: 0),
       'nongrouped' =>
-        FactoryGirl.build(:input, key: 'nongrouped')
+        FactoryGirl.build(:input, key: 'nongrouped', priority: 0)
     })
 
     Input.stub(:all).and_return(Input.records.values)


### PR DESCRIPTION
Some preparations to aid in the migration of existing ETE scaled scenarios into new DerivedDataset based scenarios:
- `Etsource::Reloader#stop!` to manually control the reloading of etsource changes directly after creating a new derived dataset
- Make a graph calculation more robust to rounding errors - proved to be a problem in a test
- Disable caching DatasetAttributes#fetch when applying inputs, so that the same input can be applied twice with different values
- Sort inputs by priority and then also by key, so that the sorting is deterministic
- Use new Atlas version:
  - No scaling of values derived from the interconnector_capacity - to be consistent with the ETE scenario scaling
  - Allow to explicitly set a scaling base_value (when creating a derived dataset) different from the area's number_of_residences - to allow the same scaling factor as in legacy ETE scenarios