### PR TITLE
Added flexibility to technical and financial parameters of tooltips

### DIFF
--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -185,6 +185,52 @@ module Api
         }
       }
 
+      # If the converter belongs to the :cost_electricity_production group then
+      # add these
+      FLEXIBILITY_ATTRIBUTES_AND_METHODS = {
+        :technical => {
+          :typical_input_capacity =>
+            { label: 'Capacity', unit:'MW',
+              formatter: FORMAT_1DP },
+          :full_load_hours  =>
+            {label: 'Full load hours', unit: 'hour / year'},
+        },
+        :cost => {
+          'initial_investment_per(:mw_electricity)' =>
+            { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'ccs_investment_per(:mw_electricity)' =>
+            { label: 'Additional inititial investment for CCS', unit: 'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'decommissioning_costs_per(:mw_electricity)' =>
+            { label: 'Decommissioning costs', unit:'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'fixed_operation_and_maintenance_costs_per(:mw_electricity)' =>
+            { label: 'Fixed operation and maintenance costs', unit:'kEUR / MWe / year',
+              formatter: ->(n) { '%.2f' % (n / 1000) } },
+          :variable_operation_and_maintenance_costs_per_full_load_hour  =>
+            { label: 'Variable operation and maintenance costs (excl CCS)', unit: 'EUR / full load hour',
+              formatter: ->(n) { n.to_i } },
+          :variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour  =>
+            { label: 'Additional variable operation and maintenance costs for CCS', unit: 'EUR / full load hour',
+              formatter: ->(n) { n.to_i } },
+          :wacc  =>
+            {label: 'Weighted average cost of capital', unit: '%'},
+          :takes_part_in_ets  =>
+            {label: 'Do emissions have to be paid through the ETS?', unit: 'yes / no', formatter: lambda{|x| x == 1 ? 'yes' : 'no'}}
+        },
+        :other => {
+          :land_use_per_unit  =>
+            {label: 'Land use per unit', unit: 'km2'},
+          :construction_time  =>
+            { label: 'Construction time', unit: 'years',
+              formatter: FORMAT_1DP },
+          :technical_lifetime  =>
+            { label: 'Technical lifetime', unit: 'years',
+              formatter: ->(n) { n.to_i } }
+        }
+      }
+
       # some converters use extra attributes. Rather than messing up the views I
       # add the method here. I hope this will be removed
       def uses_coal_and_wood_pellets?
@@ -200,6 +246,7 @@ module Api
         out = ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS if @converter.groups.include?(:cost_electricity_production)
         out = HEAT_PUMP_ATTRIBUTES_AND_METHODS              if @converter.groups.include?(:cost_heat_pumps)
         out = CHP_ATTRIBUTES_AND_METHODS                    if @converter.groups.include?(:cost_chps)
+        out = FLEXIBILITY_ATTRIBUTES_AND_METHODS            if @converter.groups.include?(:cost_flexibility)
 
         # custom stuff, trying to keep the view simple
         if uses_coal_and_wood_pellets?

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -185,27 +185,177 @@ module Api
         }
       }
 
-      # If the converter belongs to the :cost_flexibility group then
+      # If the converter belongs to the :cost_carbon_capturing group then
       # add these
-      FLEXIBILITY_ATTRIBUTES_AND_METHODS = {
+      CARBON_CAPTURING_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :typical_input_capacity =>
-            { label: 'Capacity', unit:'MW',
+            { label: 'Capacity', unit:'MWe',
               formatter: FORMAT_1DP },
+          :co_output_conversion=>
+            { label: 'Carbon monoxide output efficiency', unit: '%',
+            formatter: FORMAT_FAC_TO_PERCENT },
           :full_load_hours  =>
             {label: 'Full load hours', unit: 'hour / year'},
         },
         :cost => {
-          'initial_investment_per(:mw_electricity)' =>
+          'initial_investment_per(:mw_typical_input_capacity)' =>
             { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
               formatter: FORMAT_KILO },
-          'ccs_investment_per(:mw_electricity)' =>
+          'ccs_investment_per(:mw_typical_input_capacity)' =>
             { label: 'Additional inititial investment for CCS', unit: 'kEUR / MWe',
               formatter: FORMAT_KILO },
-          'decommissioning_costs_per(:mw_electricity)' =>
+          'decommissioning_costs_per(:mw_typical_input_capacity)' =>
             { label: 'Decommissioning costs', unit:'kEUR / MWe',
               formatter: FORMAT_KILO },
-          'fixed_operation_and_maintenance_costs_per(:mw_electricity)' =>
+          'fixed_operation_and_maintenance_costs_per(:mw_typical_input_capacity)' =>
+            { label: 'Fixed operation and maintenance costs', unit:'kEUR / MWe / year',
+              formatter: ->(n) { '%.2f' % (n / 1000) } },
+          :variable_operation_and_maintenance_costs_per_full_load_hour  =>
+            { label: 'Variable operation and maintenance costs (excl CCS)', unit: 'EUR / full load hour',
+              formatter: ->(n) { n.to_i } },
+          :variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour  =>
+            { label: 'Additional variable operation and maintenance costs for CCS', unit: 'EUR / full load hour',
+              formatter: ->(n) { n.to_i } },
+          :wacc  =>
+            {label: 'Weighted average cost of capital', unit: '%'},
+          :takes_part_in_ets  =>
+            {label: 'Do emissions have to be paid through the ETS?', unit: 'yes / no', formatter: lambda{|x| x == 1 ? 'yes' : 'no'}}
+        },
+        :other => {
+          :land_use_per_unit  =>
+            {label: 'Land use per unit', unit: 'km2'},
+          :construction_time  =>
+            { label: 'Construction time', unit: 'years',
+              formatter: FORMAT_1DP },
+          :technical_lifetime  =>
+            { label: 'Technical lifetime', unit: 'years',
+              formatter: ->(n) { n.to_i } }
+        }
+      }
+
+      # If the converter belongs to the :cost_p2g group then
+      # add these
+      P2G_ATTRIBUTES_AND_METHODS = {
+        :technical => {
+          :typical_input_capacity =>
+            { label: 'Capacity', unit:'MWe',
+              formatter: FORMAT_1DP },
+          :hydrogen_output_conversion=>
+            { label: 'Hydrogen output efficiency', unit: '%',
+            formatter: FORMAT_FAC_TO_PERCENT },
+          :full_load_hours  =>
+            {label: 'Full load hours', unit: 'hour / year'},
+        },
+        :cost => {
+          'initial_investment_per(:mw_typical_input_capacity)' =>
+            { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'ccs_investment_per(:mw_typical_input_capacity)' =>
+            { label: 'Additional inititial investment for CCS', unit: 'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'decommissioning_costs_per(:mw_typical_input_capacity)' =>
+            { label: 'Decommissioning costs', unit:'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'fixed_operation_and_maintenance_costs_per(:mw_typical_input_capacity)' =>
+            { label: 'Fixed operation and maintenance costs', unit:'kEUR / MWe / year',
+              formatter: ->(n) { '%.2f' % (n / 1000) } },
+          :variable_operation_and_maintenance_costs_per_full_load_hour  =>
+            { label: 'Variable operation and maintenance costs (excl CCS)', unit: 'EUR / full load hour',
+              formatter: ->(n) { n.to_i } },
+          :variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour  =>
+            { label: 'Additional variable operation and maintenance costs for CCS', unit: 'EUR / full load hour',
+              formatter: ->(n) { n.to_i } },
+          :wacc  =>
+            {label: 'Weighted average cost of capital', unit: '%'},
+          :takes_part_in_ets  =>
+            {label: 'Do emissions have to be paid through the ETS?', unit: 'yes / no', formatter: lambda{|x| x == 1 ? 'yes' : 'no'}}
+        },
+        :other => {
+          :land_use_per_unit  =>
+            {label: 'Land use per unit', unit: 'km2'},
+          :construction_time  =>
+            { label: 'Construction time', unit: 'years',
+              formatter: FORMAT_1DP },
+          :technical_lifetime  =>
+            { label: 'Technical lifetime', unit: 'years',
+              formatter: ->(n) { n.to_i } }
+        }
+      }
+
+      # If the converter belongs to the :cost_p2h group then
+      # add these
+      P2H_ATTRIBUTES_AND_METHODS = {
+        :technical => {
+          :typical_input_capacity =>
+            { label: 'Capacity', unit:'MWe',
+              formatter: FORMAT_1DP },
+          :useable_heat_output_conversion=>
+            { label: 'Heat efficiency', unit: '%',
+            formatter: FORMAT_FAC_TO_PERCENT },
+          :full_load_hours  =>
+            {label: 'Full load hours', unit: 'hour / year'},
+        },
+        :cost => {
+          'initial_investment_per(:mw_typical_input_capacity)' =>
+            { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'ccs_investment_per(:mw_typical_input_capacity)' =>
+            { label: 'Additional inititial investment for CCS', unit: 'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'decommissioning_costs_per(:mw_typical_input_capacity)' =>
+            { label: 'Decommissioning costs', unit:'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'fixed_operation_and_maintenance_costs_per(:mw_typical_input_capacity)' =>
+            { label: 'Fixed operation and maintenance costs', unit:'kEUR / MWe / year',
+              formatter: ->(n) { '%.2f' % (n / 1000) } },
+          :variable_operation_and_maintenance_costs_per_full_load_hour  =>
+            { label: 'Variable operation and maintenance costs (excl CCS)', unit: 'EUR / full load hour',
+              formatter: ->(n) { n.to_i } },
+          :variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour  =>
+            { label: 'Additional variable operation and maintenance costs for CCS', unit: 'EUR / full load hour',
+              formatter: ->(n) { n.to_i } },
+          :wacc  =>
+            {label: 'Weighted average cost of capital', unit: '%'},
+          :takes_part_in_ets  =>
+            {label: 'Do emissions have to be paid through the ETS?', unit: 'yes / no', formatter: lambda{|x| x == 1 ? 'yes' : 'no'}}
+        },
+        :other => {
+          :land_use_per_unit  =>
+            {label: 'Land use per unit', unit: 'km2'},
+          :construction_time  =>
+            { label: 'Construction time', unit: 'years',
+              formatter: FORMAT_1DP },
+          :technical_lifetime  =>
+            { label: 'Technical lifetime', unit: 'years',
+              formatter: ->(n) { n.to_i } }
+        }
+      }
+
+      # If the converter belongs to the :cost_p2kerosene group then
+      # add these
+      P2KEROSENE_ATTRIBUTES_AND_METHODS = {
+        :technical => {
+          :typical_input_capacity =>
+            { label: 'Capacity', unit:'MWe',
+              formatter: FORMAT_1DP },
+          :kerosene_output_conversion=>
+            { label: 'Kerosene output efficiency', unit: '%',
+            formatter: FORMAT_FAC_TO_PERCENT },
+          :full_load_hours  =>
+            {label: 'Full load hours', unit: 'hour / year'},
+        },
+        :cost => {
+          'initial_investment_per(:mw_typical_input_capacity)' =>
+            { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'ccs_investment_per(:mw_typical_input_capacity)' =>
+            { label: 'Additional inititial investment for CCS', unit: 'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'decommissioning_costs_per(:mw_typical_input_capacity)' =>
+            { label: 'Decommissioning costs', unit:'kEUR / MWe',
+              formatter: FORMAT_KILO },
+          'fixed_operation_and_maintenance_costs_per(:mw_typical_input_capacity)' =>
             { label: 'Fixed operation and maintenance costs', unit:'kEUR / MWe / year',
               formatter: ->(n) { '%.2f' % (n / 1000) } },
           :variable_operation_and_maintenance_costs_per_full_load_hour  =>
@@ -246,7 +396,10 @@ module Api
         out = ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS if @converter.groups.include?(:cost_electricity_production)
         out = HEAT_PUMP_ATTRIBUTES_AND_METHODS              if @converter.groups.include?(:cost_heat_pumps)
         out = CHP_ATTRIBUTES_AND_METHODS                    if @converter.groups.include?(:cost_chps)
-        out = FLEXIBILITY_ATTRIBUTES_AND_METHODS            if @converter.groups.include?(:cost_flexibility)
+        out = CARBON_CAPTURING_ATTRIBUTES_AND_METHODS       if @converter.groups.include?(:cost_carbon_capturing)
+        out = P2G_ATTRIBUTES_AND_METHODS                    if @converter.groups.include?(:cost_p2g)
+        out = P2H_ATTRIBUTES_AND_METHODS                    if @converter.groups.include?(:cost_p2h)
+        out = P2KEROSENE_ATTRIBUTES_AND_METHODS             if @converter.groups.include?(:cost_p2kerosene)
 
         # custom stuff, trying to keep the view simple
         if uses_coal_and_wood_pellets?

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -185,7 +185,7 @@ module Api
         }
       }
 
-      # If the converter belongs to the :cost_electricity_production group then
+      # If the converter belongs to the :cost_flexibility group then
       # add these
       FLEXIBILITY_ATTRIBUTES_AND_METHODS = {
         :technical => {

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -185,19 +185,7 @@ module Api
         }
       }
 
-      # If the converter belongs to the :cost_carbon_capturing group then
-      # add these
-      CARBON_CAPTURING_ATTRIBUTES_AND_METHODS = {
-        :technical => {
-          :typical_input_capacity =>
-            { label: 'Capacity', unit:'MWe',
-              formatter: FORMAT_1DP },
-          :co_output_conversion=>
-            { label: 'Carbon monoxide output efficiency', unit: '%',
-            formatter: FORMAT_FAC_TO_PERCENT },
-          :full_load_hours  =>
-            {label: 'Full load hours', unit: 'hour / year'},
-        },
+      FLEXIBILITY_COSTS_AND_OTHER = {
         :cost => {
           'initial_investment_per(:mw_typical_input_capacity)' =>
             { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
@@ -233,6 +221,21 @@ module Api
               formatter: ->(n) { n.to_i } }
         }
       }
+
+      # If the converter belongs to the :cost_carbon_capturing group then
+      # add these
+      CARBON_CAPTURING_ATTRIBUTES_AND_METHODS = {
+        :technical => {
+          :typical_input_capacity =>
+            { label: 'Capacity', unit:'MWe',
+              formatter: FORMAT_1DP },
+          :co_output_conversion=>
+            { label: 'Carbon monoxide output efficiency', unit: '%',
+            formatter: FORMAT_FAC_TO_PERCENT },
+          :full_load_hours  =>
+            {label: 'Full load hours', unit: 'hour / year'},
+        }
+      }.merge(FLEXIBILITY_COSTS_AND_OTHER)
 
       # If the converter belongs to the :cost_p2g group then
       # add these
@@ -246,42 +249,8 @@ module Api
             formatter: FORMAT_FAC_TO_PERCENT },
           :full_load_hours  =>
             {label: 'Full load hours', unit: 'hour / year'},
-        },
-        :cost => {
-          'initial_investment_per(:mw_typical_input_capacity)' =>
-            { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'ccs_investment_per(:mw_typical_input_capacity)' =>
-            { label: 'Additional inititial investment for CCS', unit: 'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'decommissioning_costs_per(:mw_typical_input_capacity)' =>
-            { label: 'Decommissioning costs', unit:'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'fixed_operation_and_maintenance_costs_per(:mw_typical_input_capacity)' =>
-            { label: 'Fixed operation and maintenance costs', unit:'kEUR / MWe / year',
-              formatter: ->(n) { '%.2f' % (n / 1000) } },
-          :variable_operation_and_maintenance_costs_per_full_load_hour  =>
-            { label: 'Variable operation and maintenance costs (excl CCS)', unit: 'EUR / full load hour',
-              formatter: ->(n) { n.to_i } },
-          :variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour  =>
-            { label: 'Additional variable operation and maintenance costs for CCS', unit: 'EUR / full load hour',
-              formatter: ->(n) { n.to_i } },
-          :wacc  =>
-            {label: 'Weighted average cost of capital', unit: '%'},
-          :takes_part_in_ets  =>
-            {label: 'Do emissions have to be paid through the ETS?', unit: 'yes / no', formatter: lambda{|x| x == 1 ? 'yes' : 'no'}}
-        },
-        :other => {
-          :land_use_per_unit  =>
-            {label: 'Land use per unit', unit: 'km2'},
-          :construction_time  =>
-            { label: 'Construction time', unit: 'years',
-              formatter: FORMAT_1DP },
-          :technical_lifetime  =>
-            { label: 'Technical lifetime', unit: 'years',
-              formatter: ->(n) { n.to_i } }
         }
-      }
+      }.merge(FLEXIBILITY_COSTS_AND_OTHER)
 
       # If the converter belongs to the :cost_p2h group then
       # add these
@@ -295,42 +264,8 @@ module Api
             formatter: FORMAT_FAC_TO_PERCENT },
           :full_load_hours  =>
             {label: 'Full load hours', unit: 'hour / year'},
-        },
-        :cost => {
-          'initial_investment_per(:mw_typical_input_capacity)' =>
-            { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'ccs_investment_per(:mw_typical_input_capacity)' =>
-            { label: 'Additional inititial investment for CCS', unit: 'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'decommissioning_costs_per(:mw_typical_input_capacity)' =>
-            { label: 'Decommissioning costs', unit:'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'fixed_operation_and_maintenance_costs_per(:mw_typical_input_capacity)' =>
-            { label: 'Fixed operation and maintenance costs', unit:'kEUR / MWe / year',
-              formatter: ->(n) { '%.2f' % (n / 1000) } },
-          :variable_operation_and_maintenance_costs_per_full_load_hour  =>
-            { label: 'Variable operation and maintenance costs (excl CCS)', unit: 'EUR / full load hour',
-              formatter: ->(n) { n.to_i } },
-          :variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour  =>
-            { label: 'Additional variable operation and maintenance costs for CCS', unit: 'EUR / full load hour',
-              formatter: ->(n) { n.to_i } },
-          :wacc  =>
-            {label: 'Weighted average cost of capital', unit: '%'},
-          :takes_part_in_ets  =>
-            {label: 'Do emissions have to be paid through the ETS?', unit: 'yes / no', formatter: lambda{|x| x == 1 ? 'yes' : 'no'}}
-        },
-        :other => {
-          :land_use_per_unit  =>
-            {label: 'Land use per unit', unit: 'km2'},
-          :construction_time  =>
-            { label: 'Construction time', unit: 'years',
-              formatter: FORMAT_1DP },
-          :technical_lifetime  =>
-            { label: 'Technical lifetime', unit: 'years',
-              formatter: ->(n) { n.to_i } }
         }
-      }
+      }.merge(FLEXIBILITY_COSTS_AND_OTHER)
 
       # If the converter belongs to the :cost_p2kerosene group then
       # add these
@@ -344,42 +279,8 @@ module Api
             formatter: FORMAT_FAC_TO_PERCENT },
           :full_load_hours  =>
             {label: 'Full load hours', unit: 'hour / year'},
-        },
-        :cost => {
-          'initial_investment_per(:mw_typical_input_capacity)' =>
-            { label: 'Initial investment (excl CCS)', unit: 'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'ccs_investment_per(:mw_typical_input_capacity)' =>
-            { label: 'Additional inititial investment for CCS', unit: 'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'decommissioning_costs_per(:mw_typical_input_capacity)' =>
-            { label: 'Decommissioning costs', unit:'kEUR / MWe',
-              formatter: FORMAT_KILO },
-          'fixed_operation_and_maintenance_costs_per(:mw_typical_input_capacity)' =>
-            { label: 'Fixed operation and maintenance costs', unit:'kEUR / MWe / year',
-              formatter: ->(n) { '%.2f' % (n / 1000) } },
-          :variable_operation_and_maintenance_costs_per_full_load_hour  =>
-            { label: 'Variable operation and maintenance costs (excl CCS)', unit: 'EUR / full load hour',
-              formatter: ->(n) { n.to_i } },
-          :variable_operation_and_maintenance_costs_for_ccs_per_full_load_hour  =>
-            { label: 'Additional variable operation and maintenance costs for CCS', unit: 'EUR / full load hour',
-              formatter: ->(n) { n.to_i } },
-          :wacc  =>
-            {label: 'Weighted average cost of capital', unit: '%'},
-          :takes_part_in_ets  =>
-            {label: 'Do emissions have to be paid through the ETS?', unit: 'yes / no', formatter: lambda{|x| x == 1 ? 'yes' : 'no'}}
-        },
-        :other => {
-          :land_use_per_unit  =>
-            {label: 'Land use per unit', unit: 'km2'},
-          :construction_time  =>
-            { label: 'Construction time', unit: 'years',
-              formatter: FORMAT_1DP },
-          :technical_lifetime  =>
-            { label: 'Technical lifetime', unit: 'years',
-              formatter: ->(n) { n.to_i } }
         }
-      }
+      }.merge(FLEXIBILITY_COSTS_AND_OTHER)
 
       # some converters use extra attributes. Rather than messing up the views I
       # add the method here. I hope this will be removed

--- a/app/models/api/v3/topology_presenter.rb
+++ b/app/models/api/v3/topology_presenter.rb
@@ -10,7 +10,8 @@ module Api
         :cost_chps,
         :cost_carbon_capturing,
         :cost_p2g,
-        :cost_p2h
+        :cost_p2h,
+        :cost_p2kerosene
       ]
 
       def initialize(scenario)

--- a/app/models/api/v3/topology_presenter.rb
+++ b/app/models/api/v3/topology_presenter.rb
@@ -7,7 +7,10 @@ module Api
         :cost_traditional_heat,
         :cost_electricity_production,
         :cost_heat_pumps,
-        :cost_chps
+        :cost_chps,
+        :cost_carbon_capturing,
+        :cost_p2g,
+        :cost_p2h
       ]
 
       def initialize(scenario)

--- a/app/models/qernel/converter_api/conversion.rb
+++ b/app/models/qernel/converter_api/conversion.rb
@@ -149,6 +149,8 @@ class Qernel::ConverterApi
     # MW capacity
     when :mw_input
       cost / input_capacity.to_f
+    when :mw_typical_input_capacity
+      cost / typical_input_capacity.to_f
     when :mw_electricity
       cost / electricity_output_capacity.to_f
     when :mw_heat


### PR DESCRIPTION
I have just added an extra section to the file that generates the technical financial parameters in the tooltips. To be clear, this is what I want in the tooltips of p2l:

![screen shot 2018-01-03 at 14 36 39](https://user-images.githubusercontent.com/32833996/34776195-486e46da-f616-11e7-86d5-62ee0a1fbfb6.png)

@joris, could you check if the right attributes are included?
@grdw, could you check if the syntax is correct?

Thanks!