### PR TITLE
Add converter API which inherits number of units from a parent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'rubel',         ref: 'e36554a',   github:  'quintel/rubel'
 gem 'quintel_merit', ref: 'd019226',   github:  'quintel/merit'
 gem 'turbine-graph', '>=0.1',          require: 'turbine'
 gem 'refinery',      ref: '58c1138',   github: 'quintel/refinery'
-gem 'atlas',         ref: '6eb0ad5',   github: 'quintel/atlas'
+gem 'atlas',         ref: '1ab0482',   github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: 6eb0ad5f9a721ee31c4afa36b97a357d3d42ae9d
-  ref: 6eb0ad5
+  revision: 1ab0482f69b026b64f02ea9b7afa81dd3b878300
+  ref: 1ab0482
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)

--- a/app/models/qernel/converter_api.rb
+++ b/app/models/qernel/converter_api.rb
@@ -75,6 +75,8 @@ class ConverterApi
   def self.for_converter(converter)
     if converter.groups.include?(:demand_driven)
       DemandDrivenConverterApi.new(converter)
+    elsif converter.groups.include?(:inheritable_nou)
+      InheritableNouConverterApi.new(converter)
     else
       ConverterApi.new(converter)
     end

--- a/app/models/qernel/inheritable_nou_converter_api.rb
+++ b/app/models/qernel/inheritable_nou_converter_api.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Qernel
+  # Represents a converter whose number of units is dynamically calculated based
+  # on the NoU of a parent and the share of the link between the two.
+  #
+  # For example, [Child] will have number_of_units=6.0
+  #
+  #   +-----------------+                    +-------+
+  #   | Parent (nou=20) | <- (share: 0.3) <- | Child |
+  #   +-----------------+                    +-------+
+  class InheritableNouConverterApi < ConverterApi
+    def number_of_units
+      fetch(:number_of_units, false) do
+        raise(InvalidParents, self) if converter.output_links.length != 1
+
+        units = nou_parent.converter_api.number_of_units
+
+        units && units *
+          nou_link.share *
+          nou_link.lft_input.conversion
+      end
+    end
+
+    def number_of_units=(_)
+      raise(
+        NotImplementedError,
+        'Cannot set number of units on an inheritable number-of-units ' \
+        "converter; set it on the parent (#{ nou_parent.key }) instead."
+      )
+    end
+
+    private
+
+    def nou_link
+      converter.output_links.first
+    end
+
+    def nou_parent
+      nou_link.lft_converter
+    end
+
+    # Raised when trying to create an InheritableNouConverterApi on a converter
+    # which does not have a parent.
+    class InvalidParents < RuntimeError
+      def initialize(api)
+        @api = api
+        @converter = api.converter
+      end
+
+      def message
+        links = @converter.output_links.length
+
+        "Cannot use #{ @api.class.name.split('::').last } on a " \
+        "converter with #{ links } parents (#{ @converter.key })"
+      end
+    end
+  end
+end

