### PR TITLE
Add support for waste_outputs in cost calculations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'quintel_merit', ref: '8f1e878',  github: 'quintel/merit'
 gem 'fever',         ref: 'f80677d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '316c8b1',  github: 'quintel/refinery'
-gem 'atlas',         ref: '861bb63',  github: 'quintel/atlas'
+gem 'atlas',         ref: '53c8a67',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 861bb6310a362e2d1f755f58047af24ad0799e79
-  ref: 861bb63
+  revision: 53c8a67d344acc700d1cd5f8ee01b895bfba8e40
+  ref: 53c8a67
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)

--- a/app/models/qernel/converter.rb
+++ b/app/models/qernel/converter.rb
@@ -106,6 +106,7 @@ class Converter
     network_gas
     preset_demand
     storage
+    waste_outputs
   ]
 
   # --------- Micro-optimizing ------------------------------------------------

--- a/app/models/qernel/recursive_factor/weighted_carrier.rb
+++ b/app/models/qernel/recursive_factor/weighted_carrier.rb
@@ -5,7 +5,8 @@ module Qernel::RecursiveFactor::WeightedCarrier
   # A.carrier_cost_per_mj == 0.4*0.85 + 0.6 * 1.0
   def weighted_carrier_cost_per_mj
     fetch(:weighted_carrier_cost_per_mj) do
-      recursive_factor_without_losses(:weighted_carrier_cost_per_mj_factor)
+      recursive_factor_without_losses(:weighted_carrier_cost_per_mj_factor) *
+        converter_api.costable_energy_factor
     end
   end
 

--- a/spec/models/qernel/recursive_factor/weighted_carrier_spec.rb
+++ b/spec/models/qernel/recursive_factor/weighted_carrier_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Qernel::RecursiveFactor::WeightedCarrier do
+  let(:converter) { Qernel::Converter.new(id: 1) }
+
+  def build_slot(converter, carrier, direction, conversion = 1.0)
+    Qernel::Slot.new(
+      1, converter, Qernel::Carrier.new(key: carrier), direction
+    ).with(conversion: conversion)
+  end
+
+  describe '#weighted_carrier_cost_per_mj' do
+    before do
+      allow(converter).to receive(:recursive_factor_without_losses)
+        .with(:weighted_carrier_cost_per_mj_factor)
+        .and_return(4.0)
+    end
+
+    context 'with coal and gas outputs' do
+      before do
+        converter.add_slot(build_slot(converter, :coal, :output, 0.4))
+        converter.add_slot(build_slot(converter, :gas, :output, 0.6))
+        converter.with(waste_outputs: [:coal])
+      end
+
+      it 'ignores waste outputs' do
+        expect(converter.send(:weighted_carrier_cost_per_mj)).to eq(2.4)
+      end
+    end
+
+    context 'with coal, gas, and loss outputs' do
+      before do
+        converter.add_slot(build_slot(converter, :coal, :output, 0.3))
+        converter.add_slot(build_slot(converter, :gas, :output, 0.5))
+        converter.add_slot(build_slot(converter, :loss, :output, 0.2))
+
+        converter.with(waste_outputs: [:coal])
+      end
+
+      it 'includes a costable share of loss' do
+        # 2 from the gas, plus the gas share of the loss.
+        # loss is 0.2, and gas is responsible for 0.625 (0.5 / 0.8) of
+        # that = 0.5.
+        expect(converter.send(:weighted_carrier_cost_per_mj)).to eq(2.5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`fuel_costs` and `co2_emissions_costs_per_typical_input` will now compensate for any outputs which are declared as waste. This is used in converters where an input is converted into two or more carriers, but one carrier is a waste byproduct, and should not be considered as part of the fuel or CO2 cost.

Given a node which takes in network gas and produced electricity, steam_hot_water, and loss, where the steam_hot_water is a "free" byproduct of the conversion, you would configure the node like so:

```
- waste_outputs = [steam_hot_water]
```

You may name more than one carrier if you wish. Loss is treated specially: the cost will include the share of loss which is attributable to the non-waste carriers.

For example given the following outputs:

```
- output.electricity = 0.3
- output.steam_hot_water = 0.2
- output.loss = 0.5
```

... the fuel and CO2 costs will include 60% of the loss (0.3 / (0.3 + 0.2); this is that which can be attributed to the electricity conversion, while 40% is due to the steam_hot_water.

If you have any questions – or this is not correct – please let me know.