### PR TITLE
Use sustainability_share when calculating recursively

### DIFF
--- a/app/models/qernel/recursive_factor/dependent_supply.rb
+++ b/app/models/qernel/recursive_factor/dependent_supply.rb
@@ -32,12 +32,13 @@ module Qernel::RecursiveFactor::DependentSupply
   #
   # Returns a numeric.
   def dependent_supply_of_carriers(*carriers)
-     if demand && ! demand.zero?
-       demand * recursive_factor(
-         :dependent_supply_factor_of_carriers, nil, nil, carriers)
-     else
-       0.0
-     end
+    if demand && !demand.zero?
+      demand * recursive_factor(
+        :dependent_supply_factor_of_carriers, nil, nil, carriers
+      )
+    else
+      0.0
+    end
   end
 
   alias_method :dependent_supply_of_carrier, :dependent_supply_of_carriers
@@ -70,29 +71,24 @@ module Qernel::RecursiveFactor::DependentSupply
   def dependent_supply_factor_of_carriers(link, carriers)
     return nil unless link
 
-    if carriers.include?(link.carrier.key)
-      # Phase 2; we have found a link of the desired carrier.
-      dead_end = link.rgt_converter.inputs.none? do |slot|
-        carriers.include?(slot.carrier.key)
-      end
+    # Phase 1; we have yet to find a link of the desired carrier; continue
+    # traversing until we find one, or run out of links.
+    return nil unless carriers.include?(link.carrier.key)
 
-      if dead_end || primary_energy_demand?
-        # ... the supplier has no more links of this type, therefore we
-        # calculate the dependent supply factor and do not traverse further.
-        #
-        # If factor_for_primary_demand returns zero, it is simply because the
-        # supply node is not in the primary_energy_demand group; however we
-        # don't want to ignore the node, but instead use its demand value.
-        factor = factor_for_primary_demand(link)
-        factor.zero? ? link.rgt_output.conversion : factor
-      else
-        # There are more +carrier_key+ links to be traversed...
-        nil
-      end
-    else
-      # Phase 1; we have yet to find a link of the desired carrier; continue
-      # traversing until we find one, or run out of links.
-      nil
+    # Phase 2; we have found a link of the desired carrier.
+    dead_end = link.rgt_converter.inputs.none? do |slot|
+      carriers.include?(slot.carrier.key)
+    end
+
+    if dead_end || primary_energy_demand?
+      # ... the supplier has no more links of this type, therefore we
+      # calculate the dependent supply factor and do not traverse further.
+      #
+      # If factor_for_primary_demand returns zero, it is simply because the
+      # supply node is not in the primary_energy_demand group; however we
+      # don't want to ignore the node, but instead use its demand value.
+      factor = factor_for_primary_demand(link)
+      factor.zero? ? link.rgt_output.conversion : factor
     end
   end
 end # Qernel::RecursiveFactor::DependentDemand

--- a/app/models/qernel/recursive_factor/final_demand.rb
+++ b/app/models/qernel/recursive_factor/final_demand.rb
@@ -1,22 +1,19 @@
 module Qernel::RecursiveFactor::FinalDemand
-
-
   def final_demand
     fetch(:final_demand) do
-      (self.demand || 0.0) * recursive_factor(:final_demand_factor)
+      (demand || 0.0) * recursive_factor(:final_demand_factor)
     end
   end
 
   def final_demand_of(*carriers)
-    carriers.flatten.map do |c|
-      key = c.respond_to?(:key) ? c.key : c
-      final_demand_of_carrier(key)
+    carriers.flatten.map do |carrier|
+      final_demand_of_carrier(carrier.try(:key) || carrier)
     end.compact.sum
   end
 
   def final_demand_of_carrier(carrier_key)
-    factor = recursive_factor(:final_demand_factor_of_carrier, nil, nil, carrier_key)
-    (self.demand || 0.0) * factor
+    (demand || 0.0) *
+      recursive_factor(:final_demand_factor_of_carrier, nil, nil, carrier_key)
   end
 
   def final_demand_factor_of_carrier(link, carrier_key)
@@ -24,15 +21,14 @@ module Qernel::RecursiveFactor::FinalDemand
 
     if link && final_demand_group?
       link.carrier.key == carrier_key ? 1.0 : 0.0
-    else
-      nil
     end
   end
 
-  def final_demand_factor(link,ruby18fix = nil)
-    if    final_demand_group?  then 1.0
-    elsif right_dead_end?    then 0.0
-    else                          nil
+  def final_demand_factor(_link)
+    if final_demand_group?
+      1.0
+    elsif right_dead_end?
+      0.0
     end
   end
 end

