### PR TITLE
Add primary_demand_abroad method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'quintel_merit', ref: '0f33926',  github: 'quintel/merit'
 gem 'fever',         ref: 'f80677d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '253158c',  github: 'quintel/refinery'
-gem 'atlas',         ref: '8bdb2c9',  github: 'quintel/atlas'
+gem 'atlas',         ref: 'c44627b',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 8bdb2c9bf09fa272bc7ea64e225568201a317005
-  ref: 8bdb2c9
+  revision: c44627b2fb231719ff1ad58c78b3f2531c4306e4
+  ref: c44627b
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)

--- a/app/models/qernel/converter.rb
+++ b/app/models/qernel/converter.rb
@@ -157,7 +157,16 @@ class Converter
     end
   end
 
-protected
+  # Public: Does this converter represent energy flow from outside the modelled
+  # region?
+  #
+  # Returns true or false.
+  def abroad?
+    # Double-negate as abroad may be nil.
+    !!dataset_get(:abroad) # rubocop:disable Style/DoubleNegation
+  end
+
+  protected
 
   # Memoize here, so it doesn't have to at runtime
   #

--- a/app/models/qernel/recursive_factor/primary_demand.rb
+++ b/app/models/qernel/recursive_factor/primary_demand.rb
@@ -9,6 +9,17 @@ module Qernel::RecursiveFactor::PrimaryDemand
     end
   end
 
+  # Public: Calculates the primary energy demand for primary demand nodes which
+  # considered "abroad" - not part of the region modelled.
+  #
+  # Returns a numeric.
+  def primary_demand_abroad
+    fetch(:primary_demand_abroad) do
+      (demand || 0.0) *
+        recursive_factor(:primary_demand_factor, domestic: false)
+    end
+  end
+
   def primary_demand_of(*carriers)
     carriers.flatten.map do |carrier|
       primary_demand_of_carrier(carrier.try(:key) || carrier)


### PR DESCRIPTION
* Calculates primary demand originating in nodes which are marked as "abroad", i.e. not part of the modelled region. A node can be marked as "abroad" in ETSource by adding the attribute...

  ```
  - abroad = true
  ```

  For example:

  ```ruby
  V(energy_import_greengas, primary_demand_abroad)
  # ... (returns zero for now as there are no "abroad" green-gas nodes)
  ```

  The standard `primary_demand` calculation will ignore energy originating in nodes flagged as abroad (essentially terminating the calculation when reaching a node whose inputs are all abroad).

* Adjusts recursive factor calculations to accept a "domestic" flag (enabled by default) setting whether to calculate a factor for domestic or "abroad" nodes. Recursive factor will filter out any values from the undesired localities.