### PR TITLE
Migrate rename of bunkers point source co and co2 sliders

### DIFF
--- a/db/migrate/20200611142247_rename_bunkers_co_sliders.rb
+++ b/db/migrate/20200611142247_rename_bunkers_co_sliders.rb
@@ -1,0 +1,35 @@
+require 'etengine/scenario_migration'
+
+class RenameBunkersCoSliders < ActiveRecord::Migration[5.2]
+  include ETEngine::ScenarioMigration
+
+  INPUTS = {
+    flexibility_p2l_point_source_CO2: :flexibility_p2l_point_source_co2,
+    flexibility_p2l_point_source_CO: :flexibility_p2l_point_source_co
+  }
+
+  def up
+    migrate_scenarios do |scenario|
+      update_scenario(scenario, INPUTS)
+    end
+  end
+
+  def down
+    inverted_inputs = INPUTS.invert
+
+    migrate_scenarios do |scenario|
+      update_scenario(scenario, inverted_inputs)
+    end
+  end
+
+  private
+
+  def update_scenario(scenario, inputs)
+    inputs.each do |from, to|
+      next unless scenario.user_values.key?(from)
+
+      scenario.user_values[to] = scenario.user_values.delete(from)
+    end
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_05_094049) do
+ActiveRecord::Schema.define(version: 2020_06_11_142247) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false


### PR DESCRIPTION
Final apart of fixing this issue: https://github.com/quintel/etmodel/issues/3152

Goes together with:
https://github.com/quintel/etsource/pull/2304
https://github.com/quintel/etmodel/pull/3386

Closes: https://github.com/quintel/etmodel/issues/3384