--- a/app/models/qernel/recursive_factor/primary_demand.rb
+++ b/app/models/qernel/recursive_factor/primary_demand.rb
@@ -1,59 +1,59 @@
 module Qernel::RecursiveFactor::PrimaryDemand
-
-
-  # Calculates the primary energy demand. It recursively iterates through all the child links.
-  #
-  # primary_demand: demand * SUM(links)[ link_share * 1/(1-share_of_loss) * primary_demand_link]
+  # Calculates the primary energy demand. It recursively iterates through all
+  # the child links.
   #
   # It uses primary_energy_demand? to determine if primary or not.
-  #
   def primary_demand
     fetch(:primary_demand) do
-      primary_demand_share = recursive_factor(:primary_demand_factor)
-      (self.demand || 0.0) * (primary_demand_share)
+      (demand || 0.0) * recursive_factor(:primary_demand_factor)
     end
   end
 
   def primary_demand_of(*carriers)
-    carriers.flatten.map do |c|
-      key = c.respond_to?(:key) ? c.key : c
-      primary_demand_of_carrier(key)
+    carriers.flatten.map do |carrier|
+      primary_demand_of_carrier(carrier.try(:key) || carrier)
     end.compact.sum
   end
 
   def primary_demand_of_carrier(carrier_key)
-     if demand && ! demand.zero?
-       demand * recursive_factor(
-         :primary_demand_factor_of_carrier, nil, nil, carrier_key)
-     else
-       0.0
-     end
+    if demand && !demand.zero?
+      demand * recursive_factor(
+        :primary_demand_factor_of_carrier, nil, nil, carrier_key
+      )
+    else
+      0.0
+    end
   end
 
   def primary_demand_with(factor_method, converter_share_method = nil)
-    if converter_share_method
-      w = recursive_factor("#{factor_method}_factor", "#{converter_share_method}_factor")
-    else
-      w = recursive_factor("#{factor_method}_factor")
-    end
-    d = (self.demand || 0.0)
-    w * d
+    factor =
+      if converter_share_method
+        recursive_factor(
+          "#{factor_method}_factor",
+          "#{converter_share_method}_factor"
+        )
+      else
+        recursive_factor("#{factor_method}_factor")
+      end
+
+    (demand || 0.0) * factor
   end
 
+  def primary_demand_factor(link)
+    return nil unless right_dead_end?
 
-  def primary_demand_factor(link,ruby18fix = nil)
-    return nil if !right_dead_end? # or !primary_energy_demand?
-    # We return nil when we want to continue traversing. So typically this is until
-    # we hit a dead end. Alternatively (for final_demand) we could stop when we hit
-    # a converter that is final_demand_group?
+    # We return nil when we want to continue traversing. So typically this is
+    # until we hit a dead end. Alternatively (for final_demand) we could stop
+    # when we hit a converter that is final_demand_group?
     factor_for_primary_demand(link)
   end
 
-  def primary_demand_factor_of_carrier(link, carrier_key, ruby18fix = nil)
-    return nil if !right_dead_end? or !primary_energy_demand?
+  def primary_demand_factor_of_carrier(link, carrier_key)
+    return nil if !right_dead_end? || !primary_energy_demand?
+
     link ||= output_links.first
 
-    if link and link.carrier.key == carrier_key
+    if link && link.carrier.key == carrier_key
       factor_for_primary_demand(link)
     else
       0.0
@@ -61,35 +61,35 @@ module Qernel::RecursiveFactor::PrimaryDemand
   end
 
   def factor_for_primary_demand(link)
-    # Example of a case when a link is not assigned (and therefore needs to be assigned
-    # in order to check if its imported_electricity):
-    # When you get the primary_demand of the group primary_energy_demand, you already
-    # start at the right dead end and don't jump throught links.
+    # Example of a case when a link is not assigned (and therefore needs to be
+    # assigned in order to check if its imported_electricity):
+    #
+    # When you get the primary_demand of the group primary_energy_demand, you
+    # already  start at the right dead end and don't jump throught links.
     link ||= output_links.first
 
     # If a converter has infinite ressources (such as wind, solar/sun), we
     # take the output of energy (1 - losses).
-    if infinite? and primary_energy_demand?
+    if infinite? && primary_energy_demand?
       (1 - loss_output_conversion)
 
     # Special case is imported electricity, if we import, somebody else has
     # to produce that electricity from primary energy. To take that into account
     # we add a higher factor for imported_electricity.
-    elsif primary_energy_demand? and link and link.carrier.key === :imported_electricity
+    elsif primary_energy_demand? &&
+        link && link.carrier.key == :imported_electricity
       # if export should be 1, if its import should be 1.82
-      if demand > 0.0 # if demand greater then 0.0 electricity is imported
+      if demand > 0.0
+        # if demand greater then 0.0 electricity is imported
         graph.area.import_electricity_primary_demand_factor
