### PR TITLE
Styling fixes regarding search form + button for creating a scenario

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -80,3 +80,24 @@ tr.converter-flows
     color: #444
     font-size: 1rem
     margin-top: 22px
+
+.subnav
+  ul.nav.nav-pills
+    margin-left: 9px
+
+section#search_box
+  form
+    input, label
+      line-height: 18px
+      margin-bottom: 0
+      vertical-align: middle
+
+    input#q
+      margin-right: 7px
+
+    label
+      display: inline
+      margin-right: 7px
+
+      &:hover
+        cursor: pointer

--- a/app/views/data/scenarios/index.html.haml
+++ b/app/views/data/scenarios/index.html.haml
@@ -4,12 +4,13 @@
   = form_tag data_scenarios_path, :method => :get do
     = search_field_tag :q, params[:q], :placeholder => 'search'
     = check_box_tag :in_start_menu, 1, params[:in_start_menu]
-    In start menu
+    = label_tag "In start menu", nil, for: "in_start_menu"
     = check_box_tag :protected, 1, params[:protected]
-    Protected
+    = label_tag "Protected", nil, for: "protected"
     = submit_tag "search", :class => 'btn'
 
-=link_to "create new scenario", new_data_scenario_path
+%p
+  = link_to "create new scenario", new_data_scenario_path, class: 'btn'
 
 %table.table.table-condensed
   %thead


### PR DESCRIPTION
I was about to work on #957 - only to find out that it was already fixed. Still saw some little styling things. 

Diff between production and local:

![screen shot 2017-11-08 at 10 18 51](https://user-images.githubusercontent.com/2676542/32540851-45bda7c0-c46e-11e7-8175-24c101c5cbd6.png)

----

![screen shot 2017-11-08 at 10 19 06](https://user-images.githubusercontent.com/2676542/32540852-45de0e20-c46e-11e7-8084-6422042cacc4.png)
