### PR TITLE
Reset molecule graph between calculations

### DIFF
--- a/app/models/qernel/molecules/final_calculation.rb
+++ b/app/models/qernel/molecules/final_calculation.rb
@@ -23,14 +23,6 @@ module Qernel
         @molecule_graph.calculate
         @molecule_graph
       end
-
-      private
-
-      def create_molecule_graph
-        graph = Etsource::Loader.instance.molecule_graph.tap
-        graph.dataset = @energy_graph.dataset
-        graph
-      end
     end
   end
 end

--- a/app/models/qernel/plugins/molecules.rb
+++ b/app/models/qernel/plugins/molecules.rb
@@ -46,6 +46,7 @@ module Qernel
       end
 
       def reinstall_energy_demands
+        molecule_graph.dataset = @graph.dataset
         @calculation&.reinstall_demands
       end
 


### PR DESCRIPTION
When the energy graph is reset (after Causality) the molecule graph should also be reset, ensuring that values from the re-calculated molecule graph are propagated.

Basecamp: [Merit impact does not propagate through the molecule graph?](https://3.basecamp.com/3797409/buckets/16508470/todos/3174723949)