### PR TITLE
Prefer typical_input_capacity when set

### DIFF
--- a/app/models/qernel/converter_api/cost.rb
+++ b/app/models/qernel/converter_api/cost.rb
@@ -19,10 +19,11 @@ module Qernel
     # Return a float of the input capacity of a typical plant in MWinput
     def input_capacity
       fetch(:input_capacity) do
-        electric_based_input_capacity ||
+        typical_input_capacity ||
+          electric_based_input_capacity ||
           heat_based_input_capacity ||
           cooling_based_input_capacity ||
-          typical_input_capacity || 0.0
+          0.0
       end
     end
     unit_for_calculation 'input_capacity', 'MWinput'


### PR DESCRIPTION
When calculating `input_capacity`, use the `typical_input_capacity` defined in the .ad file rather than attempting to calculate a capacity based on the electricity or heat output.

Closes #1112