### PR TITLE
Enable heat storage for all protected scenarios

### DIFF
--- a/db/migrate/20200116153454_enable_heat_storage.rb
+++ b/db/migrate/20200116153454_enable_heat_storage.rb
@@ -1,0 +1,40 @@
+class EnableHeatStorage < ActiveRecord::Migration[5.2]
+  HEAT_TOGGLE = 'heat_storage_enabled'.freeze
+
+  def up
+    update_scenarios do |scenario|
+        scenario.user_values[HEAT_TOGGLE] = 1
+    end
+  end
+
+  def update_scenarios
+    total = scenarios.count
+    changed = 0
+
+    say "Checking and migrating #{total} scenarios"
+
+    scenarios.find_each.with_index do |scenario, index|
+      if Atlas::Dataset.exists?(scenario.area_code)
+        yield(scenario)
+
+        if scenario.changed?
+          scenario.save(validate: false, touch: false)
+          changed += 1
+        end
+      end
+
+      if index.positive? && (index % 1000).zero?
+        say "#{index + 1}/#{total} (#{changed} migrated)"
+      end
+    end
+
+    say "#{total}/#{total} (#{changed} migrated)"
+  end
+
+  # All protected scenarios, and any unprotected scenarios since December 2019
+  # will be updated.
+  def scenarios
+    Scenario.migratable_since(Date.new(2019, 12, 1))
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_15_090641) do
+ActiveRecord::Schema.define(version: 2020_01_16_153454) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false


### PR DESCRIPTION
This sets the heat storage toggle to 'On' for all protected scenario's. The reason to do this is to reproduce the original energy flows of these scenario's more closely after the implementation of time-resolved heat networks. Enabling storage prevents heat produced during low demand hours from going to waste. This resembles the 'old' implementation of heat networks in which supply and demand are matched on a yearly basis.