### PR TITLE
Update Scenario area_codes to not contain `no_highways` or `no_steel`

### DIFF
--- a/db/migrate/20210420135121_remove_old_datasets_no_steel_no_highways.rb
+++ b/db/migrate/20210420135121_remove_old_datasets_no_steel_no_highways.rb
@@ -1,0 +1,40 @@
+require 'etengine/scenario_migration'
+
+class RemoveOldDatasetsNoSteelNoHighways < ActiveRecord::Migration[5.2]
+  include ETEngine::ScenarioMigration
+
+  RENAME = {
+    hengstdal: :nl
+  }.freeze
+
+  REMOVE_SUFFIX = %w[_no_highways _no_steel]
+
+  def up
+    # Rename datasets
+    RENAME.each do |old_name, new_name|
+      say_with_time "#{old_name} -> #{new_name}" do
+        Scenario.where(area_code: old_name).update_all(area_code: new_name)
+      end
+    end
+
+    # Change all no_highways- and no_steel-dataset scenarios in standard-dataset scenarios
+    Scenario.all.each do |scenario|
+      remove_any_suffix_from_area_code(scenario)
+    end
+  end
+
+  private
+
+  def remove_any_suffix_from_area_code(scenario)
+    REMOVE_SUFFIX.each do |suffix|
+      return if remove_suffix(scenario, suffix)
+    end
+  end
+
+  def remove_suffix(scenario, suffix)
+    return false unless scenario.area_code.ends_with?(suffix)
+
+    scenario.update(area_code: scenario.area_code.delete_suffix(suffix))
+    true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_20_121540) do
+ActiveRecord::Schema.define(version: 2021_04_20_135121) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false


### PR DESCRIPTION
The datasets containing these suffixes will be removed form ETSource. The standard version dataset (that does contain steel or highways) will be used instead for the affected scenarios.