### PR TITLE
Omit losses from primary demand nodes when calcualting PD

### DIFF
--- a/app/models/qernel/recursive_factor/primary_demand.rb
+++ b/app/models/qernel/recursive_factor/primary_demand.rb
@@ -81,22 +81,16 @@ module Qernel::RecursiveFactor::PrimaryDemand
   # Internal: Calculates the primary demand factor of the given edge.
   #
   # edge           - The edge whose primary demand factor is to be calculated.
-  # stop_condition - A method to be called on self to determine if the edge has
-  #                  any primary energy demand to be included in the
-  #                  calculation.
+  # stop_condition - A method to be called on self to determine if the edge has any primary energy
+  #                  demand to be included in the calculation.
   #
   # Returns a numeric.
   def factor_for_primary_demand(stop_condition = :primary_energy_demand?)
-    stop = public_send(stop_condition)
-
-    # If a node has infinite resources (such as wind, solar/sun), we
-    # take the output of energy (1 - losses).
-    if infinite? && stop
-      (1 - loss_output_conversion)
-    elsif stop # Normal case.
-      1.0
-    else
-      0.0
-    end
+    # If the stop condition is satisfied, return the output share of the node minus loss. Losses
+    # should not be included in the share from the primary demand node itself, see
+    # https://github.com/quintel/etengine/issues/1147.
+    #
+    # Nodes that do not met the stop condition are at the far-right of the graph.
+    public_send(stop_condition) ? 1.0 - loss_output_conversion : 0.0
   end
 end

--- a/spec/models/qernel/recursive_factor/primary_demand_spec.rb
+++ b/spec/models/qernel/recursive_factor/primary_demand_spec.rb
@@ -63,4 +63,51 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryDemand do
       expect(left.query.primary_demand).to eq(50.0)
     end
   end
+
+  context 'when the primary demand node has 20% loss' do
+    let(:loss) { Qernel::Carrier.new(key: :loss).with({}) }
+    let(:right) { super().with(demand: 125.0) }
+    let(:rgt_conversion) { 0.8 }
+
+    before do
+      right.add_slot(Qernel::Slot.new(nil, right, loss, :output).with(conversion: 0.2))
+    end
+
+    it 'has primary_demand of 100' do
+      # Without omitting the loss, the primary_demand would be 125.
+      expect(left.query.primary_demand).to eq(100.0)
+    end
+
+    it 'has primary_demand_of_natural_gas 100' do
+      # Without omitting the loss, the primary_demand would be 125.
+      expect(left.query.primary_demand_of_natural_gas).to eq(100.0)
+    end
+  end
+
+  context 'when the primary demand and middle nodes have 20% loss' do
+    let(:loss) { Qernel::Carrier.new(key: :loss).with({}) }
+    let(:right) { super().with(demand: 125.0) }
+    let(:rgt_conversion) { 0.8 }
+
+    before do
+      right.add_slot(Qernel::Slot.new(nil, right, loss, :output).with(conversion: 0.2))
+      middle.add_slot(Qernel::Slot.new(nil, right, loss, :output).with(conversion: 0.2))
+
+      mid_left_edge = left.input_edges.first
+      mid_left_edge.with(value: 80.0)
+      mid_left_edge.query.with(value: 80.0)
+    end
+
+    it 'has primary_demand of 100' do
+      # Without omitting the PD loss, the primary_demand would be 125. Adjustments are not made for
+      # enroute losses.
+      expect(left.query.primary_demand).to eq(100.0)
+    end
+
+    it 'has primary_demand_of_natural_gas 100' do
+      # Without omitting the PD loss, the primary_demand would be 125. Adjustments are not made for
+      # enroute losses.
+      expect(left.query.primary_demand_of_natural_gas).to eq(100.0)
+    end
+  end
 end


### PR DESCRIPTION
When calculating `primary_demand`, we no longer include energy lost on the primary demand node itself. En route losses are still accounted for. This means that if the PD node has 100PJ with 20% loss, the primary demand of this node will now be 80PJ.

Closes #1147