### PR TITLE
Implement Fever plugin; dynamic household heat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'quintel_merit', ref: '8f1e90e',  github: 'quintel/merit'
 gem 'fever',         ref: 'master',   github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '58c1138',  github: 'quintel/refinery'
-gem 'atlas',         ref: '552c847',  github: 'quintel/atlas'
+gem 'atlas',         ref: '083673e',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'quintel_merit', ref: '8f1e90e',  github: 'quintel/merit'
 gem 'fever',         ref: 'master',   github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '58c1138',  github: 'quintel/refinery'
-gem 'atlas',         ref: 'e61d9e7',  github: 'quintel/atlas'
+gem 'atlas',         ref: 'a61f841',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile
+++ b/Gemfile
@@ -39,11 +39,12 @@ gem 'fnv'
 gem 'msgpack'
 
 # own gems
-gem 'rubel',         ref: 'e36554a',   github:  'quintel/rubel'
-gem 'quintel_merit', ref: 'c72ff2f',   github:  'quintel/merit'
-gem 'turbine-graph', '>=0.1',          require: 'turbine'
-gem 'refinery',      ref: '58c1138',   github: 'quintel/refinery'
-gem 'atlas',         ref: 'd3a3bce',   github: 'quintel/atlas'
+gem 'rubel',         ref: 'e36554a',  github: 'quintel/rubel'
+gem 'quintel_merit', ref: '8f1e90e',  github: 'quintel/merit'
+gem 'fever',         ref: 'master',   github: 'quintel/fever'
+gem 'turbine-graph', '>=0.1',         require: 'turbine'
+gem 'refinery',      ref: '58c1138',  github: 'quintel/refinery'
+gem 'atlas',         ref: 'e61d9e7',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'quintel_merit', ref: '8f1e90e',  github: 'quintel/merit'
 gem 'fever',         ref: 'master',   github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '58c1138',  github: 'quintel/refinery'
-gem 'atlas',         ref: 'f69133a',  github: 'quintel/atlas'
+gem 'atlas',         ref: '552c847',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'quintel_merit', ref: '8f1e90e',  github: 'quintel/merit'
 gem 'fever',         ref: 'master',   github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '58c1138',  github: 'quintel/refinery'
-gem 'atlas',         ref: '083673e',  github: 'quintel/atlas'
+gem 'atlas',         ref: '1fe1674',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'quintel_merit', ref: '8f1e90e',  github: 'quintel/merit'
 gem 'fever',         ref: 'master',   github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '58c1138',  github: 'quintel/refinery'
-gem 'atlas',         ref: 'a61f841',  github: 'quintel/atlas'
+gem 'atlas',         ref: 'f69133a',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2',         '~>0.3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: 083673eeeb24e5a8f17b97d6461140ea8c7755ea
-  ref: 083673e
+  revision: 1fe16742b4d2cfc402c5f205102d15b5a0f862a4
+  ref: 1fe1674
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: d3a3bce606dac168f313c1c3acdfd3c1e8e7e9bf
-  ref: d3a3bce
+  revision: e61d9e77315ed3df9e592584c1ca759d2b4d2fc5
+  ref: e61d9e7
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)
@@ -22,9 +22,16 @@ GIT
       virtus (~> 1.0)
 
 GIT
+  remote: git://github.com/quintel/fever.git
+  revision: c7f1631d9e1656bdd27f998a57431e0e860104e0
+  ref: master
+  specs:
+    fever (0.1.0)
+
+GIT
   remote: git://github.com/quintel/merit.git
-  revision: c72ff2f41fb5ba398e6bd883bfd129936da334c9
-  ref: c72ff2f
+  revision: 8f1e90e6fc4d9f6cfa34ec22647d6edcb84a93ac
+  ref: 8f1e90e
   specs:
     quintel_merit (0.1.0)
       terminal-table
@@ -345,6 +352,7 @@ DEPENDENCIES
   distribution (~> 0.6)
   dotenv-rails
   factory_girl_rails
+  fever!
   fnv
   gctools
   git!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: git://github.com/quintel/fever.git
