### PR TITLE
Fix energy wrongly taken from P2G and P2H to be exported as electricity.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'parallel'
 
 # own gems
 gem 'rubel',         ref: 'e36554a',  github: 'quintel/rubel'
-gem 'quintel_merit', ref: '06f81d6',  github: 'quintel/merit'
+gem 'quintel_merit', ref: 'a0bc994',  github: 'quintel/merit'
 gem 'fever',         ref: 'f80677d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '72eacf8',  github: 'quintel/refinery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: 06f81d6c4da8be647386ebc8883cbc5f76fb620b
-  ref: 06f81d6
+  revision: a0bc9945dabdeb75a461a089deca90b85f290662
+  ref: a0bc994
   specs:
     quintel_merit (0.1.0)
       terminal-table


### PR DESCRIPTION
Fixes that energy would be taken from P2G, P2H, and other flexibility technologies that don't output heat, to satisfy price-sensitive demands (export with the dispatchable toggle enabled).

Also ensures correct load curves on P2P when used to satisfy both ordinary and price-sensitive demands.

Ref quintel/etmodel#3421.

---

With scenario:

```yaml
---
capacity_of_energy_hydrogen_flexibility_p2g_electricity: 50000.0
capacity_of_energy_power_wind_turbine_offshore: 50000.0
electricity_interconnector_1_capacity: 50000.0
settings_satisfy_export_with_dispatchables: 1.0
```

| Before | After |
| :---: | :---: |
| ![Screenshot 2020-07-30 at 15 08 16](https://user-images.githubusercontent.com/4383/88932847-835b6400-d276-11ea-997a-073c3dd3d666.png) | ![Screenshot 2020-07-30 at 15 07 08](https://user-images.githubusercontent.com/4383/88932737-632ba500-d276-11ea-999c-c6037d44b27a.png) |


