### PR TITLE
Fix incorrect demand on flex with zero output capacity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'parallel'
 
 # own gems
 gem 'rubel',         ref: 'e36554a',  github: 'quintel/rubel'
-gem 'quintel_merit', ref: 'a0bc994',  github: 'quintel/merit'
+gem 'quintel_merit', ref: '6a614e3',  github: 'quintel/merit'
 gem 'fever',         ref: 'f80677d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '72eacf8',  github: 'quintel/refinery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: a0bc9945dabdeb75a461a089deca90b85f290662
-  ref: a0bc994
+  revision: 6a614e3ed3c2d3c4d1a324c29d1829829d937d16
+  ref: 6a614e3
   specs:
     quintel_merit (0.1.0)
       terminal-table

--- a/app/models/qernel/merit_facade/heat_storage_adapter.rb
+++ b/app/models/qernel/merit_facade/heat_storage_adapter.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Qernel
+  module MeritFacade
+    # A global buffer for heat, used in the heat network order.
+    #
+    # Heat storage typically has infinite input capacity, storing all excesses, but limited output
+    # capacity. This means that we have to calculate the demand and full load hours of the node
+    # differently. Other flexibility options are calculated using their input capacity; this is not
+    # possible with infinite input capacity, so the FLH is calculated based on the output of the
+    # participant.
+    class HeatStorageAdapter < StorageAdapter
+      def inject!
+        super
+
+        inject_infinite! if infinite_storage?
+
+        # If the capacity is set dynamically by this adapter, reflect the change on the source node.
+        inject_dynamic_output_capacity! if @config.output_capacity_from_demand_of
+      end
+
+      def producer_attributes
+        attrs = super
+
+        # This must be performed AFTER setting the input capacity per unit (in
+        # StorageAdapter#producer_attributes) as this feature specifies that it affects output
+        # capacity only.
+        if @config.output_capacity_from_demand_of
+          attrs[:output_capacity_per_unit] = capacity_from_other_demand
+        end
+
+        attrs
+      end
+
+      private
+
+      # Infinite storage has an infinitely large reserve, which is then resized after the
+      # calculation to be the maximum value stored.
+      def infinite_storage?
+        @config.group == :infinite
+      end
+
+      # Internal: Sets demand and related attributes on the target API. Determines demand using the
+      # output (since input capacity may be infinite) rather than the input as is the case for other
+      # flexibility technologies.
+      def inject_demand!
+        target_api.demand = participant.production / output_efficiency
+
+        full_load_hours =
+          target_api.demand / (
+            participant.output_capacity_per_unit *
+            participant.number_of_units *
+            3600
+          )
+
+        target_api[:full_load_hours]   = full_load_hours
+        target_api[:full_load_seconds] = full_load_hours * 3600
+      end
+
+      def inject_infinite!
+        reserve = @participant.reserve
+        stored = Array.new(8760) { |frame| reserve.at(frame) }
+
+        source_api.storage.volume = stored.max.ceil.to_f
+
+        inject_curve!(full_name: :storage_curve) { stored }
+      end
+
+      def storage_volume_per_unit
+        infinite_storage? ? Float::INFINITY : super
+      end
+    end
+  end
+end


### PR DESCRIPTION
Electricity flex technologies with no output capacity would have a demand of zero set in the graph, rather than their real electricity demand. This is because four months ago we added support for heat storage, and correct calculation of its demand needed to be based on its output capacity. I wrongly opted all flexibilities technologies into this behaviour; technologies with zero electricity output capacity (P2H, P2H) would therefore receive a demand of zero in the graph.

This, in turn, would cause incorrect calculation of CO2 when using these technologies and failing Mechnical Turk tests.

Their demands are now set based on their input capacity – since all flex will have input, but not all have output – and a custom adapter has been added for heat storage.

Please test or merge simultaneously with https://github.com/quintel/etsource/pull/2340.