### PR TITLE
Add migration for households P2P

### DIFF
--- a/db/migrate/20201118102339_household_battery_volume.rb
+++ b/db/migrate/20201118102339_household_battery_volume.rb
@@ -1,0 +1,20 @@
+require 'etengine/scenario_migration'
+
+class HouseholdBatteryVolume < ActiveRecord::Migration[5.2]
+  include ETEngine::ScenarioMigration
+  P2P_KEY = "households_flexibility_p2p_electricity_market_penetration"
+  # old volume divided by new volume
+  ADJUSTMENT_FACTOR = 0.0198 / 0.0097
+
+  def up
+    migrate_scenarios do |scenario|
+      if scenario.user_values.key?(P2P_KEY)
+        new_value = scenario.user_values[P2P_KEY] * ADJUSTMENT_FACTOR
+        if new_value > 100.0
+          new_value = 100.0
+        end
+        scenario.user_values[P2P_KEY] = new_value
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_155601) do
+ActiveRecord::Schema.define(version: 2020_11_18_102339) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false


### PR DESCRIPTION
Specs of households P2P have been updated (quintel/etsource@4fe7e510231a9d9d8b413e4d73f73c27bd450bd7). The default volume of 1 P2P unit is now 50% lower than before. To limit the impact on scenarios, the households P2P slider value is doubled to ensure the available storage volume remains constant. For scenarios with an initial slider value of >50%, doubling the slider value is not fully possible as the max slider value is 100%.

See: https://github.com/quintel/etsource/pull/2376