### PR TITLE
Clear region list prior to calculating datasets

### DIFF
--- a/app/models/etsource/atlas_loader.rb
+++ b/app/models/etsource/atlas_loader.rb
@@ -129,7 +129,7 @@ module Etsource
       def reload!
         super
 
-        Etsource::Dataset.region_codes.each do |code|
+        Etsource::Dataset.region_codes(refresh: true).each do |code|
           calculator = ->{ calculate!(code) }
 
           yield(code, calculator) if block_given?

--- a/app/models/etsource/dataset.rb
+++ b/app/models/etsource/dataset.rb
@@ -24,7 +24,9 @@ module Etsource
       ::Etsource::Dataset::Import.new(country).import
     end
 
-    def self.region_codes
+    def self.region_codes(refresh: false)
+      NastyCache.instance.delete('region_codes') if refresh
+
       NastyCache.instance.fetch('region_codes') do
         Atlas::Dataset.all
           .select { |dataset| dataset.enabled[:etengine] }

--- a/app/models/nasty_cache.rb
+++ b/app/models/nasty_cache.rb
@@ -113,6 +113,11 @@ class NastyCache
     @cache_store[key] = value
   end
 
+  def delete(key)
+    @cache_store.delete(key)
+    Rails.cache.delete(rails_cache_key(key))
+  end
+
 ##############
 # protected
 ##############

--- a/spec/models/nasty_cache_spec.rb
+++ b/spec/models/nasty_cache_spec.rb
@@ -56,6 +56,35 @@ describe NastyCache do
     @cache.fetch_cached('cache_1_baz') { "bar" }.should == "bar"
   end
 
+  context 'delete' do
+    context 'when no value is set' do
+      it 'does nothing' do
+        @cache.delete('no')
+        expect(@cache.get('no')).to be_nil
+      end
+    end
+
+    context 'when an in-memory value is set' do
+      before { @cache.set('inmem', 1) }
+
+      it 'removes the in-memory value' do
+        expect { @cache.delete('inmem') }
+          .to change { @cache.get('inmem') }
+          .from(1).to(nil)
+      end
+    end
+
+    context 'when a Rails cache value is set' do
+      before { @cache.fetch_cached('rval') { 2 } }
+
+      it 'removes the in-memory value' do
+        expect { @cache.delete('rval') }
+          .to change { @cache.get('rval') }
+          .from(2).to(nil)
+      end
+    end
+  end
+
   context "two processes" do
     before {
       @cache_1 = NastyCache.new_process


### PR DESCRIPTION
Importing a new ETSource commit would attempt to reload the Atlas data before the Rails/in-memory caches had been expired (largely to prevent old Atlas data from re-populating the caches).

This commit adds `NastyCache.delete` and will remove the cached list of regions prior to reloading Atlas data, thus ensuring that newly-added or -enabled datasets are calculated.

Closes #977