### PR TITLE
Add migration for CO2 emissions

### DIFF
--- a/db/migrate/20180104152128_correct_co2_emission_sliders.rb
+++ b/db/migrate/20180104152128_correct_co2_emission_sliders.rb
@@ -1,0 +1,34 @@
+class CorrectCo2EmissionSliders < ActiveRecord::Migration
+  KG_PER_MJ_IN_G_PER_KWH = 3600.0
+
+  def change
+    scenarios = Scenario.where(
+      '(protected = ? OR created_at >= ?) AND source != ? AND title != ?',
+      true, 1.month.ago, 'Mechanical Turk', 'test'
+    ).order(:area_code)
+
+    count = 0
+    puts "Need to migrate: #{ scenarios.count } scenarios"
+
+    scenarios.find_each do |scenario|
+      next unless scenario.valid?
+
+      if count % 50 == 0
+        puts "#{ Time.now } | #{ count } -> #{ scenario.id }"
+      end
+
+      gql = scenario.gql
+
+      scenario.user_values.merge!(
+        co2_emissions_of_imported_electricity_present: KG_PER_MJ_IN_G_PER_KWH *
+          gql.present.query(:average_co2_emissions_of_produced_electricity),
+        co2_emissions_of_imported_electricity_future: KG_PER_MJ_IN_G_PER_KWH *
+          gql.future.query(:average_co2_emissions_of_produced_electricity)
+      )
+
+      scenario.save
+
+      count += 1
+    end
+  end
+end

--- a/db/migrate/20180104152128_correct_co2_emission_sliders.rb
+++ b/db/migrate/20180104152128_correct_co2_emission_sliders.rb
@@ -1,7 +1,7 @@
-class CorrectCo2EmissionSliders < ActiveRecord::Migration
+class CorrectCo2EmissionSliders < ActiveRecord::Migration[5.1]
   KG_PER_MJ_IN_G_PER_KWH = 3600.0
 
-  def change
+  def up
     scenarios = Scenario.where(
       '(protected = ? OR created_at >= ?) AND source != ? AND title != ?',
       true, 1.month.ago, 'Mechanical Turk', 'test'
@@ -30,5 +30,9 @@ class CorrectCo2EmissionSliders < ActiveRecord::Migration
 
       count += 1
     end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171220132741) do
+ActiveRecord::Schema.define(version: 20180104152128) do
 
   create_table "fce_values", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string "using_country"


### PR DESCRIPTION
Migrated scenarios count: 3672

Time between each 50 scenarios:

```
2018-01-05 17:01:06 +0100 | 0 -> 114947
2018-01-05 17:01:53 +0100 | 50 -> 116948
```

It's about a minute per 50. So 3000 / 60 =~ 50 minutes before this migration is finished.