### PR TITLE
Add migration to fix district heating cost sliders

### DIFF
--- a/db/migrate/20201126215921_fix_heat_cost.rb
+++ b/db/migrate/20201126215921_fix_heat_cost.rb
@@ -1,0 +1,19 @@
+require 'etengine/scenario_migration'
+
+class FixHeatCost < ActiveRecord::Migration[5.2]
+  include ETEngine::ScenarioMigration
+  INDOOR_KEY = "costs_heat_infra_indoors"
+  OUTDOOR_KEY = "costs_heat_infra_outdoors"
+
+  def up
+    migrate_scenarios do |scenario|
+      if scenario.user_values[INDOOR_KEY] == 0.8
+        scenario.user_values[INDOOR_KEY] = 80.0
+      end
+
+      if scenario.user_values[OUTDOOR_KEY] == 0.8
+        scenario.user_values[OUTDOOR_KEY] = 80.0
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_18_102339) do
+ActiveRecord::Schema.define(version: 2020_11_26_215921) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false


### PR DESCRIPTION
Scenarios based on the featured Climate Agreement scenario wrongfully assume a (non-sensical) 99.2% decrease in district heating costs. This should be a 20% decrease according to the scenario authors. The input value was (somehow?) changed from 80 to 0.8, a factor 100 difference). This migration looks up all scenarios with the faulty 0.8 values and overwrites them with the correct 80 value.