### PR TITLE
Bugfix Scenario#dup, Scenario#clone

### DIFF
--- a/app/models/scenario/copies.rb
+++ b/app/models/scenario/copies.rb
@@ -2,47 +2,22 @@
 # configured, and don't pollute the original.
 module Scenario::Copies
 
-  #######
   private
-  #######
-
-  # Sets up a duplicate of the scenario.
-  #
-  # @param [Scenario] other
-  #   The dup'ed scenario.
-  #
-  # @see Scenario#initialize_copy
-  #
-  def initialze_dup(other)
-    initialize_copy(other)
-    super
-  end
-
-  # Sets up a clone of the scenario.
-  #
-  # @param [Scenario] other
-  #   The cloned scenario.
-  #
-  # @see Scenario#initialize_copy
-  #
-  def initialize_clone(other)
-    initialize_copy(other)
-    super
-  end
 
   # Sets up clones and dups of the scenario.
   #
   # Typically used when we want to perform calculations using previous values
   # provided by a user, before their new values are applied (e.g. balancing).
   #
-  # @param [Scenario] other
-  #   The cloned scenario.
+  # @param [Scenario] orig
+  #   The original scenario that _self_ is cloned from.
   #
-  def initialize_copy(other)
-    other.instance_variable_set(:@gql,            nil)
-    other.instance_variable_set(:@inputs_before,  nil)
-    other.instance_variable_set(:@inputs_present, nil)
-    other.instance_variable_set(:@inputs_future,  nil)
+  def initialize_copy(orig)
+    super
+    @gql            = nil
+    @inputs_before  = nil
+    @inputs_present = nil
+    @inputs_future  = nil
   end
 
 end # Scenario::Copies

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -326,6 +326,13 @@ describe Scenario do
       )
     end
 
+    before(:each) do
+      scenario.inputs_present
+      scenario.inputs_future
+      scenario.inputs_before
+      scenario.gql
+    end
+
     let(:dup) { scenario.dup }
 
     it 'clones the end year' do
@@ -353,7 +360,17 @@ describe Scenario do
     end
 
     it 'does not clone inputs_present' do
-      dup.inputs_present.should_not equal(scenario.inputs_present)
+      expect(dup.inputs_present).to_not equal(scenario.inputs_present)
+    end
+
+    it 'preserves inputs_present of the original' do
+      old_obj = scenario.inputs_present
+      dup
+      expect(scenario.inputs_present).to equal(old_obj)
+    end
+
+    it 're-generates the same inputs_present as for the original' do
+      expect(dup.inputs_present).to eq(scenario.inputs_present)
     end
 
     it 'does not clone inputs_before' do


### PR DESCRIPTION
- Bugfix: Hook is called on the new copy and receives the original
- Cleanup: initialize_copy is called automatically by the others