### PR TITLE
Add Slot::LinkBased

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'quintel_merit', ref: '8f1e878',  github: 'quintel/merit'
 gem 'fever',         ref: 'f80677d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: 'e3e3ba8',  github: 'quintel/refinery'
-gem 'atlas',         ref: 'f73251e',  github: 'quintel/atlas'
+gem 'atlas',         ref: '79f76c4',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: f73251ecd4df7a1d1a7e48b1ebd531147bcf6992
-  ref: f73251e
+  revision: 79f76c43c583a63ca104eac9fdec065b4c3357a9
+  ref: 79f76c4
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)

--- a/app/models/etsource/from_atlas.rb
+++ b/app/models/etsource/from_atlas.rb
@@ -26,11 +26,14 @@ module Etsource
       #
       # Returns a Qernel::Slot.
       def slot(slot, converter, carrier)
-        type = if slot.carrier == :loss
-          :loss
-        elsif slot.is_a?(Atlas::Slot::Elastic)
-          :elastic
-        end
+        type =
+          if slot.carrier == :loss
+            :loss
+          elsif slot.is_a?(Atlas::Slot::Elastic)
+            :elastic
+          elsif slot.is_a?(Atlas::Slot::Dynamic)
+            :link_based
+          end
 
         slot_from_data(converter, carrier, slot.direction, type)
       end

--- a/app/models/qernel/merit_facade/consumer_adapter.rb
+++ b/app/models/qernel/merit_facade/consumer_adapter.rb
@@ -10,6 +10,8 @@ module Qernel
           PseudoConsumerAdapter
         when :consumption_loss
           ConsumptionLossAdapter
+        when :electricity_loss
+          ElectricityLossAdapter
         else
           self
         end
@@ -41,16 +43,11 @@ module Qernel
       end
 
       def input_of_carrier
-        if source_api.converter.input(@context.carrier)
-          source_api.public_send(@context.carrier_named('input_of_%s'))
-        elsif @context.carrier == :electricity &&
-            source_api.converter.input(:loss)
-          # HV loss node does not have an electricity input; use graph method
-          # which compensates for export.
-          @context.graph.query.electricity_losses_if_export_is_zero
-        else
+        unless source_api.converter.input(@context.carrier)
           raise "No acceptable consumption input for #{source_api.key}"
         end
+
+        source_api.public_send(@context.carrier_named('input_of_%s'))
       end
 
       def installed?

--- a/app/models/qernel/merit_facade/curtailment_adapter.rb
+++ b/app/models/qernel/merit_facade/curtailment_adapter.rb
@@ -11,12 +11,6 @@ module Qernel
         input_link = target_api.converter.input(@context.carrier).links.first
         demand     = participant.production(:mj)
 
-        if @context.carrier == :electricity
-          # Figure out the output efficiency of the network; curtailment needs
-          # to be reduced by exactly this amount to prevent unwanted import.
-          demand *= input_link.output.conversion
-        end
-
         if input_link.link_type == :inversed_flexible
           # We need to override the calculation of an inversed flexible link
           # and set the demand explicitly.

--- a/app/models/qernel/merit_facade/electricity_loss_adapter.rb
+++ b/app/models/qernel/merit_facade/electricity_loss_adapter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Qernel
+  module MeritFacade
+    # A special case of consumer used when representing loss within the
+    # electricity network. In this we need to determine the demand from a method
+    # on GraphApi, and set the demand on the node and sole incoming link after
+    # the calculation is done. This is required in order for Slot::LinkBased to
+    # calculate the share of electricty.
+    class ElectricityLossAdapter < ConsumerAdapter
+      def inject!
+        super
+
+        production = @participant.production
+
+        target_api.demand = production
+
+        input_link.value = production
+        input_link.calculated = true
+      end
+
+      def input_of_carrier
+        # HV loss node does not have an electricity input; use graph method
+        # which compensates for export.
+        @context.graph.query.electricity_losses_if_export_is_zero
+      end
+
+      private
+
+      def input_link
+        links = target_api.converter.input(:loss).links
+
+        if links.length != 1
+          raise "Could not find single loss input on #{target_api.key} for " \
+                "use by #{self.class.name} (found #{links.length} links)"
+        end
+
+        links.first
+      end
+    end
+  end
+end

--- a/app/models/qernel/slot.rb
+++ b/app/models/qernel/slot.rb
@@ -30,11 +30,13 @@ class Slot
   # Returns an instance of Slot, or a Slot subclass.
   #
   def self.factory(type, id, converter, carrier, direction = :input)
-    klass = case type
-      when :loss    then Slot::Loss
-      when :elastic then Slot::Elastic
-      else               Slot
-    end
+    klass =
+      case type
+      when :loss       then Slot::Loss
+      when :elastic    then Slot::Elastic
+      when :link_based then Slot::LinkBased
+      else                  Slot
+      end
 
     klass.new(id, converter, carrier, direction)
   end