-  revision: 60bea425a798ffc368dda512e3b7eacb9207b7bc
+  revision: 0f3fa348ff338ad77f9ac07c71c0a96389661fe8
   ref: master
   specs:
     fever (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: f69133a5b7a4f66509f971c28fa28b9362c90019
-  ref: f69133a
+  revision: 552c847eb8562a079c4728ffd554b72d23e72cd0
+  ref: 552c847
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: git://github.com/quintel/fever.git
-  revision: 0f3fa348ff338ad77f9ac07c71c0a96389661fe8
+  revision: 5e3a40c3487227768cc6c0ee3426ac9543b7a9fb
   ref: master
   specs:
     fever (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: 552c847eb8562a079c4728ffd554b72d23e72cd0
-  ref: 552c847
+  revision: 083673eeeb24e5a8f17b97d6461140ea8c7755ea
+  ref: 083673e
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: git://github.com/quintel/fever.git
-  revision: c7f1631d9e1656bdd27f998a57431e0e860104e0
+  revision: 96c6c4da6305048c78ed34a2b2fd771914a09390
   ref: master
   specs:
     fever (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: git://github.com/quintel/fever.git
-  revision: 96c6c4da6305048c78ed34a2b2fd771914a09390
+  revision: 60bea425a798ffc368dda512e3b7eacb9207b7bc
   ref: master
   specs:
     fever (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: a61f841b62c8e550b46feee96d4b6d87f7e72e74
-  ref: a61f841
+  revision: f69133a5b7a4f66509f971c28fa28b9362c90019
+  ref: f69133a
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GIT
 
 GIT
   remote: git://github.com/quintel/atlas.git
-  revision: e61d9e77315ed3df9e592584c1ca759d2b4d2fc5
-  ref: e61d9e7
+  revision: a61f841b62c8e550b46feee96d4b6d87f7e72e74
+  ref: a61f841
   specs:
     atlas (1.0.0)
       activemodel (>= 4.0)

--- a/app/models/etsource/fever.rb
+++ b/app/models/etsource/fever.rb
@@ -1,0 +1,25 @@
+module Etsource
+  module Fever
+    module_function
+
+    # Public: Reads the Fever information from the Atlas node list.
+    #
+    # Returns a Hash where each key is the Fever participant "group"
+    # ("hot_water",  "space_heating", etc), and each value is a Hash in
+    # the form {Node#key => Node#fever}.
+    def data
+      Rails.cache.fetch('fever_data') do
+        grouped = Atlas::Node.all.select(&:fever).group_by do |node|
+          node.fever.group
+        end
+
+        grouped.each_with_object({}) do |(group, nodes), data|
+          data[group] =
+            nodes.each_with_object({}) do |node, bt|
+              (bt[node.fever.type] ||= []).push(node.key)
+            end
+        end
+      end
+    end
+  end
+end

--- a/app/models/gql/runtime/functions/lookup.rb
+++ b/app/models/gql/runtime/functions/lookup.rb
@@ -237,13 +237,28 @@ module Gql::Runtime
       #
       # Returns an array.
       def MERIT_DEMAND_COMPONENT(type)
-        unless Qernel::Plugins::Merit::Curves::CURVE_NAMES.include?(type.to_sym)
+        case type.to_sym
+        when :ev_demand then
+          scope.graph.plugin(:merit).curves.ev_demand.to_a
+        when :household_hot_water
+          fever_electricity_demand(:hot_water)
+        when :old_household_space_heating_demand
+          fever_electricity_demand(:space_heating)
+        when :new_household_space_heating_demand
+          [0.0] * 8760
+        else
           raise "Invalid merit demand component: #{ type.inspect }"
         end
+      end
 
-        scope.graph.plugin(:merit).curves.public_send(type.to_sym).to_a
+      private
+
+      def fever_electricity_demand(group)
+        return [] unless scope.graph.plugin(:time_resolve)
+
+        scope.graph.plugin(:time_resolve)
+          .fever.group(group).elec_demand_curve.to_a
       end
     end
-
   end
 end

--- a/app/models/gquery.rb
+++ b/app/models/gquery.rb
@@ -90,9 +90,11 @@ class Gquery
   end
 
   def self.name_or_query_contains(q)
+    escaped = Regexp.escape(q)
+
     all.select do |g|
       [:key, :query, :deprecated_key].any? do |attr|
-        g.send(attr).to_s.include? q
+        g.send(attr).to_s.match(/\b#{ escaped }\b/)
       end
     end
   end

--- a/app/models/input.rb
+++ b/app/models/input.rb
@@ -28,10 +28,12 @@ class Input
   end
 
   def self.with_queries_containing(q)
+    escaped = Regexp.escape(q)
+
     all.select do |input|
       [:label_query, :query, :max_value_gql,
        :min_value_gql, :start_value_gql]. any? do |attr|
-        input.send(attr).to_s.include? q
+        input.send(attr).to_s.match(/\b#{ escaped }\b/)
       end
     end
   end

--- a/app/models/qernel/converter_api.rb
+++ b/app/models/qernel/converter_api.rb
@@ -59,7 +59,7 @@ class ConverterApi
   attr_accessor :load_profile_key
 
   # dataset attributes of converter
-  dataset_accessors [:preset_demand, :demand, :storage]
+  dataset_accessors [:preset_demand, :demand, :storage, :fever]
 
   # Returns a ConverterApi instance based on the given Converter.
   #

--- a/app/models/qernel/graph.rb
+++ b/app/models/qernel/graph.rb
@@ -22,7 +22,7 @@ class Graph
 
   PLUGINS = [ Plugins::DisableSectors,
               Plugins::SimpleMeritOrder,
-              Plugins::MeritOrder,
+              Plugins::TimeResolve,
               Plugins::FCE,
               Plugins::MaxDemandRecursive,
               Plugins::ResettableSlots ]
@@ -72,6 +72,11 @@ class Graph
   # during calculation of the graph. Returns nil if no such plugin exists, or if
   # it wasn't used in this scenario.
   def plugin(name)
+    # Temporary backwards compatibility.
+    if name.to_sym == :merit && lifecycle.plugins[:time_resolve]
+      return lifecycle.plugins[:time_resolve].merit
+    end
+
     lifecycle.plugins[name.to_sym]
   end
 

--- a/app/models/qernel/plugins/fever.rb
+++ b/app/models/qernel/plugins/fever.rb
@@ -1,0 +1,4 @@
+module Qernel::Plugins
+  module Fever
+  end
+end

--- a/app/models/qernel/plugins/fever/adapter.rb
+++ b/app/models/qernel/plugins/fever/adapter.rb
@@ -9,7 +9,7 @@ module Qernel::Plugins
         type = converter.dataset_get(:fever).type.to_sym
 
         klass = case type
-          when :producer then ProducerAdapter
+          when :producer then ProducerAdapter.factory(converter, graph, dataset)
           when :storage  then StorageAdapter
           when :consumer then ConsumerAdapter
           else raise "Unknown Fever type: #{ type }"

--- a/app/models/qernel/plugins/fever/adapter.rb
+++ b/app/models/qernel/plugins/fever/adapter.rb
@@ -33,6 +33,10 @@ module Qernel::Plugins
         raise NotImplementedError
       end
 
+      def producer_for_carrier(_carrier)
+        raise NotImplementedError
+      end
+
       private
 
       # Internal: Fever expects totals -- not per-unit -- values. Using this

--- a/app/models/qernel/plugins/fever/adapter.rb
+++ b/app/models/qernel/plugins/fever/adapter.rb
@@ -25,6 +25,10 @@ module Qernel::Plugins
         @config    = converter.dataset_get(:fever)
       end
 
+      def inspect
+        "#<#{ self.class.name } converter=#{ @converter.key }>"
+      end
+
       def participant
         raise NotImplementedError
       end

--- a/app/models/qernel/plugins/fever/adapter.rb
+++ b/app/models/qernel/plugins/fever/adapter.rb
@@ -1,0 +1,46 @@
+module Qernel::Plugins
+  module Fever
+    # Base class which handles setting up the participant in Fever, and
+    # converting data post-calculation to be added back to ETEngine.
+    class Adapter
+      def self.adapter_for(converter, graph, dataset)
+        type = converter.dataset_get(:fever).type.to_sym
+
+        klass = case type
+          when :producer then ProducerAdapter
+          when :storage  then StorageAdapter
+          when :consumer then ConsumerAdapter
+          else raise "Unknown Fever type: #{ type }"
+        end
+
+        klass.new(converter, graph, dataset)
+      end
+
+      def initialize(converter, graph, dataset)
+        @converter = converter.converter_api
+        @graph     = graph
+        @dataset   = dataset
+        @config    = converter.dataset_get(:fever)
+      end
+
+      def participant
+        raise NotImplementedError
+      end
+
+      def inject!
+        raise NotImplementedError
+      end
+
+      private
+
+      # Internal: Fever expects totals -- not per-unit -- values. Using this
+      # method will ensure you always get a total value.
+      #
+      # Returns a numeric.
+      def total_value(attribute = nil)
+        per_unit = block_given? ? yield : @converter.public_send(attribute)
+        per_unit * @converter.number_of_units
+      end
+    end
+  end # Fever
+end # Qernel::Plugins

--- a/app/models/qernel/plugins/fever/adapter.rb
+++ b/app/models/qernel/plugins/fever/adapter.rb
@@ -3,6 +3,8 @@ module Qernel::Plugins
     # Base class which handles setting up the participant in Fever, and
     # converting data post-calculation to be added back to ETEngine.
     class Adapter
+      attr_reader :converter
+
       def self.adapter_for(converter, graph, dataset)
         type = converter.dataset_get(:fever).type.to_sym
 

--- a/app/models/qernel/plugins/fever/consumer_adapter.rb
+++ b/app/models/qernel/plugins/fever/consumer_adapter.rb
@@ -1,0 +1,26 @@
+module Qernel::Plugins
+  module Fever
+    # Represents a Fever participant which will describe total demand.
+    class ConsumerAdapter < Adapter
+      def initialize(converter, graph, dataset)
+        super
+        @was = @converter.demand
+      end
+
+      def participant
+        @participant ||=
+          ::Fever::Consumer.new((demand_curve * @converter.demand).to_a)
+      end
+
+      def inject!
+        @converter.demand = participant.load_curve.sum * 3600 # MWh -> MJ
+      end
+
+      private
+
+      def demand_curve
+        TimeResolve.load_profile(@dataset, @config.curve)
+      end
+    end # ConsumerAdapter
+  end
+end

--- a/app/models/qernel/plugins/fever/consumer_adapter.rb
+++ b/app/models/qernel/plugins/fever/consumer_adapter.rb
@@ -17,6 +17,10 @@ module Qernel::Plugins
         @converter.demand = participant.load_curve.sum * 3600 # MWh -> MJ
       end
 
+      def producer_for_carrier(_carrier)
+        nil
+      end
+
       private
 
       def demand_curve

--- a/app/models/qernel/plugins/fever/consumer_adapter.rb
+++ b/app/models/qernel/plugins/fever/consumer_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Qernel::Plugins
   module Fever
     # Represents a Fever participant which will describe total demand.
@@ -8,8 +10,7 @@ module Qernel::Plugins
       end
 
       def participant
-        @participant ||=
-          ::Fever::Consumer.new((demand_curve * @converter.demand).to_a)
+        @participant ||=::Fever::Consumer.new(demand_curve.to_a)
       end
 
       def inject!
@@ -19,7 +20,12 @@ module Qernel::Plugins
       private
 
       def demand_curve
-        TimeResolve.load_profile(@dataset, @config.curve)
+        if @config.curve.to_s.delete(' ') == 'dynamic:household_heat'
+          # Yuck.
+          @graph.plugin(:time_resolve).fever.curves.household_heat
+        else
+          TimeResolve.load_profile(@dataset, @config.curve) * @converter.demand
+        end
       end
     end # ConsumerAdapter
   end

--- a/app/models/qernel/plugins/fever/consumer_adapter.rb
+++ b/app/models/qernel/plugins/fever/consumer_adapter.rb
@@ -10,11 +10,11 @@ module Qernel::Plugins
       end
 
       def participant
-        @participant ||=::Fever::Consumer.new(demand_curve.to_a)
+        @participant ||= ::Fever::Consumer.new(demand_curve.to_a)
       end
 
       def inject!
-        @converter.demand = participant.load_curve.sum * 3600 # MWh -> MJ
+        # Nothing to do.
       end
 
       def producer_for_carrier(_carrier)

--- a/app/models/qernel/plugins/fever/curves.rb
+++ b/app/models/qernel/plugins/fever/curves.rb
@@ -1,0 +1,19 @@
+module Qernel::Plugins
+  module Fever
+    # Provides demand curves appropriate for a scenario.
+    class Curves
+      def initialize(graph)
+        @graph = graph
+      end
+
+      def household_heat
+        merit_curves = @graph.plugin(:time_resolve).merit.curves
+
+        Qernel::Plugins::Merit::Util.add_curves([
+          merit_curves.old_household_space_heating_demand,
+          merit_curves.new_household_space_heating_demand
+        ])
+      end
+    end
+  end
+end

--- a/app/models/qernel/plugins/fever/delegated_capacity_curve.rb
+++ b/app/models/qernel/plugins/fever/delegated_capacity_curve.rb
@@ -1,0 +1,35 @@
+module Qernel::Plugins
+  module Fever
+    class DelegatedCapacityCurve
+      include Enumerable
+
+      def initialize(capacity, other)
+        @capacity = capacity
+        @other    = other
+      end
+
+      # Internal: Prevents Fever from trying to coerce the object into an array.
+      def length
+        @other.load_curve.length
+      end
+
+      # Internal: Prevents Fever from trying to coerce the object into an array.
+      def to_curve
+        self
+      end
+
+      def each
+        if block_given?
+          @other.load_curve.length.times { |frame| yield self[frame] }
+        else
+          enum_for(:each)
+        end
+      end
+
+      def [](frame)
+        remaining = @capacity - @other.load_at(frame)
+        remaining <= 0 ? 0.0 : remaining
+      end
+    end
+  end
+end

--- a/app/models/qernel/plugins/fever/electricity_demand_curve.rb
+++ b/app/models/qernel/plugins/fever/electricity_demand_curve.rb
@@ -15,7 +15,7 @@ module Qernel::Plugins
       end
 
       def get(frame)
-        @producers.sum { |prod, conv| prod.load_curve[frame] * conv }
+        @producers.sum { |prod, conv| prod.input_at(frame) * conv }
       end
 
       def [](frame)

--- a/app/models/qernel/plugins/fever/electricity_demand_curve.rb
+++ b/app/models/qernel/plugins/fever/electricity_demand_curve.rb
@@ -3,8 +3,8 @@ module Qernel::Plugins
     # Reads from the electricity-based heat producers in Fever to detemine
     # Merit order demands.
     class ElectricityDemandCurve
-      def initialize(adapters)
-        @producers = adapters.map { |adapter| adapter.participant.producer }
+      def initialize(producers)
+        @producers = producers
       end
 
       def to_a

--- a/app/models/qernel/plugins/fever/electricity_demand_curve.rb
+++ b/app/models/qernel/plugins/fever/electricity_demand_curve.rb
@@ -1,0 +1,31 @@
+module Qernel::Plugins
+  module Fever
+    # Reads from the electricity-based heat producers in Fever to detemine
+    # Merit order demands.
+    class ElectricityDemandCurve
+      def initialize(adapters)
+        @producers = adapters.each_with_object({}) do |adapter, data|
+          data[adapter.participant.producer] =
+            adapter.converter.electricity_input_conversion
+        end
+      end
+
+      def to_a
+        Array.new(8760) { |frame| get(frame) }
+      end
+
+      def get(frame)
+        @producers.sum { |prod, conv| prod.load_curve[frame] * conv }
+      end
+
+      def [](frame)
+        get(frame)
+      end
+
+      # For some reason, Merit calls curve#values#[]
+      def values
+        self
+      end
+    end
+  end
+end

--- a/app/models/qernel/plugins/fever/electricity_demand_curve.rb
+++ b/app/models/qernel/plugins/fever/electricity_demand_curve.rb
@@ -4,10 +4,7 @@ module Qernel::Plugins
     # Merit order demands.
     class ElectricityDemandCurve
       def initialize(adapters)
-        @producers = adapters.each_with_object({}) do |adapter, data|
-          data[adapter.participant.producer] =
-            adapter.converter.electricity_input_conversion
-        end
+        @producers = adapters.map { |adapter| adapter.participant.producer }
       end
 
       def to_a
@@ -15,7 +12,7 @@ module Qernel::Plugins
       end
 
       def get(frame)
-        @producers.sum { |prod, conv| prod.input_at(frame) * conv }
+        @producers.sum { |prod| prod.input_at(frame) }
       end
 
       def [](frame)

--- a/app/models/qernel/plugins/fever/group.rb
+++ b/app/models/qernel/plugins/fever/group.rb
@@ -20,6 +20,13 @@ module Qernel::Plugins
         calculator.calculate_frame(frame)
       end
 
+      def elec_demand_curve
+        @elec_demand_curve ||=
+          Qernel::Plugins::Fever::ElectricityDemandCurve.new(
+            adapters.select { |a| a.converter.converter.input(:electricity) }
+          )
+      end
+
       def adapters
         adapters_by_type.values.flatten
       end

--- a/app/models/qernel/plugins/fever/group.rb
+++ b/app/models/qernel/plugins/fever/group.rb
@@ -1,0 +1,43 @@
+module Qernel::Plugins
+  module Fever
+    class Group
+      attr_reader :name
+
+      def initialize(name, plugin)
+        @name = name
+        @plugin = plugin
+      end
+
+      def calculator
+        @calculator ||= ::Fever::Calculator.new(
+          adapters_by_type[:consumer].first.participant,
+          adapters_by_type[:storage].map(&:participant) +
+            adapters_by_type[:producer].map(&:participant)
+        )
+      end
+
+      def calculate_frame(frame)
+        calculator.calculate_frame(frame)
+      end
+
+      def adapters
+        adapters_by_type.values.flatten
+      end
+
+      def adapters_by_type
+        return @adapters if @adapters
+
+        @adapters = Plugin::TYPES.each_with_object({}) do |type, data|
+          data[type] =
+            (Etsource::Fever.data[@name][type] || []).map do |node_key|
+              Adapter.adapter_for(
+                @plugin.graph.converter(node_key),
+                @plugin.graph,
+                @plugin.dataset
+              )
+            end
+        end
+      end
+    end # Group
+  end # Fever
+end

--- a/app/models/qernel/plugins/fever/group.rb
+++ b/app/models/qernel/plugins/fever/group.rb
@@ -24,7 +24,7 @@ module Qernel::Plugins
       def elec_demand_curve
         @elec_demand_curve ||=
           Qernel::Plugins::Fever::ElectricityDemandCurve.new(
-            adapters.select { |a| a.converter.converter.input(:electricity) }
+            adapters.map { |a| a.producer_for_carrier(:electricity) }.compact
           )
       end
 

--- a/app/models/qernel/plugins/fever/group.rb
+++ b/app/models/qernel/plugins/fever/group.rb
@@ -4,8 +4,9 @@ module Qernel::Plugins
       attr_reader :name
 
       def initialize(name, plugin)
-        @name = name
-        @plugin = plugin
+        @name    = name
+        @graph   = plugin.graph
+        @dataset = plugin.dataset
       end
 
       def calculator
@@ -37,11 +38,7 @@ module Qernel::Plugins
         @adapters = Plugin::TYPES.each_with_object({}) do |type, data|
           data[type] =
             (Etsource::Fever.data[@name][type] || []).map do |node_key|
-              Adapter.adapter_for(
-                @plugin.graph.converter(node_key),
-                @plugin.graph,
-                @plugin.dataset
-              )
+              Adapter.adapter_for(@graph.converter(node_key), @graph, @dataset)
             end
         end
       end

--- a/app/models/qernel/plugins/fever/hhp_adapter.rb
+++ b/app/models/qernel/plugins/fever/hhp_adapter.rb
@@ -45,7 +45,7 @@ module Qernel::Plugins
       # producer cannot meet demand.
       def secondary_component
         @secondary_component ||= ::Fever::Producer.new(
-          total_value(:heat_output_capacity) * secondary_share
+          total_value { @config.capacity[:network_gas] }
         )
       end
 
@@ -59,7 +59,7 @@ module Qernel::Plugins
 
       # Internal: The share of the secondary component carrier.
       def secondary_share
-        1.0-@converter.converter.input(:network_gas).conversion
+        1.0 - @converter.converter.input(:network_gas).conversion
       end
 
       # Internal: Re-balances the efficiency of the (typically) electricity and

--- a/app/models/qernel/plugins/fever/hhp_adapter.rb
+++ b/app/models/qernel/plugins/fever/hhp_adapter.rb
@@ -3,6 +3,11 @@ module Qernel::Plugins
     # An adapter which sets up a hybrid heat-pump to participate in Fever.
     class HHPAdapter < ProducerAdapter
       def inject!
+        if @converter.number_of_units.zero? ||
+            participant.producer.load_curve.all?(&:zero?)
+          return
+        end
+
         orig_sec_share = secondary_share
 
         # Sets the load-adjusted efficiency of the primary component carriers.

--- a/app/models/qernel/plugins/fever/hhp_adapter.rb
+++ b/app/models/qernel/plugins/fever/hhp_adapter.rb
@@ -33,6 +33,13 @@ module Qernel::Plugins
         ::Fever::CompositeProducer.new([primary_component, secondary_component])
       end
 
+      def producer_for_carrier(carrier)
+        case carrier
+        when @config.efficiency_based_on then primary_component
+        when :network_gas                then secondary_component
+        end
+      end
+
       private
 
       # Internal: The Fever producer which will be the first one asked to

--- a/app/models/qernel/plugins/fever/hhp_adapter.rb
+++ b/app/models/qernel/plugins/fever/hhp_adapter.rb
@@ -1,0 +1,77 @@
+module Qernel::Plugins
+  module Fever
+    # An adapter which sets up a hybrid heat-pump to participate in Fever.
+    class HHPAdapter < ProducerAdapter
+      def inject!
+        orig_sec_share = secondary_share
+
+        # Sets the load-adjusted efficiency of the primary component carriers.
+        primary_adapter.inject!
+
+        # Set the demands and other attributes based on the whole producer and
+        # not the individual parts.
+        super
+
+        # Set the conversion of the secondary component carrier.
+        sec_demand   = secondary_component.load_curve.sum
+        total_demand = primary_component.load_curve.sum + sec_demand
+        sec_share    = sec_demand / total_demand
+
+        @converter.converter.input(:network_gas)[:conversion] = sec_share
+
+        # The electric adapter has already set the electricity and ambient heat
+        # conversions, but failed to account for the new secondary share.
+        balance_primary_efficiency!(orig_sec_share - sec_share)
+      end
+
+      def producer
+        ::Fever::CompositeProducer.new([primary_component, secondary_component])
+      end
+
+      private
+
+      # Internal: The Fever producer which will be the first one asked to
+      # satisfy demand.
+      def primary_component
+        @primary_component ||= primary_adapter.participant.producer
+      end
+
+      # Internal: The Fever producer which will be used when the primary
+      # producer cannot meet demand.
+      def secondary_component
+        @secondary_component ||= ::Fever::Producer.new(
+          total_value(:heat_output_capacity) * secondary_share
+        )
+      end
+
+      # Internal: The primary producer is typically a variable-efficiency heat
+      # pump.
+      def primary_adapter
+        @primary_adapter ||= VariableEfficiencyProducerAdapter.new(
+          @converter.converter, @graph, @dataset
+        )
+      end
+
+      # Internal: The share of the secondary component carrier.
+      def secondary_share
+        1.0-@converter.converter.input(:network_gas).conversion
+      end
+
+      # Internal: Re-balances the efficiency of the (typically) electricity and
+      # ambient heat inputs to account for how much energy they actually
+      # provided relative to the gas component.
+      def balance_primary_efficiency!(secondary_delta)
+        slots = [
+          primary_adapter.based_on_slot,
+          primary_adapter.balanced_with_slot
+        ]
+
+        total_conv = slots.sum(&:conversion)
+
+        slots.each do |slot|
+          slot[:conversion] += secondary_delta * (slot.conversion / total_conv)
+        end
+      end
+    end
+  end
+end

--- a/app/models/qernel/plugins/fever/plugin.rb
+++ b/app/models/qernel/plugins/fever/plugin.rb
@@ -19,6 +19,10 @@ module Qernel::Plugins
         @groups || setup
       end
 
+      def curves
+        @curves ||= Curves.new(@graph)
+      end
+
       def setup
         @groups =
           Etsource::Fever.data.keys.map { |group| Group.new(group, self) }

--- a/app/models/qernel/plugins/fever/plugin.rb
+++ b/app/models/qernel/plugins/fever/plugin.rb
@@ -23,9 +23,13 @@ module Qernel::Plugins
         @curves ||= Curves.new(@graph)
       end
 
+      # Configures the Fever groups, ensuring that hot water is first since its
+      # producers may be used as aliases in other groups.
       def setup
         @groups =
-          Etsource::Fever.data.keys.map { |group| Group.new(group, self) }
+          Etsource::Fever.data.keys
+            .sort_by { |key| key == :hot_water ? 0 : 1 }
+            .map { |key| Group.new(key, self) }
       end
 
       # Internal: Instructs each contained calculator to compute loads.

--- a/app/models/qernel/plugins/fever/plugin.rb
+++ b/app/models/qernel/plugins/fever/plugin.rb
@@ -11,11 +11,6 @@ module Qernel::Plugins
         @dataset = Atlas::Dataset.find(@graph.area.area_code)
       end
 
-      # def calculators
-      #   setup unless @calculators
-      #   @calculators
-      # end
-
       def group(name)
         @groups.find { |c| c.name == name }
       end

--- a/app/models/qernel/plugins/fever/plugin.rb
+++ b/app/models/qernel/plugins/fever/plugin.rb
@@ -15,6 +15,10 @@ module Qernel::Plugins
         @groups.find { |c| c.name == name }
       end
 
+      def groups
+        @groups || setup
+      end
+
       def setup
         @groups =
           Etsource::Fever.data.keys.map { |group| Group.new(group, self) }

--- a/app/models/qernel/plugins/fever/plugin.rb
+++ b/app/models/qernel/plugins/fever/plugin.rb
@@ -1,0 +1,71 @@
+module Qernel::Plugins
+  module Fever
+    class Plugin
+      def initialize(graph)
+        @graph = graph
+      end
+
+      def calculator
+        setup unless @calculator
+        @calculator
+      end
+
+      # Public: Returns the Atlas dataset for the current graph region.
+      def dataset
+        @dataset ||= Atlas::Dataset.find(@graph.area.area_code)
+      end
+
+      def setup
+        @calculator =
+          if adapters.any?
+            ::Fever::Calculator.new(
+              adapters[:consumer].first.participant,
+              adapters[:storage].map(&:participant) +
+                adapters[:producer].map(&:participant)
+            )
+          else
+            ::Fever::Calculator.new(::Fever::Consumer.new([]), [])
+          end
+      end
+
+      # Internal: Returns an array of converters which are of the requested
+      # merit order +type+ (defined in PRODUCER_TYPES).
+      #
+      # TODO Memoize this on Etsource like MeritOrder.
+      #
+      # Returns an array.
+      def converters(type)
+        Atlas::Node.all
+          .select { |n| n.fever && n.fever.type == type }
+          .map { |n| @graph.converter(n.key) }
+      end
+
+      # Internal: Takes loads and costs from the calculated Merit order, and
+      # installs them on the appropriate converters in the graph. The updated
+      # values will be used in the recalculated graph.
+      #
+      # Returns nothing.
+      def inject_values!
+        adapters.values.flatten.each(&:inject!)
+      end
+
+      private
+
+      def adapters
+        return @adapters if @adapters
+
+        @adapters = Hash.new { |h, k| h[k] = [] }
+
+        [:consumer, :storage, :producer].each do |type|
+          converters(type).each do |converter|
+            @adapters[type].push(Qernel::Plugins::Fever::Adapter.adapter_for(
+              converter, @graph, dataset
+            ))
+          end
+        end
+
+        @adapters
+      end
+    end # Plugin
+  end # Fever
+end # Qernel::Plugins

--- a/app/models/qernel/plugins/fever/producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/producer_adapter.rb
@@ -56,6 +56,10 @@ module Qernel::Plugins
         end
       end
 
+      def producer_for_carrier(carrier)
+        participant.producer if @converter.converter.input(carrier)
+      end
+
       private
 
       def output_efficiency

--- a/app/models/qernel/plugins/fever/producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/producer_adapter.rb
@@ -6,7 +6,7 @@ module Qernel::Plugins
       def participant
         @participant ||=
           ::Fever::Activity.new(
-            ::Fever::Producer.new(total_value(:heat_output_capacity)),
+            ::Fever::Producer.new(total_value(:heat_output_capacity) / 100),
             share: @converter.converter.output(:useable_heat).links.first.share
           )
       end

--- a/app/models/qernel/plugins/fever/producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/producer_adapter.rb
@@ -31,7 +31,7 @@ module Qernel::Plugins
       end
 
       def producer
-        ::Fever::Producer.new(total_value(:heat_output_capacity) / 100),
+        ::Fever::Producer.new(total_value(:heat_output_capacity))
       end
 
       def share

--- a/app/models/qernel/plugins/fever/producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/producer_adapter.rb
@@ -55,9 +55,7 @@ module Qernel::Plugins
 
         link = @converter.converter.output(:useable_heat).links.first
 
-        if link.lft_converter.key.to_s.include?('aggregator')
-          delta = @orig_production - heat_production
-
+        if @converter.converter.groups.include?(:aggregator_producer)
           link.share =
             @orig_production > 0 ? heat_production / @orig_production : 1.0
         end

--- a/app/models/qernel/plugins/fever/producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/producer_adapter.rb
@@ -31,7 +31,19 @@ module Qernel::Plugins
       end
 
       def producer
-        ::Fever::Producer.new(total_value(:heat_output_capacity))
+        if (st = @converter.dataset_get(:storage)) && st.volume > 0
+          ::Fever::BufferingProducer.new(
+            total_value(:heat_output_capacity), reserve
+          )
+        else
+          ::Fever::Producer.new(total_value(:heat_output_capacity))
+        end
+      end
+
+      def reserve
+        ::Merit::Flex::Reserve.new(
+          total_value { @converter.dataset_get(:storage).volume }
+        )
       end
 
       def share

--- a/app/models/qernel/plugins/fever/producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/producer_adapter.rb
@@ -1,0 +1,31 @@
+module Qernel::Plugins
+  module Fever
+    # Represents a Fever participant which will provide energy needed to meet
+    # demand.
+    class ProducerAdapter < Adapter
+      def participant
+        @participant ||=
+          ::Fever::Activity.new(
+            ::Fever::Producer.new(total_value(:heat_output_capacity)),
+            share: @converter.converter.output(:useable_heat).links.first.share
+          )
+      end
+
+      def inject!
+        heat_production = participant.producer.load_curve.sum * 3600 # MWh -> MJ
+        full_load_hours = heat_production / total_value(:heat_output_capacity)
+
+        @converter.demand              = heat_production / output_efficiency
+        @converter[:full_load_hours]   = full_load_hours
+        @converter[:full_load_seconds] = full_load_hours * 3600
+      end
+
+      private
+
+      def output_efficiency
+        slots = @converter.converter.outputs.reject(&:loss?)
+        slots.any? ? slots.sum(&:conversion) : 1.0
+      end
+    end # ProducerAdapter
+  end
+end

--- a/app/models/qernel/plugins/fever/producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/producer_adapter.rb
@@ -15,8 +15,14 @@ module Qernel::Plugins
       end
 
       def inject!
-        heat_production = participant.producer.load_curve.sum * 3600 # MWh -> MJ
-        full_load_hours = heat_production / total_value(:heat_output_capacity)
+        producer = participant.producer
+        heat_production = producer.load_curve.sum * 3600 # MWh -> MJ
+
+        if heat_production.zero?
+          full_load_hours = 0.0
+        else
+          full_load_hours = heat_production / producer.capacity
+        end
 
         @converter.demand              = heat_production / output_efficiency
         @converter[:full_load_hours]   = full_load_hours

--- a/app/models/qernel/plugins/fever/producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/producer_adapter.rb
@@ -115,9 +115,13 @@ module Qernel::Plugins
       end
 
       def reserve
-        ::Merit::Flex::Reserve.new(
-          total_value { @converter.dataset_get(:storage).volume }
-        )
+        volume  = total_value { @converter.dataset_get(:storage).volume }
+        reserve = ::Merit::Flex::Reserve.new(volume)
+
+        # Buffer starts full.
+        reserve.add(0, volume)
+
+        reserve
       end
 
       def share

--- a/app/models/qernel/plugins/fever/storage_adapter.rb
+++ b/app/models/qernel/plugins/fever/storage_adapter.rb
@@ -1,0 +1,22 @@
+module Qernel::Plugins
+  module Fever
+    # Represents a Fever participant which will store excess energy from
+    # elsewhere, convert it to heat, and make it available for use later.
+    class StorageAdapter < ProducerAdapter
+      def participant
+        @participant ||=
+          ::Fever::Activity.new(
+            ::Fever::ReserveProducer.new(total_value(:output_capacity), reserve)
+          )
+      end
+
+      private
+
+      def reserve
+        ::Merit::Flex::Reserve.new(
+          total_value { @converter.dataset_get(:storage).volume }
+        )
+      end
+    end # StorageAdapter
+  end
+end

--- a/app/models/qernel/plugins/fever/storage_adapter.rb
+++ b/app/models/qernel/plugins/fever/storage_adapter.rb
@@ -6,7 +6,10 @@ module Qernel::Plugins
       def participant
         @participant ||=
           ::Fever::Activity.new(
-            ::Fever::ReserveProducer.new(total_value(:output_capacity), reserve)
+            ::Fever::ReserveProducer.new(
+              total_value(:heat_output_capacity),
+              reserve
+            )
           )
       end
 

--- a/app/models/qernel/plugins/fever/variable_efficiency_producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/variable_efficiency_producer_adapter.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Qernel::Plugins
+  module Fever
+    class VariableEfficiencyProducerAdapter < ProducerAdapter
+      def inject!
+        converter = @converter.converter
+
+        based_on       = converter.input(@config.efficiency_based_on)
+        balanced_with  = converter.input(@config.efficiency_balanced_with)
+        combined_share = based_on[:conversion] + balanced_with[:conversion]
+
+        super
+
+        efficiency = 1 / load_adjusted_input_efficiency
+
+        based_on[:conversion]      = efficiency * combined_share
+        balanced_with[:conversion] = (1.0 - efficiency) * combined_share
+      end
+
+      private
+
+      # Internal: Computes the actual efficiency of the heat pump over the year,
+      # depending on when demand arose.
+      #
+      # Returns a numeric.
+      def load_adjusted_input_efficiency
+        producer = participant.producer
+        lcurve   = producer.load_curve
+
+        lcurve.map.with_index do |load, index|
+          input = producer.input_at(index)
+          input.zero? ? 0.0 : load / producer.input_at(index)
+        end.sum / lcurve.length
+      end
+
+      # Internal: The input efficiency curve to be used by the producer.
+      #
+      # Returns an array.
+      def input_efficiency
+        base_eff = @converter.electricity_input_conversion
+
+        temperature_curve.map do |val|
+          case val
+          when -Float::INFINITY...-10 then 1 / (base_eff * 2.0)
+          when -10...0                then 1 / (base_eff * 1.6)
+          when 0...10                 then 1 / (base_eff * 1.2)
+          when 10...20                then 1 / (base_eff * 1.0)
+          when 20...30                then 1 / (base_eff * 0.8)
+          when 30..Float::INFINITY    then 1 / (base_eff * 0.6)
+          end
+        end
+      end
+
+      # Internal: The curve of air temperatures in the region.
+      def temperature_curve
+        Qernel::Plugins::TimeResolve.load_profile(@dataset, 'air_temperature')
+      end
+    end
+  end
+end

--- a/app/models/qernel/plugins/fever/variable_efficiency_producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/variable_efficiency_producer_adapter.rb
@@ -94,11 +94,15 @@ module Qernel::Plugins
       #
       # Returns an array.
       def efficiency_based_capacity
+        cop_cutoff = @config.cop_cutoff || 1.0
+
         input_cap = total_value do
           @config.capacity[@config.efficiency_based_on]
         end
 
-        input_efficiency.map { |eff| input_cap * eff }
+        input_efficiency.map do |eff|
+          eff < cop_cutoff ? 0.0 : input_cap * eff
+        end
       end
     end
   end

--- a/app/models/qernel/plugins/fever/variable_efficiency_producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/variable_efficiency_producer_adapter.rb
@@ -56,17 +56,15 @@ module Qernel::Plugins
       # Returns an array.
       def input_efficiency
         @input_efficiency ||= begin
-          base_eff = based_on_slot.conversion
+          base_cop   = @config.base_cop
+          per_degree = @config.cop_per_degree
 
           temperature_curve.map do |val|
-            case val
-            when -Float::INFINITY...-10 then 1 / (base_eff * 2.0)
-            when -10...0                then 1 / (base_eff * 1.6)
-            when 0...10                 then 1 / (base_eff * 1.2)
-            when 10...20                then 1 / (base_eff * 1.0)
-            when 20...30                then 1 / (base_eff * 0.8)
-            when 30..Float::INFINITY    then 1 / (base_eff * 0.6)
-            end
+            cop = base_cop + per_degree * val
+
+            # Coefficient of performance must not drop below 1.0 (where there is
+            # no "balanced_with" energy, and only "based_on" energy is used).
+            cop < 1.0 ? 1.0 : cop
           end
         end
       end

--- a/app/models/qernel/plugins/fever/variable_efficiency_producer_adapter.rb
+++ b/app/models/qernel/plugins/fever/variable_efficiency_producer_adapter.rb
@@ -75,7 +75,13 @@ module Qernel::Plugins
       end
 
       def capacity
-        heat_capacity = total_value(:heat_output_capacity)
+        heat_capacity =
+          if @config.capacity.present?
+            total_value { @config.capacity[@config.efficiency_based_on] }
+          else
+            total_value(:heat_output_capacity)
+          end
+
         converter = @converter.converter
 
         # Producers with only two slots (the based_on and balanced_with) use the

--- a/app/models/qernel/plugins/merit/curves.rb
+++ b/app/models/qernel/plugins/merit/curves.rb
@@ -64,42 +64,6 @@ module Qernel::Plugins
         )
       end
 
-      # Public: Describes the weighted average coefficient of performance of the
-      # electric hot water producers.
-      #
-      # Returns a float.
-      def household_hot_water_cop
-        total = @graph.query.group_demand_for_electricity(
-          :merit_household_hot_water_producers
-        )
-
-        converters = @graph.group_converters(
-          :merit_household_hot_water_producers
-        )
-
-        converters.sum do |converter|
-          api = converter.converter_api
-          api.coefficient_of_performance * (api.input_of_electricity / total)
-        end
-      end
-
-      # Public: The share of electrical technologies among all household hot
-      # water producers.
-      #
-      # Returns a float.
-      def share_of_electricity_in_household_hot_water
-        producers = @graph.group_converters(
-          :merit_household_hot_water_producers
-        )
-
-        outputs = producers.flat_map do |conv|
-          conv.output(:useable_heat).links.map(&:lft_converter)
-        end.uniq
-
-        producers.map(&:converter_api).sum(&:output_of_useable_heat) /
-          outputs.map(&:converter_api).sum(&:input_of_useable_heat)
-      end
-
       # Public: Creates a profile describing the demand for electricity due to
       # heating and cooling in old households.
       def old_household_space_heating_demand

--- a/app/models/qernel/plugins/merit/household_heat.rb
+++ b/app/models/qernel/plugins/merit/household_heat.rb
@@ -25,20 +25,14 @@ module Qernel::Plugins
       # Public: The total demand for electricity for heating technologies for
       # households of the given type; :old or :new.
       def demand_of(type)
-        demand_for_electricity * share_of(type)
+        share_of(type) * @graph.converter(
+          :households_useful_demand_for_space_heating_after_insulation_and_solar_heater
+        ).converter_api.input_of(:useable_heat)
       end
 
       # Public: The share of households of the given type; :old or :new.
       def share_of(type)
         type == :new ? share_of_new_households : share_of_old_households
-      end
-
-      # Public: The total demand for electricity for heating technologies in
-      # households.
-      def demand_for_electricity
-        @graph.query.group_demand_for_electricity(
-          :merit_household_space_heating_producers
-        )
       end
 
       # Public: The share of households which are classed as "old".
@@ -79,4 +73,3 @@ module Qernel::Plugins
     end
   end # Merit
 end # Qernel::Plugins
-

--- a/app/models/qernel/plugins/merit/household_heat.rb
+++ b/app/models/qernel/plugins/merit/household_heat.rb
@@ -25,9 +25,7 @@ module Qernel::Plugins
       # Public: The total demand for electricity for heating technologies for
       # households of the given type; :old or :new.
       def demand_of(type)
-        share_of(type) * @graph.converter(
-          :households_useful_demand_for_space_heating_after_insulation_and_solar_heater
-        ).converter_api.input_of(:useable_heat)
+        share_of(type) * demand_for_heat
       end
 
       # Public: The share of households of the given type; :old or :new.
@@ -51,6 +49,15 @@ module Qernel::Plugins
           old = share_of_old_households
           old.zero? && new_demand.zero? ? 0.0 : 1.0 - old
         end
+      end
+
+      def demand_for_heat
+        @demand_for_heat ||=
+          Etsource::Fever.data.values
+            .flat_map { |nodes| nodes[:consumer] }
+            .sum do |key|
+              @graph.converter(key).converter_api.input_of(:useable_heat)
+            end
       end
 
       private

--- a/app/models/qernel/plugins/merit/household_heat.rb
+++ b/app/models/qernel/plugins/merit/household_heat.rb
@@ -52,12 +52,17 @@ module Qernel::Plugins
       end
 
       def demand_for_heat
-        @demand_for_heat ||=
-          Etsource::Fever.data.values
-            .flat_map { |nodes| nodes[:consumer] }
-            .sum do |key|
+        @demand_for_heat ||= begin
+          sh_group = Etsource::Fever.data[:space_heating]
+
+          if sh_group && sh_group[:consumer].present?
+            sh_group[:consumer].sum do |key|
               @graph.converter(key).converter_api.input_of(:useable_heat)
             end
+          else
+            0.0
+          end
+        end
       end
 
       private

--- a/app/models/qernel/plugins/merit/household_power_to_heat_adapter.rb
+++ b/app/models/qernel/plugins/merit/household_power_to_heat_adapter.rb
@@ -18,15 +18,15 @@ module Qernel::Plugins
           load_curve.set(frame, load_curve.get(frame) - stored)
 
           stored
-
-          # @delegate.store_excess(frame, amount)
         end
       end
 
       def producer_attributes
         attrs = super
 
-        attrs[:delegate] = @graph.plugin(:time_resolve).fever.calculator
+        # Yuck.
+        attrs[:delegate] =
+          @graph.plugin(:time_resolve).fever.group(:hot_water).calculator
 
         # attrs[:decay] =
         #   @converter.number_of_units.zero? ? ->(*) { 0.0 } : reserve_decay

--- a/app/models/qernel/plugins/merit_order.rb
+++ b/app/models/qernel/plugins/merit_order.rb
@@ -77,8 +77,9 @@ module Qernel::Plugins
       end
 
       @graph.graph_query.total_demand_for_electricity -
-        # Curves are in mWh; convert back to J.
-        (3600.0 * curves.ev_demand.sum + fever_demands)
+        fever_demands -
+        # Curves are in MWh; convert back to J.
+        (3600.0 * curves.ev_demand.sum)
     end
 
     # Internal: Sets the position of each dispatchable in the merit order -

--- a/app/models/qernel/plugins/merit_order.rb
+++ b/app/models/qernel/plugins/merit_order.rb
@@ -62,7 +62,7 @@ module Qernel::Plugins
     def total_demand_curve
       # Hot water demand is added as a separate user so that demand may be
       # altered by P2H.
-      @total_demand_curve ||= super + curves.combined
+      @total_demand_curve ||= super + curves.ev_demand
     end
 
     # Internal: The total electricity demand, joules, across the graph, minus

--- a/app/models/qernel/plugins/merit_order.rb
+++ b/app/models/qernel/plugins/merit_order.rb
@@ -38,10 +38,12 @@ module Qernel::Plugins
     def setup
       super
 
-      @order.add(::Merit::User.create(
-        key:        :household_hot_water,
-        load_curve: curves.household_hot_water_demand
-      ))
+      @graph.plugin(:time_resolve).fever.groups.each do |fgroup|
+        @order.add(::Merit::User.create(
+          key: :"fever_#{ fgroup.name }",
+          load_curve: fgroup.elec_demand_curve
+        ))
+      end
     end
 
     # Internal: Takes loads and costs from the calculated Merit order, and

--- a/app/models/qernel/plugins/merit_order.rb
+++ b/app/models/qernel/plugins/merit_order.rb
@@ -70,9 +70,15 @@ module Qernel::Plugins
     #
     # Returns a float.
     def total_demand
+      fever_demands = @graph.plugin(:time_resolve).fever.groups.sum do |group|
+        group.adapters_by_type[:producer].sum do |adapt|
+          adapt.converter.input_of_electricity
+        end
+      end
+
       @graph.graph_query.total_demand_for_electricity -
         # Curves are in mWh; convert back to J.
-        (3600.0 * (curves.combined.sum + curves.household_hot_water_demand.sum))
+        (3600.0 * curves.ev_demand.sum + fever_demands)
     end
 
     # Internal: Sets the position of each dispatchable in the merit order -

--- a/app/models/qernel/plugins/plugin.rb
+++ b/app/models/qernel/plugins/plugin.rb
@@ -73,7 +73,7 @@ module Qernel::Plugins
       # Internal: Sets up inheritance of hooks, ensuring that subclasses cannot
       # affect the hooks defined on the superclass.
       def inherited(child)
-        child.hooks = Hash[self.hooks.map { |key, hooks| [key, hook.dup] }]
+        child.hooks = Hash[self.hooks.map { |key, hook| [key, hook.dup] }]
         child.hooks.default_proc = proc { |hash, key| hash[key] = [] }
       end
 

--- a/app/models/qernel/plugins/time_resolve.rb
+++ b/app/models/qernel/plugins/time_resolve.rb
@@ -1,0 +1,87 @@
+module Qernel::Plugins
+  # Graph plugin which coordinates the calculation of time-resolved electricity
+  # and heat loads in Merit and Fever.
+  class TimeResolve
+    include Plugin
+
+    before :first_calculation, :clone_dataset
+    after  :first_calculation, :setup
+    after  :first_calculation, :run
+    before :recalculation,     :inject
+
+    attr_reader :merit
+    attr_reader :fever
+
+    # Public: The SimpleMeritOrder plugin is enabled only on future graphs, and
+    # only when the "full" Merit order has not been requested.
+    def self.enabled?(graph)
+      !SimpleMeritOrder.enabled?(graph)
+    end
+
+    # Public: A unique name to represent the plugin.
+    #
+    # Returns a symbol.
+    def self.plugin_name
+      :time_resolve
+    end
+
+    # Internal: Retrieves the load curve matching the given key.
+    #
+    # Returns a Merit::Curve.
+    def self.load_profile(dataset, key)
+      unless (path = dataset.load_profile_path(key)).file?
+        raise "No such load profile: #{ path }"
+      end
+
+      ::Merit::LoadProfile.load(path)
+    end
+
+    def initialize(graph)
+      super
+      @merit = MeritOrder.new(graph)
+      @fever = Qernel::Plugins::Fever::Plugin.new(graph)
+    end
+
+    # Internal: Sets up the Merit::Order. Clones the graph dataset so that we
+    # can reset the graph after the first calculation.
+    def clone_dataset
+      @original_dataset = DeepClone.clone(@graph.dataset)
+    end
+
+    # Internal: After the first graph is calculated, demands are passed into the
+    # Merit order to determine in which order to run the plants. The results are
+    # stored for future use.
+    def run(lifecycle)
+      lifecycle.must_recalculate!
+    end
+
+    # Internal: Sets up Fever and Merit.
+    def setup
+      @fever.setup
+      @merit.setup
+    end
+
+    def inject
+      merit_calc = ::Merit::StepwiseCalculator.new.calculate(@merit.order)
+      fever_calc = @fever.calculator
+
+      8760.times do |frame|
+        fever_calc.calculate_frame(frame)
+        merit_calc.call(frame)
+      end
+
+      # Detaching the dataset clears the goals. This would ordinarily be correct
+      # behaviour, but we need to preserve them for the second calculation.
+      goals = @graph.goals
+      @graph.detach_dataset!
+
+      @graph.dataset = @original_dataset
+      @graph.goals   = goals
+
+      # Any subsequent calculations (one of which) must have the merit order
+      # demands injected into the graph.
+      @merit.send(:inject_values!)
+      @fever.inject_values!
+    end
+  end
+end

--- a/app/models/qernel/plugins/time_resolve.rb
+++ b/app/models/qernel/plugins/time_resolve.rb
@@ -63,10 +63,9 @@ module Qernel::Plugins
 
     def inject
       merit_calc = ::Merit::StepwiseCalculator.new.calculate(@merit.order)
-      fever_calc = @fever.calculator
 
       8760.times do |frame|
-        fever_calc.calculate_frame(frame)
+        @fever.calculate_frame(frame)
         merit_calc.call(frame)
       end
 

--- a/app/views/data/converters/show.html.haml
+++ b/app/views/data/converters/show.html.haml
@@ -68,13 +68,13 @@
           %td Used in Gqueries
           %td
             %ol
-              - Gquery.name_or_query_contains(converter_key).each do |gquery|
+              - Gquery.name_or_query_contains(converter_key).sort_by(&:key).each do |gquery|
                 %li= link_to gquery.key, data_gquery_path(:id => gquery.id)
         %tr
           %td Used in Inputs
           %td
             %ol
-              - Input.with_queries_containing(converter_key).each do |input|
+              - Input.with_queries_containing(converter_key).sort_by(&:key).each do |input|
                 %li= link_to input.key, data_input_path(:id => input.id, :highlight => converter_key)
 
 .row-fluid.future-edges

--- a/spec/models/qernel/plugins/merit/curves_spec.rb
+++ b/spec/models/qernel/plugins/merit/curves_spec.rb
@@ -113,9 +113,8 @@ describe 'Qernel::Plugins::Merit::Curves' do
         .with(:merit_new_household_heat)
         .and_return([new_houses])
 
-      allow(graph_api)
-        .to receive(:group_demand_for_electricity)
-        .with(:merit_household_space_heating_producers).and_return(8760.0)
+      allow(curves.send(:heat_demand))
+        .to receive(:demand_for_heat).and_return(8760.0)
     end
 
     context 'with a "share" of 0.25 (25/75 profile mix)' do
@@ -157,9 +156,8 @@ describe 'Qernel::Plugins::Merit::Curves' do
         .with(:merit_new_household_heat)
         .and_return([new_houses])
 
-      allow(graph_api)
-        .to receive(:group_demand_for_electricity)
-        .with(:merit_household_space_heating_producers).and_return(8760.0)
+      allow(curves.send(:heat_demand))
+        .to receive(:demand_for_heat).and_return(8760.0)
     end
 
     context 'with a "share" of 0.75 (25/75 profile mix)' do

--- a/spec/models/qernel/plugins/merit/household_heat_spec.rb
+++ b/spec/models/qernel/plugins/merit/household_heat_spec.rb
@@ -1,11 +1,15 @@
 require 'spec_helper'
 
 describe Qernel::Plugins::Merit::HouseholdHeat do
-  let(:helper) { described_class.new(graph) }
+  let(:helper) do
+    helper = described_class.new(graph)
+    allow(helper).to receive(:demand_for_heat).and_return(heat_demand)
+    helper
+  end
 
   let(:old_household_demand) { 0.0 }
   let(:new_household_demand) { 0.0 }
-  let(:electricity_demand)   { 0.0 }
+  let(:heat_demand)   { 0.0 }
 
   let(:graph) do
     api   = double('Qernel::GraphApi')
@@ -22,22 +26,18 @@ describe Qernel::Plugins::Merit::HouseholdHeat do
       .with(:merit_new_household_heat)
       .and_return([new_house])
 
-    allow(api).to receive(:group_demand_for_electricity)
-      .with(:merit_household_space_heating_producers)
-      .and_return(electricity_demand)
-
     graph
   end
 
   context 'with electricity demand of 1000' do
-    let(:electricity_demand) { 1000.0 }
+    let(:heat_demand) { 1000.0 }
 
     context 'with 100% new houses' do
       let(:new_household_demand) { 100.0 }
       let(:old_household_demand) { 0.0 }
 
       it 'has total electricity demand of 1000' do
-        expect(helper.demand_for_electricity).to eq(1000)
+        expect(helper.demand_for_heat).to eq(1000)
       end
 
       it 'has 0% share of old households' do
@@ -62,7 +62,7 @@ describe Qernel::Plugins::Merit::HouseholdHeat do
       let(:old_household_demand) { 100.0 }
 
       it 'has total electricity demand of 1000' do
-        expect(helper.demand_for_electricity).to eq(1000)
+        expect(helper.demand_for_heat).to eq(1000)
       end
 
       it 'has 100% share of old households' do
@@ -87,7 +87,7 @@ describe Qernel::Plugins::Merit::HouseholdHeat do
       let(:old_household_demand) { 40.0 }
 
       it 'has total electricity demand of 1000' do
-        expect(helper.demand_for_electricity).to eq(1000)
+        expect(helper.demand_for_heat).to eq(1000)
       end
 
       it 'has 40% share of old households' do
@@ -112,7 +112,7 @@ describe Qernel::Plugins::Merit::HouseholdHeat do
       let(:old_household_demand) { 0.0 }
 
       it 'has total electricity demand of 1000' do
-        expect(helper.demand_for_electricity).to eq(1000)
+        expect(helper.demand_for_heat).to eq(1000)
       end
 
       it 'has 0% share of old households' do
@@ -134,14 +134,14 @@ describe Qernel::Plugins::Merit::HouseholdHeat do
   end # with electricity demand of 1000
 
   context 'with no electricity demand' do
-    let(:electricity_demand) { 0.0 }
+    let(:heat_demand) { 0.0 }
 
     context 'with 40% old houses, 60% new houses' do
       let(:new_household_demand) { 60.0 }
       let(:old_household_demand) { 40.0 }
 
       it 'has total electricity demand of zero' do
-        expect(helper.demand_for_electricity).to eq(0)
+        expect(helper.demand_for_heat).to eq(0)
       end
 
       it 'has 40% share of old households' do

--- a/spec/models/qernel/plugins/merit_order_spec.rb
+++ b/spec/models/qernel/plugins/merit_order_spec.rb
@@ -45,8 +45,8 @@ module Qernel::Plugins
         graph = gql.present.graph
         graph.calculate
 
-        expect(graph.lifecycle.plugins[:merit]).to be_a(SimpleMeritOrder)
-        expect(graph.lifecycle.plugins[:merit]).to_not be_a(MeritOrder)
+        expect(graph.plugin(:merit)).to be_a(SimpleMeritOrder)
+        expect(graph.plugin(:merit)).to_not be_a(MeritOrder)
       end
 
       it 'uses the SimpleMeritOrder plugin on the future graph' do
@@ -55,8 +55,8 @@ module Qernel::Plugins
         graph = gql.future.graph
         graph.calculate
 
-        expect(graph.lifecycle.plugins[:merit]).to be_a(SimpleMeritOrder)
-        expect(graph.lifecycle.plugins[:merit]).to_not be_a(MeritOrder)
+        expect(graph.plugin(:merit)).to be_a(SimpleMeritOrder)
+        expect(graph.plugin(:merit)).to_not be_a(MeritOrder)
       end
     end # when the scenario has the MeritOrder disabled
 
@@ -81,7 +81,7 @@ module Qernel::Plugins
 
         graph = gql.future.graph
 
-        expect(graph.lifecycle.plugins[:merit]).to be_a(MeritOrder)
+        expect(graph.plugin(:merit)).to be_a(MeritOrder)
       end
 
       it 'calculates the future graph twice' do


### PR DESCRIPTION
Implements an interface with the Fever gem to dynamically compute the supply and consumption of heat within households. Interacts with Merit by setting the load of electrical producers and supplying excess electricity to P2H for storage.

Implements:

* Variable-efficiency producers, whose output capacity varies depending on the ambient temperature.
* Hybrid heat pumps which switch to gas when the electric component has insufficient capacity.
* Gas combi-boilers satisfy hot water demands before space heating .
* Space heating loads may be deferred a number of hours when capacity is insufficient (default is four hours).
* CoP-cutoff for hybrid heat pumps where the electric component will fail-over to gas when the ambient temperature is too low.
* Some producers use their spare capacity to store heat in a buffer.
* Changes to demand-driven converters to account for the new "aggregator" nodes, which have been inserted between heat producers and the useful demand nodes.