### PR TITLE
Migrate hard-coded domestic freight transport modal split

### DIFF
--- a/db/migrate/20210209084243_fix_inland_shipping_efficiency.rb
+++ b/db/migrate/20210209084243_fix_inland_shipping_efficiency.rb
@@ -1,0 +1,21 @@
+require 'etengine/scenario_migration'
+
+class FixInlandShippingEfficiency < ActiveRecord::Migration[5.2]
+  include ETEngine::ScenarioMigration
+
+  def up
+    migrate_scenarios do |scenario|
+      if ( scenario.area_code == "nl" &&
+         scenario.user_values["transport_trucks_share"].to_f > 83.2 && scenario.user_values["transport_trucks_share"].to_f < 83.6 &&
+         scenario.user_values["transport_freight_trains_share"].to_f > 5.0 && scenario.user_values["transport_freight_trains_share"].to_f < 5.4 && 
+         scenario.user_values["transport_ships_share"].to_f > 11.2 && scenario.user_values["transport_ships_share"].to_f < 11.6
+         )
+
+         scenario.user_values.delete("transport_trucks_share")
+         scenario.user_values.delete("transport_freight_trains_share")
+         scenario.user_values.delete("transport_ships_share")
+      end
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_10_162856) do
+ActiveRecord::Schema.define(version: 2021_02_09_084243) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false


### PR DESCRIPTION
The energy use of domestic navigation technologies has been updated as part of etdataset issue #859 (see also etdataset pull request #860). The modal split of domestic freight transport is calculated using the total energy use for each technology in MJ and the typical energy use in MJ/tkm. This means that, because the typical energy use of domestic navigation technologies in MJ/tkm has been decreased, the model split for domestic freight transport is changed as well.

For blank scenarios the modal split updates automatically. For scenarios where a different modal split is hardcoded as user input, nothing should change. However, for scenarios where the original modal split is hardcoded as user input, the modal split should update to the new values, in order to minimise the impact on the scenario.

This migration therefore resets the modal split for scenarios where the original modal split was hardcoded as user input.