### PR TITLE
Stop primary demand recursion when reaching group

### DIFF
--- a/app/models/qernel/recursive_factor/primary_co2.rb
+++ b/app/models/qernel/recursive_factor/primary_co2.rb
@@ -30,7 +30,8 @@ module Qernel::RecursiveFactor::PrimaryCo2
   #   co2_per_mj of primary_energy_demand carrier
   def co2_per_mj_of_carrier_factor(link, carrier_key)
     return 0.0 if query.free_co2_factor == 1.0
-    return nil if !domestic_dead_end? || !primary_energy_demand?
+
+    return nil unless domestic_dead_end? || primary_energy_demand?
 
     link ||= output_links.first
 
@@ -55,7 +56,8 @@ module Qernel::RecursiveFactor::PrimaryCo2
   #   co2_per_mj of primary_energy_demand carrier
   #
   def co2_per_mj_factor(link)
-    return nil if !domestic_dead_end? || !primary_energy_demand?
+    return nil unless domestic_dead_end? || primary_energy_demand?
+
     link ||= output_links.first
 
     carrier = link.nil? ? output_carriers.reject(&:loss?).first : link.carrier

--- a/app/models/qernel/recursive_factor/primary_demand.rb
+++ b/app/models/qernel/recursive_factor/primary_demand.rb
@@ -53,11 +53,13 @@ module Qernel::RecursiveFactor::PrimaryDemand
   end
 
   def primary_demand_factor(_link)
-    factor_for_primary_demand if domestic_dead_end?
+    factor_for_primary_demand if primary_energy_demand? || domestic_dead_end?
   end
 
   def primary_demand_including_abroad_factor(_link)
-    factor_for_primary_demand if right_dead_end?
+    if (abroad? && primary_energy_demand?) || right_dead_end?
+      factor_for_primary_demand
+    end
   end
 
   def primary_demand_factor_of_carrier(
@@ -65,7 +67,7 @@ module Qernel::RecursiveFactor::PrimaryDemand
     carrier_key,
     stop_condition = :primary_energy_demand?
   )
-    return nil if !domestic_dead_end? || !primary_energy_demand?
+    return nil unless primary_energy_demand?
 
     link ||= output_links.first
 

--- a/spec/fixtures/etsource/nodes/nosector/resettable_slots_with_reset_slot.ad
+++ b/spec/fixtures/etsource/nodes/nosector/resettable_slots_with_reset_slot.ad
@@ -1,2 +1,2 @@
-- groups = [primary_energy_demand]
+- groups = []
 - preset_demand = 1000.0


### PR DESCRIPTION
Previously primary demand calculations would terminate only after reaching a node at the far-right of the graph which was also a member of the "primary_energy_demand" group. Now, the recursion will stop if reaching a group member even if it is not at the far-right.

Closes #1036 

We (@redekok , @ChaelKruip and I) have tested this new primary demand calculation thoroughly (Dropbox (Quintel)/Quintel/Projects/201811_biomass/Checks) and it does what is should do!