### PR TITLE
Update Atlas ref in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'quintel_merit', ref: '7855a69',  github: 'quintel/merit'
 gem 'fever',         ref: 'f80677d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '253158c',  github: 'quintel/refinery'
-gem 'atlas',         ref: '893c548',  github: 'quintel/atlas'
+gem 'atlas',         ref: '2fbb2fb',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 893c548806b8b867754ab77f7714497643a28c74
-  ref: 893c548
+  revision: 2fbb2fb102f4e7120f8333fb1e226a11d00bc00d
+  ref: 2fbb2fb
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)


### PR DESCRIPTION
In order to fix https://github.com/quintel/etmodel/issues/2912, the Atlas ref in ETEngine's Gemfile was updated to https://github.com/quintel/atlas/pull/131/commits/2fbb2fb102f4e7120f8333fb1e226a11d00bc00d.