### PR TITLE
Merit storage may be share of another node's mean

### DIFF
--- a/app/helpers/inspect_helper.rb
+++ b/app/helpers/inspect_helper.rb
@@ -181,7 +181,7 @@ module InspectHelper
   #
   # Returns true or false.
   def object_attribute_is_converter?(name)
-    %i[alias_of delegate].include?(name)
+    %i[alias_of output_capacity_from_demand_of delegate].include?(name)
   end
 
   # Public: Returns the scenario flexibility or heat network order as a string

--- a/app/models/qernel/merit_facade/flex_adapter.rb
+++ b/app/models/qernel/merit_facade/flex_adapter.rb
@@ -38,7 +38,7 @@ module Qernel
 
         target_api.demand =
           full_load_seconds *
-          source_api.input_capacity *
+          participant.output_capacity_per_unit *
           participant.number_of_units
 
         inject_curve!(:input) do


### PR DESCRIPTION
Allows setting storage output capacity to be the mean hourly load of another node.

Merge order:

1. quintel/etsource#2268
2. This PR second
3. quintel/etmodel#3331