### PR TITLE
Price-sensitives receive equal shares of excess/dispatchables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'parallel'
 
 # own gems
 gem 'rubel',         ref: 'e36554a',  github: 'quintel/rubel'
-gem 'quintel_merit', ref: '6a614e3',  github: 'quintel/merit'
+gem 'quintel_merit', ref: '74b140d',  github: 'quintel/merit'
 gem 'fever',         ref: 'f80677d',  github: 'quintel/fever'
 gem 'turbine-graph', '>=0.1',         require: 'turbine'
 gem 'refinery',      ref: '72eacf8',  github: 'quintel/refinery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,8 +24,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: 6a614e3ed3c2d3c4d1a324c29d1829829d937d16
-  ref: 6a614e3
+  revision: 74b140d74401277292ddd2911a9674873d9a8e76
+  ref: 74b140d
   specs:
     quintel_merit (0.1.0)
       terminal-table

--- a/app/models/qernel/merit_facade/flex_group_builder.rb
+++ b/app/models/qernel/merit_facade/flex_group_builder.rb
@@ -15,9 +15,12 @@ module Qernel
           end
 
         group_class =
-          case config['behavior']
-          when 'share' then Merit::Flex::ShareGroup
-          else              Merit::Flex::Group
+          if config['behavior'] == 'share'
+            Merit::Flex::ShareGroup
+          elsif key == 'export'
+            Merit::Flex::CostBasedShareGroup
+          else
+            Merit::Flex::Group
           end
 
         group_class.new(key.to_sym, sorting)


### PR DESCRIPTION
* Price-sensitive users now receive equal shares of excess.
* Price-sensitive users now receive equal shares of available dispatchable energy.

The performance penalty is hard to quantify. On my laptop, three interconnectors with the dispatchables toggle turned on, compared with one interconnector and the toggle off, costs maybe 100ms. I think these changes are responsible for roughly half of that. I expect you'll want to merge this, but I feel like I have to reiterate that our use of Ruby for hourly calculations is becoming more ridiculous with every new feature.

P.S. My brain is broken from writing `while` loops in Ruby.

![4golgu](https://user-images.githubusercontent.com/4383/94578199-583dc280-026f-11eb-8679-8a242a07b821.jpg)

## Excess energy

| One interconnector | Two interconnectors |
| :---: | :---: |
| ![equal-excess-1](https://user-images.githubusercontent.com/4383/94578247-6986cf00-026f-11eb-9c97-ce4694445e6e.png) | ![equal-excess-2](https://user-images.githubusercontent.com/4383/94578261-6e4b8300-026f-11eb-8324-7bf1108c0928.png) |

## Dispatchables toggle on

| Two interconnectors | Three interconnectors |
| :---: | :---: |
| ![Screenshot 2020-09-29 at 15 57 00](https://user-images.githubusercontent.com/4383/94578665-e9ad3480-026f-11eb-859f-8319696de1ac.png) | ![Screenshot 2020-09-29 at 15 57 09](https://user-images.githubusercontent.com/4383/94578679-ec0f8e80-026f-11eb-89d0-538615f542b1.png) |

Closes #1129