### PR TITLE
Use imported_electricity cost to set MO import price

### DIFF
--- a/app/models/qernel/plugins/merit/adapter.rb
+++ b/app/models/qernel/plugins/merit/adapter.rb
@@ -6,10 +6,8 @@ module Qernel::Plugins
 
       def self.adapter_for(converter, graph, dataset)
         klass = case converter.dataset_get(:merit_order).type.to_sym
-          when :dispatchable
+          when :dispatchable, :volatile, :must_run
             ProducerAdapter.factory(converter, graph, dataset)
-          when :volatile, :must_run
-            AlwaysOnAdapter
           when :flex
             FlexAdapter.factory(converter, graph, dataset)
           when :consumer

--- a/app/models/qernel/plugins/merit/dispatchable_adapter.rb
+++ b/app/models/qernel/plugins/merit/dispatchable_adapter.rb
@@ -1,0 +1,34 @@
+module Qernel::Plugins
+  module Merit
+    # Adds data needed to calculate profitability of a dispatchable producer.
+    class DispatchableAdapter < ProducerAdapter
+      def inject!
+        super
+
+        @converter.dataset_lazy_set(:marginal_costs) do
+          participant.marginal_costs.to_f
+        end
+
+        @converter.dataset_lazy_set(:profitability) do
+          participant.profitability
+        end
+
+        @converter.dataset_lazy_set(:profit_per_mwh_electricity) do
+          participant.profit_per_mwh_electricity
+        end
+      end
+
+      def producer_attributes
+        attrs = super
+
+        attrs[:fixed_costs_per_unit] =
+          @converter.send(:fixed_costs)
+
+        attrs[:fixed_om_costs_per_unit] =
+          @converter.send(:fixed_operation_and_maintenance_costs_per_year)
+
+        attrs
+      end
+    end
+  end
+end

--- a/app/models/qernel/plugins/merit/import_adapter.rb
+++ b/app/models/qernel/plugins/merit/import_adapter.rb
@@ -1,64 +1,36 @@
 module Qernel::Plugins
   module Merit
-    class ImportAdapter < Adapter
+    # Implements behaviour specific to the import interconnector.
+    class ImportAdapter < ProducerAdapter
       def inject!
+        super
+
         elec_link = @converter.converter.output(:electricity).links.first
-        demand    = participant.production(:mj)
 
         if elec_link.link_type == :flexible
           # We need to override the calculation of the flexible link and set
           # set the demand explicitly.
-          elec_link.dataset_set(:value, demand)
+          elec_link.dataset_set(:value, @converter.demand)
           elec_link.dataset_set(:calculated, true)
         end
-
-        @converter.demand = demand
       end
 
       private
-
-      def producer_attributes
-        attrs = super
-
-        # The marginal cost of the import producer is 1 EUR more than the the
-        # most expensive participant.
-        #
-        # See https://github.com/quintel/merit/issues/143
-        attrs[:marginal_costs]           = max_marginal_cost + 1.0
-        attrs[:number_of_units]          = 1.0
-        attrs[:output_capacity_per_unit] = @converter.electricity_output_capacity
-
-        attrs
-      end
 
       def producer_class
         ::Merit::DispatchableProducer
       end
 
-      # Internal: Determines the marginal cost of the most expensive merit order
-      # participant.
-      #
-      # Returns a Float.
-      def max_marginal_cost
-        types = @graph.plugin(:merit).participant_types
+      def marginal_costs
+        @graph.carrier(:imported_electricity).cost_per_mj * 3600
+      end
 
-        mo_converters = @graph.converters.select do |conv|
-          conf = conv.dataset_get(:merit_order)
+      def output_capacity_per_unit
+        @converter.electricity_output_capacity
+      end
 
-          conf &&
-            conf.type != :consumer &&
-            conv.query.number_of_units > 0 &&
-            types.include?(conf.type)
-        end
-
-        mo_converters.map do |conv|
-          begin
-            cost = conv.query.marginal_costs
-            cost.nan? || cost == Float::INFINITY ? 0.0 : cost
-          rescue
-            0.0
-          end
-        end.max
+      def flh_capacity
+        @converter.electricity_output_capacity
       end
     end # ImportAdapter
   end # Merit


### PR DESCRIPTION
Refactors the ProducerAdapter into a separate DispatchableAdapter class,
and made ImportAdapter inherit from the Producer. Allows the import
interconnector to use the price of the imported electricity carrier in
order to behave like any other dispatchable.

Ref quintel/etmodel#2826