### PR TITLE
Set cop cutoff to old default for existing scenarios

### DIFF
--- a/db/migrate/20200330110023_update_cop_cutoff.rb
+++ b/db/migrate/20200330110023_update_cop_cutoff.rb
@@ -1,0 +1,19 @@
+require 'etengine/scenario_migration'
+
+class UpdateCopCutoff < ActiveRecord::Migration[5.2]
+  include ETEngine::ScenarioMigration
+
+  COP_CUTOFF_KEY = 'households_flexibility_space_heating_cop_cutoff'.freeze
+
+  # The new defualt for cop cutoff is 2.6. However to retain the outcomes
+  # of older scenarios, untouched cop cutoff values are set to the previous
+  # default of 1.0
+
+  def up
+    migrate_scenarios do |scenario|
+      next if scenario.user_values[COP_CUTOFF_KEY]
+
+      scenario.user_values[COP_CUTOFF_KEY] = 1.0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_084657) do
+ActiveRecord::Schema.define(version: 2020_03_30_110023) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false


### PR DESCRIPTION
The new defualt for cop cutoff is 2.6. However, to retain the outcomes of existing scenarios, untouched cop cutoff values are set to the previous default of 1.0.