-      else # energy gets exported.
+      else
+        # energy gets exported.
         graph.area.export_electricity_primary_demand_factor
       end
-
     elsif primary_energy_demand? # Normal case.
       1.0
-    # ignore this converter if it is a dead end but not a primary_energy_demand.
-    # for example some environment converters.
     else
       0.0
     end
   end
-
 end

--- a/app/models/qernel/recursive_factor/sustainable.rb
+++ b/app/models/qernel/recursive_factor/sustainable.rb
@@ -1,29 +1,25 @@
-
 module Qernel::RecursiveFactor::Sustainable
-
-
-  # Primary demand of sustainable sources. Uses the Carrier#sustainable attribute
-  #
+  # Primary demand of sustainable sources. Uses the Carrier#sustainable
+  # attribute.
   def primary_demand_of_sustainable
     fetch(:primary_demand_of_sustainable) do
-      (self.demand || 0.0) * (recursive_factor(:sustainable_factor))
+      (demand || 0.0) * recursive_factor(:sustainable_factor)
     end
   end
 
-  # Primary demand of fossil sources. (primary_demand - primary_demand_of_sustainable)
+  # Primary demand of fossil sources.
   #
+  # i.e. (primary_demand - primary_demand_of_sustainable)
   def primary_demand_of_fossil
     fetch(:primary_demand_of_fossil) do
-      self.primary_demand - (recursive_factor(:sustainable_factor)) * (self.demand || 0.0)
+      primary_demand - recursive_factor(:sustainable_factor) * (demand || 0.0)
     end
   end
-
 
   # The share of sustainable energy. It is the (recursive) sum of the
   #  sustainable shares of its parents (nodes to the right).
   #
   # A.sustainability_share == 0.4*0.85 + 0.6 * 1.0
-  #
   def sustainability_share
     fetch(:sustainability_share, false) do
       recursive_factor_without_losses(:sustainability_share_factor)
@@ -31,41 +27,37 @@ module Qernel::RecursiveFactor::Sustainable
   end
 
   def sustainability_share_factor(link)
-    if right_dead_end? and link
-      # If the converter has a sustainability share which has been explicitly
-      # set (through research data or a graph plugin), use that in preference to
-      # the carrier sustainability.
-      custom_share = query.dataset_get(:sustainability_share)
-      custom_share || link.carrier.sustainable
-    end
+    return nil unless right_dead_end? && link
+
+    # If the converter has a sustainability share which has been explicitly
+    # set (through research data or a graph plugin), use that in preference to
+    # the carrier sustainability.
+    custom_share = query.dataset_get(:sustainability_share)
+    custom_share || link.carrier.sustainable
   end
 
+  def sustainable_factor(link)
+    return nil unless right_dead_end?
 
-  def sustainable_factor(link,ruby18fix = nil)
-    return nil if !right_dead_end?
     link ||= output_links.first
 
-    if infinite? and primary_energy_demand?
+    if infinite? && primary_energy_demand?
       (1 - loss_output_conversion)
-    elsif primary_energy_demand? and link and link.carrier.sustainable
+    elsif primary_energy_demand? && link && link.carrier.sustainable
       link.carrier.sustainable
     else
       0.0
     end
   end
 
-
   # Total amount of energy that are losses
   #
   # @return [Float]
-  #
   def total_losses
-    out = self.output(:loss)
-    out and out.external_value
+    output(:loss).try(:external_value)
   end
 
   def infinite?
-    carriers = slots.map {|slot| slot.carrier}.uniq
-    !carriers.empty? and carriers.any?(&:infinite)
+    slots.map(&:carrier).any?(&:infinite)
   end
 end

--- a/app/models/qernel/recursive_factor/sustainable.rb
+++ b/app/models/qernel/recursive_factor/sustainable.rb
@@ -32,9 +32,11 @@ module Qernel::RecursiveFactor::Sustainable
 
   def sustainability_share_factor(link)
     if right_dead_end? and link
-      link.carrier.sustainable
-    else
-      nil
+      # If the converter has a sustainability share which has been explicitly
+      # set (through research data or a graph plugin), use that in preference to
+      # the carrier sustainability.
+      custom_share = query.dataset_get(:sustainability_share)
+      custom_share || link.carrier.sustainable
     end
   end
 

--- a/app/models/qernel/recursive_factor/weighted_carrier.rb
+++ b/app/models/qernel/recursive_factor/weighted_carrier.rb
@@ -1,12 +1,8 @@
 module Qernel::RecursiveFactor::WeightedCarrier
