### PR TITLE
Migrate some scenarios to use new dataset names

### DIFF
--- a/db/migrate/20181218151344_rename_old_datasets.rb
+++ b/db/migrate/20181218151344_rename_old_datasets.rb
@@ -1,0 +1,22 @@
+class RenameOldDatasets < ActiveRecord::Migration[5.1]
+  NAMES = {
+    GM0393_haarlemmerliede_en_spaarnwoude: :GM0394_haarlemmermeer,
+    flevoland: :PV24_flevoland,
+    friesland: :PV21_friesland,
+    noorderplantsoen: :BU00140201_noorderplantsoenbuurt,
+    reitdiep: :BU00140904_reitdiep,
+    stichtse_vecht: :GM1904_stichtse_vecht
+  }.freeze
+
+  def up
+    NAMES.each do |old_name, new_name|
+      say_with_time "#{old_name} -> #{new_name}" do
+        Scenario.where(area_code: old_name).update_all(area_code: new_name)
+      end
+    end
+  end
+
+  def down
+    # Nothing to do.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181012140201) do
+ActiveRecord::Schema.define(version: 20181218151344) do
 
   create_table "fce_values", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.string "using_country"


### PR DESCRIPTION
Some old datasets have been superseded by datasets created in ETLocal. This migrates scenarios using those datasets to use the new names, allowing for the removal of the old datasets from ETSource.

Ref quintel/etsource#1876