### PR TITLE
added a naive implementation of projecting scenarios

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -149,6 +149,19 @@ module Api
         )
       end
 
+      # POST /api/v3/scenarios/project
+      def project
+        from = Scenario.find(params[:from])
+        onto = Scenario.find(params[:onto])
+        sliders = params[:sliders]
+        render json: Scenario::Projector.new(from, onto, sliders)
+
+      rescue ActiveRecord::RecordNotFound
+        render  status: :bad_request,
+                json: { errors: ['bad request'] }
+
+      end
+
       # PUT-PATCH /api/v3/scenarios/:id
       #
       # This is the main scenario interaction method

--- a/app/models/scenario/projector.rb
+++ b/app/models/scenario/projector.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Scenario
+  # Create a new scenario with settings from two scenarios.
+  class Projector
+    attr_reader :onto, :from, :sliders, :result
+    def initialize(from, onto, sliders)
+      @from = from
+      @onto = onto
+      @sliders = sliders
+    end
+
+    # This implementation is really naive. We still have to autobalance
+    # sharegroups. ScenarioUpdater seems a bit smarter about this but I'm
+    # having trouble deciphering it.
+    # There would be two ways to acomplish this:
+    # - Leverage ScenarioUpdater
+    # - Write a service to balance a sharegroup
+
+    def call
+      attributes = onto.attributes.except("id", "user_values")
+      from_user_values =
+        from.user_values
+          .select { |key,value| @sliders.include? key }
+
+      attributes[:user_values] = onto.user_values.merge(from_user_values)
+
+      Scenario.create(attributes)
+    end
+
+    def as_json(options)
+      { id: call.id }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
         end
         collection do
           post :merge
+          post :project
         end
         get :templates, :on => :collection
         resources :converters, :only => :show do

--- a/spec/models/scenario/projector_spec.rb
+++ b/spec/models/scenario/projector_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Scenario::Projector do
+  let(:from) do
+    FactoryBot.create(:scenario, {
+      user_values: { input_1: 1, input_2: 0}
+    })
+  end
+
+  let(:onto) do
+    FactoryBot.create(:scenario, {
+      user_values: { input_1: 0,input_2: 1, input_3: 1 }
+    })
+  end
+
+  subject { described_class.new(from, onto, ['input_1']) }
+
+  it { is_expected.to respond_to :call }
+  it { is_expected.to respond_to :as_json }
+
+  describe '#call' do
+    subject { described_class.new(from, onto, ['input_1']).call }
+
+    it 'create a scenario' do
+      from
+      onto
+      expect { subject }.to change { Scenario.count }.by(1)
+    end
+
+    it 'returns a scenario' do
+      expect(subject).to be_a Scenario
+    end
+
+    describe 'user_values'
+      context 'with provided sliders' do
+        context 'that occurs in "from"' do
+          it 'have the same value as "from"' do
+            expect(subject.user_values[:input_1])
+              .to eq from.user_values[:input_1]
+          end
+        end
+
+        context 'that dont occur in "from"' do
+          it 'have the same value as "onto"' do
+            expect(subject.user_values[:input_3])
+              .to eq onto.user_values[:input_3]
+          end
+        end
+      end
+
+      context 'with an ommited slider' do
+        it 'have the value of "onto"' do
+          expect(subject.user_values[:input_2]).to eq onto.user_values[:input_2]
+        end
+      end
+  end
+end

--- a/spec/requests/api/v3/scenarios_project_spec.rb
+++ b/spec/requests/api/v3/scenarios_project_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# This action was build to enable projecting cherrypicked sliders from one
+# scenario onto the next one.
+describe 'APIv3 Scenarios/project', :etsource_fixture do
+
+  let(:scenario_one) do
+    FactoryBot.create(:scenario)
+  end
+
+  let(:scenario_two) do
+    FactoryBot.create(:scenario)
+  end
+
+  context 'with valid params' do
+    let(:params) do
+      { from: scenario_one.id,
+        onto: scenario_two.id,
+        sliders: [ "input_1" ] }
+    end
+
+    subject do
+      post '/api/v3/scenarios/project', params: params
+      response
+    end
+
+    it { is_expected.to have_http_status 200 }
+
+    it 'creates a new scenario' do
+      # lets eagerly create the two existing scenarios before counting!
+      scenario_one
+      scenario_two
+
+      expect { subject }.to change{ Scenario.count }.by 1
+    end
+
+    it 'has the id of the newly created scenario in the body' do
+      expect(JSON.parse(subject.body)).to have_key("id")
+    end
+  end
+
+  it 'with invalid params' do
+    post '/api/v3/scenarios/project', params: {}
+    expect(response.status).to eq(400)
+  end
+
+end


### PR DESCRIPTION
A new `project scenario` POST action will be build within ETEngine. it takes the following parameters

```json
{ 
  "from_scenario_id": 1234,
  "onto_scenario_id": 1235,
  "sliders": [
    "slider_keyname_1",
    "slider_keyname_2",
    "slider_keyname_3"
  ]
}
```
and it returns a scenario_id:
```json
{
  "scenario_id": 1236
}
```
There are still some problems in this branch though. I haven't figured out how to handle balancing share groups and I could well blow through all my time left trying to figure it out so I'll leave this one to @noracato . The current code that handles balancing inputs doesn't seem to be neatly packaged and I'm not sure how much work it is to pry it loose. 
@antw recommended me to look here: https://github.com/quintel/etengine/blob/master/app/models/api/v3/scenario_updater.rb#L200-L256

