### PR TITLE
Fix incorrect P2H FLH and demand calculation

### DIFF
--- a/app/models/qernel/merit_facade/power_to_heat_adapter.rb
+++ b/app/models/qernel/merit_facade/power_to_heat_adapter.rb
@@ -12,8 +12,10 @@ module Qernel
       def inject!
         super
 
+        production = participant.production
+
         full_load_hours =
-          participant.production / input_efficiency / (
+          production / input_efficiency / (
             source_api.input_capacity *
             participant.number_of_units *
             3600
@@ -29,10 +31,7 @@ module Qernel
         target_api[:full_load_hours]   = full_load_hours
         target_api[:full_load_seconds] = full_load_seconds
 
-        target_api.demand =
-          full_load_seconds *
-          source_api.input_capacity *
-          participant.number_of_units
+        target_api.demand = production
 
         inject_curve!(full_name: :heat_output_curve) { @heat_output_curve }
       end

--- a/app/models/qernel/merit_facade/power_to_heat_adapter.rb
+++ b/app/models/qernel/merit_facade/power_to_heat_adapter.rb
@@ -14,7 +14,7 @@ module Qernel
 
         full_load_hours =
           participant.production / input_efficiency / (
-            participant.input_capacity_per_unit *
+            source_api.input_capacity *
             participant.number_of_units *
             3600
           )


### PR DESCRIPTION
Fixes incorrect calculation of full load hours and demand for P2H, when input capacity is limited by total demand.

The calculation of FLH should be based on the _real_ input capacity of the node, not the artificially-limited capacity of the merit participant.

![Screenshot 2020-06-18 at 14 14 11](https://user-images.githubusercontent.com/4383/85024572-2e540a80-b16e-11ea-8f91-a77b7d4e5646.png)

Closes #1126 