--- a/spec/models/qernel/inheritable_nou_converter_api_spec.rb
+++ b/spec/models/qernel/inheritable_nou_converter_api_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+module Qernel
+  describe InheritableNouConverterApi do
+    describe 'when parent has 20 units' do
+      let(:graph) do
+        layout = <<-LAYOUT.strip_heredoc
+          useable_heat: parent(100) == s(0.25) ==> child_one
+          useable_heat: parent      == s(0.75) ==> child_two
+        LAYOUT
+
+        GraphParser.new(layout).build
+      end # graph
+
+      let(:parent)    { graph.converters.detect { |c| c.key == :parent    } }
+      let(:child_one) { graph.converters.detect { |c| c.key == :child_one } }
+      let(:child_two) { graph.converters.detect { |c| c.key == :child_two } }
+
+      before do
+        parent.converter_api.stub(:number_of_units).and_return(20.0)
+
+        child_one.converter_api = InheritableNouConverterApi.new(child_one)
+        child_two.converter_api = InheritableNouConverterApi.new(child_two)
+
+        [child_one, child_two].each do |converter|
+          converter.graph = graph
+        end
+      end
+
+      # ------------------------------------------------------------------------
+
+      it 'has 5 units when the converter has a 25% share' do
+        child_one.converter_api.number_of_units.should eql(5.0)
+      end
+
+      it 'has 15 units when the converter has a 75% share' do
+        child_two.converter_api.number_of_units.should eql(15.0)
+      end
+
+      it 'denies setting number of units' do
+        expect { child_two.converter_api.number_of_units = 2.0 }
+          .to raise_error(NotImplementedError, /cannot set number of units/i)
+      end
+    end # when parent has 20 units
+
+    describe 'when parent has 20 units and 0.5 parent slot conversion' do
+      let(:graph) do
+        layout = <<-LAYOUT.strip_heredoc
+          useable_heat[0.5]: parent(100) == s(0.6) ==> child_one
+          electricity[0.5]:  parent      == s(1.0) ==> child_two
+        LAYOUT
+
+        GraphParser.new(layout).build
+      end # graph
+
+      let(:parent) { graph.converters.detect { |c| c.key == :parent    } }
+      let(:child)  { graph.converters.detect { |c| c.key == :child_one } }
+
+      before do
+        parent.converter_api.stub(:number_of_units).and_return(20.0)
+
+        child.converter_api = InheritableNouConverterApi.new(child)
+        child.graph = graph
+      end
+
+      # ------------------------------------------------------------------------
+
+      it 'has 10 units when the converter has a 60% share' do
+        child.converter_api.number_of_units.should eql(6.0)
+      end
+    end # when parent has 20 units and 0.5 parent slot conversion
+
+    context 'when the converter has no parent' do
+      let(:graph) do
+        layout = <<-LAYOUT.strip_heredoc
+          useable_heat: parent(100) == s(0.25) ==> child_one
+        LAYOUT
+
+        GraphParser.new(layout).build
+      end # graph
+
+      let(:converter) { graph.converters.detect { |c| c.key == :parent } }
+
+      before do
+        converter.converter_api = InheritableNouConverterApi.new(converter)
+        converter.graph = graph
+      end
+
+      it 'raises an error' do
+        expect { InheritableNouConverterApi.new(converter).number_of_units }
+          .to raise_error(Qernel::InheritableNouConverterApi::InvalidParents)
+      end
+    end # when the converter has no parent
+
+    describe 'when parent has <nil> units' do
+      let(:graph) do
+        layout = <<-LAYOUT.strip_heredoc
+          useable_heat: parent(100) == s(1.0) ==> child
+        LAYOUT
+
+        GraphParser.new(layout).build
+      end # graph
+
+      let(:parent) { graph.converters.detect { |c| c.key == :parent } }
+      let(:child)  { graph.converters.detect { |c| c.key == :child } }
+
+      before do
+        parent.converter_api.stub(:number_of_units).and_return(nil)
+
+        child.converter_api = InheritableNouConverterApi.new(child)
+        child.graph = graph
+      end
+
+      # ------------------------------------------------------------------------
+
+      it 'returns <nil> units' do
+        expect(child.converter_api.number_of_units).to be_nil
+      end
+
+      it 'returns a value once the parent has one' do
+        expect { parent.converter_api.stub(:number_of_units).and_return(20) }
+          .to change { child.converter_api.number_of_units }
+          .from(nil).to(20)
+      end
+    end # when a parent has <nil> units
+  end
+end


### PR DESCRIPTION
Converters which belong to the "inheritable_nou" group will inherit their `number_of_units` from their parent (left) node. A node which acts this way is permitted to have only one parent (via a single output link).

In order to determine the NoU, the value of the parent is taken and then adjusted according to the slot conversion of the parent node and the share of the connecting edge.

For example, a parent and child node connected via an electricity edge of share 0.5 and with an electricity input conversion of 0.5, where the parent has 100 units, will assign 25 units to the child.