### PR TITLE
changed attributes and methods to new presentation_group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'quintel_merit', ref: '3faa2ab',  github: 'quintel/merit'
 gem 'fever',         ref: 'e988f2d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '90cc27e',  github: 'quintel/refinery'
-gem 'atlas',         ref: '80b1d80',  github: 'quintel/atlas'
+gem 'atlas',         ref: 'aaa8380',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2'

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'quintel_merit', ref: '3faa2ab',  github: 'quintel/merit'
 gem 'fever',         ref: 'e988f2d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '90cc27e',  github: 'quintel/refinery'
-gem 'atlas',         ref: 'aaa8380',  github: 'quintel/atlas'
+gem 'atlas',         ref: '26000a6',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: aaa8380cec0aa12bf9b4911d8eba9dbf7a7af1e5
-  ref: aaa8380
+  revision: 26000a645fd8e219c8850f2bde36072264e38a07
+  ref: 26000a6
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 80b1d80687f2753bb788fc2f89da2db76fae0fac
-  ref: 80b1d80
+  revision: aaa8380cec0aa12bf9b4911d8eba9dbf7a7af1e5
+  ref: aaa8380
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)

--- a/app/models/api/v3/converter_presenter.rb
+++ b/app/models/api/v3/converter_presenter.rb
@@ -24,8 +24,7 @@ module Api
         json[:key]                  = @key
         json[:sector]               = @present.sector_key
         json[:use]                  = @present.use_key
-        json[:groups]               = @present.groups
-
+        json[:presentation_group]   = @present.presentation_group
         json[:data] = {}
 
         attributes_and_methods_to_show.each_pair do |group, items|

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -8,7 +8,7 @@ module Api
       FORMAT_1DP            = ->(n) { '%.1f' % n }
       FORMAT_FAC_TO_PERCENT = ->(n) { FORMAT_1DP.call(n * 100) }
 
-      # If the converter belongs to the :cost_electricity_production group then
+      # If the converter belongs to the electricity_production presentation group then
       # add these
       ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -60,7 +60,7 @@ module Api
         }
       }
 
-      # If the converter belongs to the :cost_traditional_heat group then
+      # If the converter belongs to the traditional_heat presentation group then
       # add these
       HEAT_PRODUCTION_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -97,7 +97,7 @@ module Api
         }
       }
 
-      # If the converter belongs to the :cost_heat_pumps group then
+      # If the converter belongs to the heat_pumps presentation group then
       # add these
       HEAT_PUMP_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -135,7 +135,7 @@ module Api
         }
       }
 
-      # If the converter belongs to the :cost_chps group then
+      # If the converter belongs to the chps presentation group then
       # add these
       CHP_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -185,7 +185,7 @@ module Api
         }
       }
 
-      # If the converter belongs to the :cost_hydrogen_production group then
+      # If the converter belongs to the hydrogen_production presentation group then
       # add these
       HYDROGEN_PRODUCTION_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -266,7 +266,7 @@ module Api
         }
       }
 
-      # If the converter belongs to the :cost_carbon_capturing group then
+      # If the converter belongs to the carbon_capturing presentation group then
       # add these
       CARBON_CAPTURING_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -281,7 +281,7 @@ module Api
         }
       }.merge(FLEXIBILITY_COSTS_AND_OTHER)
 
-      # If the converter belongs to the :cost_p2g group then
+      # If the converter belongs to the p2g presentation group then
       # add these
       P2G_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -296,7 +296,7 @@ module Api
         }
       }.merge(FLEXIBILITY_COSTS_AND_OTHER)
 
-      # If the converter belongs to the :cost_p2h group then
+      # If the converter belongs to the p2h presentation group then
       # add these
       P2H_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -311,7 +311,7 @@ module Api
         }
       }.merge(FLEXIBILITY_COSTS_AND_OTHER)
 
