### PR TITLE
Minor change to converter technical and financial properties table

### DIFF
--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -65,7 +65,7 @@ module Api
       HEAT_PRODUCTION_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :heat_output_capacity =>
-            { label: 'Heat capacity', unit:'MW',
+            { label: 'Heat capacity per unit', unit: 'MW',
               formatter: FORMAT_1DP },
           :full_load_hours  =>
             {label: 'Full load hours', unit: 'hour / year'},
@@ -102,7 +102,7 @@ module Api
       HEAT_PUMP_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :heat_output_capacity =>
-            {label: 'Heat capacity', unit:'MW'},
+            {label: 'Heat capacity per unit', unit: 'MW'},
           :coefficient_of_performance =>
             {label: 'Coefficient of Performance',  unit:''},
           :full_load_hours  =>
@@ -140,7 +140,7 @@ module Api
       CHP_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :electricity_output_capacity =>
-            { label: 'Electrical capacity', unit:'MW',
+            { label: 'Electrical capacity per unit', unit: 'MW',
               formatter: FORMAT_1DP },
           :electricity_output_conversion  =>
             { label: 'Electrical efficiency', unit: '%',
@@ -190,7 +190,7 @@ module Api
       HYDROGEN_PRODUCTION_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :typical_input_capacity =>
-            { label: 'Capacity', unit:'MW input',
+            { label: 'Capacity per unit', unit: 'MW input',
               formatter: ->(n) { n && FORMAT_1DP.call(n) } },
           :hydrogen_output_conversion  =>
             { label: 'Hydrogen output efficiency', unit: '%',
@@ -271,7 +271,7 @@ module Api
       CARBON_CAPTURING_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :typical_input_capacity =>
-            { label: 'Capacity', unit:'MWe',
+            { label: 'Capacity per unit', unit: 'MWe',
               formatter: FORMAT_1DP },
           :co_output_conversion=>
             { label: 'Carbon monoxide output efficiency', unit: '%',
@@ -286,7 +286,7 @@ module Api
       P2G_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :typical_input_capacity =>
-            { label: 'Capacity', unit:'MWe',
+            { label: 'Capacity per unit', unit: 'MWe',
               formatter: FORMAT_1DP },
           :hydrogen_output_conversion=>
             { label: 'Hydrogen output efficiency', unit: '%',
@@ -301,7 +301,7 @@ module Api
       P2H_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :typical_input_capacity =>
-            { label: 'Capacity', unit:'MWe',
+            { label: 'Capacity per unit', unit: 'MWe',
               formatter: FORMAT_1DP },
           :useable_heat_output_conversion=>
             { label: 'Heat efficiency', unit: '%',
@@ -316,7 +316,7 @@ module Api
       P2KEROSENE_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :typical_input_capacity =>
-            { label: 'Capacity', unit:'MWe',
+            { label: 'Capacity per unit', unit: 'MWe',
               formatter: FORMAT_1DP },
           :kerosene_output_conversion=>
             { label: 'Kerosene output efficiency', unit: '%',

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -56,7 +56,7 @@ module Api
               formatter: FORMAT_1DP },
           :technical_lifetime  =>
             { label: 'Technical lifetime', unit: 'years',
-              formatter: ->(n) { n.to_i } },
+              formatter: ->(n) { n.to_i } }
         }
       }
 

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -13,7 +13,7 @@ module Api
       ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :electricity_output_capacity =>
-            { label: 'Electrical capacity per unit', unit:'MW',
+            { label: 'Electrical capacity per unit', unit: 'MW',
               formatter: FORMAT_1DP },
           :electricity_output_conversion  =>
             { label: 'Electrical efficiency', unit: '%',

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -13,7 +13,7 @@ module Api
       ELECTRICITY_PRODUCTION_ATTRIBUTES_AND_METHODS = {
         :technical => {
           :electricity_output_capacity =>
-            { label: 'Electrical capacity', unit:'MW',
+            { label: 'Electrical capacity per unit', unit:'MW',
               formatter: FORMAT_1DP },
           :electricity_output_conversion  =>
             { label: 'Electrical efficiency', unit: '%',
@@ -56,7 +56,7 @@ module Api
               formatter: FORMAT_1DP },
           :technical_lifetime  =>
             { label: 'Technical lifetime', unit: 'years',
-              formatter: ->(n) { n.to_i } }
+              formatter: ->(n) { n.to_i } },
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/quintel/etmodel/issues/3100:

![image](https://user-images.githubusercontent.com/5946498/62363218-258b2380-b51f-11e9-8352-35448d44d7de.png)

I've decided not to include the total installed capacity in this table, since the technical and financial properties are values for one typical unit. In addition, I wasn't sure if it was technically feasible in ETEngine.