### PR TITLE
Permit correct parameters for converters controller

### DIFF
--- a/app/controllers/api/v3/converters_controller.rb
+++ b/app/controllers/api/v3/converters_controller.rb
@@ -31,7 +31,7 @@ module Api
       #   "keyN": [ .. ]
       # }
       def stats
-        keys = params.require(:keys)
+        keys = permitted_params.to_h.fetch(:keys)
         gql  = @scenario.gql(prepare: true)
 
         render json: { nodes: Hash[keys.map do |key, graph_attributes|
@@ -54,6 +54,10 @@ module Api
         @converter = ConverterPresenter.new(key, @scenario)
       rescue Exception => e
         render :json => {:errors => [e.message]}, :status => 404 and return
+      end
+
+      def permitted_params
+        params.permit(:scenario_id, keys: {})
       end
     end
   end


### PR DESCRIPTION
@antw I don't have a strong preference to use:

This...

```ruby
keys = params.require(:keys).permit!.to_h
```

... over my fix. So feel free to overwrite it if you feel like it 😆 