-
-  # Carrier Cost can depend on the share of other carriers flowing
-  # into it.
-  # E.g. Gas price is dependent on the mix of greengas and natural
-  # gas.
+  # Carrier Cost can depend on the share of other carriers flowing into it.
+  # For example, gas price is dependent on the mix of greengas and natural gas.
   #
   # A.carrier_cost_per_mj == 0.4*0.85 + 0.6 * 1.0
-  #
   def weighted_carrier_cost_per_mj
     fetch(:weighted_carrier_cost_per_mj) do
       recursive_factor_without_losses(:weighted_carrier_cost_per_mj_factor)
@@ -18,21 +14,18 @@ module Qernel::RecursiveFactor::WeightedCarrier
     # these are excluded from this calculation
     # old: if right_dead_end? and link
     # new: always 0 for elec and steam_hw
-    if link
-      if (link.carrier.electricity? || link.carrier.steam_hot_water?)
-        0.0
-      elsif link.carrier.cost_per_mj || right_dead_end?
-        link.carrier.cost_per_mj
-      else
-        nil # continue to the right
-      end
-    else
-      nil # continue to the right
+    return unless link
+
+    if link.carrier.electricity? || link.carrier.steam_hot_water?
+      0.0
+    elsif link.carrier.cost_per_mj || right_dead_end?
+      link.carrier.cost_per_mj
     end
+
+    # Else: continue traversing right.
   end
 
   # Same as weighted_carrier_cost_per_mj but for co2
-  #
   def weighted_carrier_co2_per_mj
     fetch(:weighted_carrier_co2_per_mj) do
       recursive_factor_without_losses(:weighted_carrier_co2_per_mj_factor)
@@ -40,17 +33,15 @@ module Qernel::RecursiveFactor::WeightedCarrier
   end
 
   def weighted_carrier_co2_per_mj_factor(link)
-    # because electricity and steam_hot_water have no intrinsic co2
-    # these are excluded from this calculation
-    if link
-      if link.carrier.co2_conversion_per_mj || right_dead_end?
-        link.carrier.co2_conversion_per_mj
-      else
-        nil # continue to the right
-      end
-    else
-      nil # continue to the right
-    end
-  end
+    return unless link
 
+    # Electricity and steam_hot_water have no intrinsic CO2 and are therefore
+    # excluded from this calculation.
+
+    if link.carrier.co2_conversion_per_mj || right_dead_end?
+      link.carrier.co2_conversion_per_mj
+    end
+
+    # Else: continue traversing right.
+  end
 end

--- a/spec/models/qernel/converter_spec.rb
+++ b/spec/models/qernel/converter_spec.rb
@@ -26,6 +26,61 @@ module Qernel
         api.should be_kind_of(Qernel::DemandDrivenConverterApi)
       end
     end
+
+    describe 'sustainability_share' do
+      it 'defaults to 0' do
+        converter = Converter.new(id: 1, key: :hi).with({})
+        expect(converter.sustainability_share).to eq(0)
+      end
+
+      context 'two nodes connected with a sustainable=0.5 carrier' do
+        let(:graph) do
+          layout = <<-LAYOUT.strip_heredoc
+            useable_heat: left(100) == s(0.25) ==> right
+          LAYOUT
+
+          graph = GraphParser.new(layout).build
+
+          allow(graph.converter(:left).input_links.first.carrier)
+            .to receive(:sustainable).and_return(0.5)
+
+          graph
+        end
+
+        let(:sustainability) { graph.converter(:left).sustainability_share }
+
+        it 'uses the carrier sustainability' do
+          expect(sustainability).to eq(0.5 * 0.25) # sustainability * link share
+        end
+
+        it 'uses the right-most sustainability_share when present' do
+          graph.converter(:right).dataset_set(:sustainability_share, 0.25)
+
+          expect(sustainability).to eq(0.25 * 0.25)
+        end
+      end # two nodes connected with a systainable=0.5 carrier
+
+      context 'two nodes connected with a sustainable=0.5 carrier' do
+        let(:graph) do
+          layout = <<-LAYOUT.strip_heredoc
+            useable_heat: left(100) == s(0.25) ==> right
+          LAYOUT
+
+          graph = GraphParser.new(layout).build
+
+          allow(graph.converter(:left).input_links.first.carrier)
+            .to receive(:sustainable).and_return(nil)
+
+          graph
+        end
+
+        let(:sustainability) { graph.converter(:left).sustainability_share }
+
+        it 'is 0' do
+          expect(sustainability).to eq(0)
+        end
+      end # two nodes connected with a systainable=nil carrier
+    end
   end
 
 end


### PR DESCRIPTION
If sustainability_share_factor - used to calculate sustainability share recursively - reaches a right-most node which has an explicit share already set, use that in preference over the carrier attribute.

This enables the correct calculation of sustainability share values for converters which take stored electricity as input.