-      # If the converter belongs to the :cost_p2kerosene group then
+      # If the converter belongs to the p2kerosene presentation group then
       # add these
       P2KEROSENE_ATTRIBUTES_AND_METHODS = {
         :technical => {
@@ -337,15 +337,15 @@ module Api
       # details page, in the /data section and through the API (v3)
       def attributes_and_methods_to_show
         out = {}
-        out = HEAT_PRODUCTION_ATTRIBUTES_AND_METHODS        if @converter.groups.include?(:cost_traditional_heat)
-        out = ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS if @converter.groups.include?(:cost_electricity_production)
-        out = HEAT_PUMP_ATTRIBUTES_AND_METHODS              if @converter.groups.include?(:cost_heat_pumps)
-        out = CHP_ATTRIBUTES_AND_METHODS                    if @converter.groups.include?(:cost_chps)
-        out = HYDROGEN_PRODUCTION_ATTRIBUTES_AND_METHODS    if @converter.groups.include?(:cost_hydrogen_production)
-        out = CARBON_CAPTURING_ATTRIBUTES_AND_METHODS       if @converter.groups.include?(:cost_carbon_capturing)
-        out = P2G_ATTRIBUTES_AND_METHODS                    if @converter.groups.include?(:cost_p2g)
-        out = P2H_ATTRIBUTES_AND_METHODS                    if @converter.groups.include?(:cost_p2h)
-        out = P2KEROSENE_ATTRIBUTES_AND_METHODS             if @converter.groups.include?(:cost_p2kerosene)
+        out = HEAT_PRODUCTION_ATTRIBUTES_AND_METHODS        if @converter.presentation_group == "traditional_heat"
+        out = ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS if @converter.presentation_group == "electricity_production"
+        out = HEAT_PUMP_ATTRIBUTES_AND_METHODS              if @converter.presentation_group == "heat_pumps"
+        out = CHP_ATTRIBUTES_AND_METHODS                    if @converter.presentation_group == "chps"
+        out = HYDROGEN_PRODUCTION_ATTRIBUTES_AND_METHODS    if @converter.presentation_group == "hydrogen_production"
+        out = CARBON_CAPTURING_ATTRIBUTES_AND_METHODS       if @converter.presentation_group == "carbon_capturing"
+        out = P2G_ATTRIBUTES_AND_METHODS                    if @converter.presentation_group == "p2g"
+        out = P2H_ATTRIBUTES_AND_METHODS                    if @converter.presentation_group == "p2h"
+        out = P2KEROSENE_ATTRIBUTES_AND_METHODS             if @converter.presentation_group == "p2kerosene"
 
         # custom stuff, trying to keep the view simple
         if uses_coal_and_wood_pellets?

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -336,16 +336,29 @@ module Api
       # combines the *_VALUES hashes as needed. This is used in the converter
       # details page, in the /data section and through the API (v3)
       def attributes_and_methods_to_show
-        out = {}
-        out = HEAT_PRODUCTION_ATTRIBUTES_AND_METHODS        if @converter.presentation_group == "traditional_heat"
-        out = ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS if @converter.presentation_group == "electricity_production"
-        out = HEAT_PUMP_ATTRIBUTES_AND_METHODS              if @converter.presentation_group == "heat_pumps"
-        out = CHP_ATTRIBUTES_AND_METHODS                    if @converter.presentation_group == "chps"
-        out = HYDROGEN_PRODUCTION_ATTRIBUTES_AND_METHODS    if @converter.presentation_group == "hydrogen_production"
-        out = CARBON_CAPTURING_ATTRIBUTES_AND_METHODS       if @converter.presentation_group == "carbon_capturing"
-        out = P2G_ATTRIBUTES_AND_METHODS                    if @converter.presentation_group == "p2g"
-        out = P2H_ATTRIBUTES_AND_METHODS                    if @converter.presentation_group == "p2h"
-        out = P2KEROSENE_ATTRIBUTES_AND_METHODS             if @converter.presentation_group == "p2kerosene"
+        out =
+          case @converter.presentation_group
+          when :traditional_heat
+            HEAT_PRODUCTION_ATTRIBUTES_AND_METHODS
+          when :electricity_production
+            ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS
+          when :heat_pumps
+            HEAT_PUMP_ATTRIBUTES_AND_METHODS
+          when :chps
+            CHP_ATTRIBUTES_AND_METHODS
+          when :hydrogen_production
+            HYDROGEN_PRODUCTION_ATTRIBUTES_AND_METHODS
+          when :carbon_capturing
+            CARBON_CAPTURING_ATTRIBUTES_AND_METHODS
+          when :p2g
+            P2G_ATTRIBUTES_AND_METHODS
+          when :p2h
+            P2H_ATTRIBUTES_AND_METHODS
+          when :p2kerosene
+            P2KEROSENE_ATTRIBUTES_AND_METHODS
+          else
+            {}
+          end
 
         # custom stuff, trying to keep the view simple
         if uses_coal_and_wood_pellets?

--- a/app/models/api/v3/topology_presenter.rb
+++ b/app/models/api/v3/topology_presenter.rb
@@ -2,18 +2,6 @@ module Api
   module V3
     class TopologyPresenter
 
-      # converter groups that have the converter summary table
-      GROUPS_WITH_EXTRA_INFO = [
-        :cost_traditional_heat,
-        :cost_electricity_production,
-        :cost_heat_pumps,
-        :cost_chps,
-        :cost_carbon_capturing,
-        :cost_p2g,
-        :cost_p2h,
-        :cost_p2kerosene
-      ]
-
       def initialize(scenario)
         @scenario = scenario
         @gql = @scenario.gql(prepare: true)
@@ -47,8 +35,7 @@ module Api
             fill_color:        ConverterPositions::FILL_COLORS[c.sector_key],
             stroke_color:      '#999',
             sector:            c.sector_key,
-            use:               c.use_key,
-            summary_available: (c.groups & GROUPS_WITH_EXTRA_INFO).any?
+            use:               c.use_key
           }
 
         end

--- a/app/models/etsource/from_atlas.rb
+++ b/app/models/etsource/from_atlas.rb
@@ -14,7 +14,8 @@ module Etsource
           key:                  node.key.to_sym,
           sector_id:            node.sector.to_sym,
           use_id:               node.use.try(:to_sym),
-          groups:               node.groups
+          groups:               node.groups,
+          presentation_group:   node.presentation_group
         )
       end
 

--- a/app/models/qernel/converter.rb
+++ b/app/models/qernel/converter.rb
@@ -79,7 +79,8 @@ class Converter
                :input_links,
                :groups,
                :sector_key,
-               :use_key
+               :use_key,
+               :presentation_group
 
   attr_accessor :converter_api, :key, :graph
 
@@ -125,6 +126,7 @@ class Converter
     @groups     = opts[:groups] || []
     @use_key    = opts[:use_id]
     @sector_key = opts[:sector_id]
+    @presentation_group = opts[:presentation_group]
 
     @output_links, @input_links = [], []
     @output_hash, @input_hash = {}, {}


### PR DESCRIPTION
- Added new presentation_group attribute
- Linked technical and financial specs table to presentation_groups
- Removed obsolete (?) groups_with_extra_info and summary_table

@antw I tried to get the new presentation_group attribute to work. It looks all right on my local machine. If you have time, could you check whether I didn't mess things up and are happy with this solution? Priority is low.

Related PRs: https://github.com/quintel/atlas/pull/125 and https://github.com/quintel/etsource/pull/1777