--- a/app/models/qernel/slot/link_based.rb
+++ b/app/models/qernel/slot/link_based.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Qernel
+  class Slot
+    # A slot which calculates its conversion by looking at the demand of all the
+    # links belonging to it, and determining their share of the demand of _all_
+    # links in the same direction from the converter.
+    #
+    # This is useful in cases where a graph plugin changes the flow of some of
+    # the outputs, and the conversions need to be updated to ensure they remain
+    # consistent with the energy flowing through them.
+    #
+    # This ignores any conversion set on the slot, or sibling slots, presuming
+    # them to be inaccurate at the time of calculation.
+    #
+    # Note that a demand `value` must be known for all the links in order to
+    # calculate a conversion. If some values are missing, LinkBased will fall
+    # back to the behaviour of Slot.
+    class LinkBased < Slot
+      def conversion
+        link_based_conversion || super
+      end
+
+      private
+
+      def link_based_conversion
+        fetch(:link_based_conversion, false) do
+          self_and_siblings = input? ? @converter.inputs : @converter.outputs
+          all_links = self_and_siblings.flat_map(&:links)
+
+          return nil unless all_links.all?(&:value)
+
+          demand = all_links.sum(&:value)
+          conversion = demand.zero? ? 0.0 : @links.sum(&:value) / demand
+
+          dataset_set(:conversion, conversion)
+          dataset_set(:link_based_conversion, conversion)
+
+          conversion
+        end
+      end
+    end
+  end
+end

--- a/spec/models/qernel/slot/link_based_spec.rb
+++ b/spec/models/qernel/slot/link_based_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Qernel::Slot::LinkBased do
+  let(:graph) do
+    layout = <<-LAYOUT.strip_heredoc
+      electricity[1.0;0.9(link_based)]: elec_output  == s(1.0)  ==> network
+      loss[1.0;0.1]:                    loss_output  == s(1.0)  ==> network
+    LAYOUT
+
+    Qernel::GraphParser.new(layout).build
+  end
+
+  let(:network)     { graph.converter(:network) }
+  let(:loss)        { network.output(:loss) }
+  let(:electricity) { network.output(:electricity) }
+
+  let(:loss_link)   { loss.links.first }
+  let(:elec_link)   { electricity.links.first }
+
+  before do
+    # GraphParser adds a conversion; get rid of it.
+    electricity.dataset_attributes.delete(:conversion)
+  end
+
+  # --------------------------------------------------------------------------
+
+  context 'when a value is known for all links' do
+    before do
+      loss_link.value = 25.0
+      elec_link.value = 75.0
+    end
+
+    it 'calculates the LinkBased conversion' do
+      expect(electricity.conversion).to eq(0.75)
+    end
+
+    it 'does not affect sibling slots' do
+      expect(loss.conversion).to eq(0.1)
+    end
+
+    it 'does not recalculate when data changes' do
+      expect { elec_link.value = 25.0 }
+        .not_to change(electricity, :conversion).from(0.75)
+    end
+  end
+
+  context 'when all the links are zero' do
+    before do
+      loss_link.value = 0.0
+      elec_link.value = 0.0
+    end
+
+    it 'calculates the LinkBased conversion as zero' do
+      expect(electricity.conversion).to eq(0.0)
+    end
+  end
+
+  context 'when a :link_based_conversion value is stored' do
+    before do
+      loss_link.value = 25.0
+      elec_link.value = 75.0
+
+      electricity.dataset_set(:link_based_conversion, 1.0)
+    end
+
+    it 'retrieves the cached value' do
+      expect(electricity.conversion).to eq(1.0)
+    end
+  end
+
+  context 'when the link has no value' do
+    before do
+      loss_link.value = 25.0
+      elec_link.value = nil
+    end
+
+    it 'does not calculate a value; returning zero' do
+      expect(electricity.conversion).to eq(0)
+    end
+
+    it 'does not cache the returned value as :conversion' do
+      expect(electricity.dataset_get(:conversion)).to be_nil
+    end
+
+    it 'does not cache the returned value as :link_based_conversion' do
+      expect(electricity.dataset_get(:link_based_conversion)).to be_nil
+    end
+
+    it 'calculates once enough data is available' do
+      expect { elec_link.value = 25.0 }
+        .to change(electricity, :conversion)
+        .from(0.0).to(0.5)
+    end
+
+    context 'when a :conversion is cached' do
+      before { electricity.dataset_set(:conversion, 0.4) }
+
+      it 'returns the cached :conversion' do
+        expect(electricity.conversion).to eq(0.4)
+      end
+    end
+  end
+
+  context 'when a sibling slot link has no value' do
+    before do
+      loss_link.value = nil
+      elec_link.value = 75.0
+    end
+
+    it 'does not calculate a value; returning zero' do
+      expect(electricity.conversion).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Allows a slot to recalculate its conversion once the value of all links are known. This helps when a heat network technology changes the demand of one or more links during the calculation.

This is part of the fix for unexpected HV shortage or surpluses due to the selection of heat network technologies.

Please merge with https://github.com/quintel/etsource/pull/2213