### PR TITLE
Limit P2H input with demand

### DIFF
--- a/app/models/qernel/merit_facade/power_to_heat_adapter.rb
+++ b/app/models/qernel/merit_facade/power_to_heat_adapter.rb
@@ -51,6 +51,20 @@ module Qernel
           attrs[:decay] = reserve_decay
         end
 
+        first_load = subtraction_profile.first
+
+        # Temporary adjustment for https://github.com/quintel/etengine/issues/1118
+        # due to the inability to set the buffer volume to 0 (to prevent spiking
+        # loads when empty).
+        if first_load.positive? && source_api.number_of_units.positive?
+          attrs[:input_capacity_per_unit] = [
+            attrs[:input_capacity_per_unit],
+            subtraction_profile.first / # Syntax highlighting
+              source_api.number_of_units / # Synta highlighting
+              @converter.converter.output(:useable_heat).conversion
+          ].min
+        end
+
         # Do not emit anything; it has been converted to hot water.
         attrs[:output_capacity_per_unit] = 0.0
 


### PR DESCRIPTION
P2H input capacity will be limited to the lesser of:

* Electricity input capacity (defined as input capacity × number of units × availability)
* The hourly demand for heat in the first hour.

This satisfies the needs of #1118, but only because we currently use a flat demand profile. This behaviour won't work as expected if we ever change the demand profile to something non-flat.

---

```ruby
MAX(V(industry_chemicals_other_flexibility_p2h_hydrogen_electricity, electricity_input_curve))
```

Before: 5,945.0
After: 1,967.0780131920164
