### PR TITLE
Remove reserved fraction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'quintel_merit', ref: '93c684a',  github: 'quintel/merit'
 gem 'fever',         ref: 'f80677d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '72eacf8',  github: 'quintel/refinery'
-gem 'atlas',         ref: '4775a22',  github: 'quintel/atlas'
+gem 'atlas',         ref: '06afd1e',  github: 'quintel/atlas'
 
 # system gems
 gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 4775a22fea689c68c189d73aa827e6c94d111a69
-  ref: 4775a22
+  revision: 06afd1e79eee1c202112155147f7ef6c491f3a6c
+  ref: 06afd1e
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)

--- a/app/models/qernel/converter_api/attributes.rb
+++ b/app/models/qernel/converter_api/attributes.rb
@@ -23,7 +23,6 @@ module Qernel
         :technical_lifetime => ['Technical lifetime', 'year'],
         :typical_input_capacity => ['', 'MWinput'],
         :output_capacity => ['', 'MW'],
-        :reserved_fraction => ['', ''],
         :input_efficiency => ['', ''],
         :output_efficiency => ['', '']
       },

--- a/app/models/qernel/merit_facade/adapter.rb
+++ b/app/models/qernel/merit_facade/adapter.rb
@@ -43,7 +43,7 @@ module Qernel
       # Returns true or false.
       def installed?
         source_api.number_of_units.positive? &&
-          source_api.availability.positive?
+          target_api.availability.positive?
       end
 
       private
@@ -57,7 +57,7 @@ module Qernel
         {
           key: @converter.key,
           number_of_units: source_api.number_of_units,
-          availability: source_api.availability,
+          availability: target_api.availability,
 
           # The marginal costs attribute is not optional, but it is an
           # unnecessary calculation when the Merit order is not being run.

--- a/app/models/qernel/merit_facade/storage_adapter.rb
+++ b/app/models/qernel/merit_facade/storage_adapter.rb
@@ -74,10 +74,7 @@ module Qernel
       end
 
       def storage_volume_per_unit
-        return Float::INFINITY if infinite_storage?
-
-        source_api.storage.volume *
-          (1 - (source_api.reserved_fraction || 0.0))
+        infinite_storage? ? Float::INFINITY : source_api.storage.volume
       end
 
       def producer_class

--- a/spec/fixtures/etsource/datasets/ameland/graph_values.yml
+++ b/spec/fixtures/etsource/datasets/ameland/graph_values.yml
@@ -7,6 +7,3 @@ share_setter:
 
 conversion_setter:
   :"converter_fixture_for_slots+@gas": 0.5
-
-reserved_fraction_setter:
-  baz: 1

--- a/spec/fixtures/etsource/nodes/nosector/baz.ad
+++ b/spec/fixtures/etsource/nodes/nosector/baz.ad
@@ -1,2 +1,2 @@
 - groups = []
-- graph_methods = [demand_setter, reserved_fraction_setter]
+- graph_methods = [demand_setter]


### PR DESCRIPTION
Removes the `reserved_fraction` attribute and instead sets availability on the EV flex node. This will cause both the storage volume and input capacity to be affected by the user choice in ETModel.

See also quintel/etsource#2269