### PR TITLE
Add 3 decimal point formatter for traditional_heat presenter group

### DIFF
--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -5,8 +5,8 @@ module Api
     #
     module ConverterPresenterData
       FORMAT_KILO           = ->(n) { (n / 1000).to_i }
-      FORMAT_1DP            = ->(n) { '%.1f' % n }
-      FORMAT_3DP            = ->(n) { '%.3f' % n }
+      FORMAT_1DP            = ->(n) { format('%.1f', n) }
+      FORMAT_3DP            = ->(n) { format('%.3f', n) }
       FORMAT_FAC_TO_PERCENT = ->(n) { FORMAT_1DP.call(n * 100) }
 
       # If the converter belongs to the electricity_production presentation group then

--- a/app/models/api/v3/converter_presenter_data.rb
+++ b/app/models/api/v3/converter_presenter_data.rb
@@ -6,6 +6,7 @@ module Api
     module ConverterPresenterData
       FORMAT_KILO           = ->(n) { (n / 1000).to_i }
       FORMAT_1DP            = ->(n) { '%.1f' % n }
+      FORMAT_3DP            = ->(n) { '%.3f' % n }
       FORMAT_FAC_TO_PERCENT = ->(n) { FORMAT_1DP.call(n * 100) }
 
       # If the converter belongs to the electricity_production presentation group then
@@ -66,7 +67,7 @@ module Api
         :technical => {
           :heat_output_capacity =>
             { label: 'Heat capacity per unit', unit: 'MW',
-              formatter: FORMAT_1DP },
+              formatter: FORMAT_3DP },
           :full_load_hours  =>
             {label: 'Full load hours', unit: 'hour / year'},
           :heat_output_conversion  =>


### PR DESCRIPTION
Rounds heating capacity to 3 decimal places to ensures that capacity is not rounded to zero for heating technologies

See: https://github.com/quintel/etmodel/issues/3241