### PR TITLE
Add migration to set fuel production sliders to zero in all scenarios

### DIFF
--- a/db/migrate/20210512100520_set_fuel_production_to_zero.rb
+++ b/db/migrate/20210512100520_set_fuel_production_to_zero.rb
@@ -1,0 +1,17 @@
+require 'etengine/scenario_migration'
+
+class SetFuelProductionToZero < ActiveRecord::Migration[5.2]
+  include ETEngine::ScenarioMigration
+  def up
+    migrate_scenarios do |scenario|
+      # Set fuel production of primary carriers to zero. These are new inputs. In some areas it
+      # had a non-zero default value due to the time_curves (which are now removed). This migration
+      # could result in a different import / export balance in scenarios.
+      scenario.user_values["fuel_production_coal"] = 0.0
+      scenario.user_values["fuel_production_crude_oil"] = 0.0
+      scenario.user_values["fuel_production_lignite"] = 0.0
+      scenario.user_values["fuel_production_natural_gas"] = 0.0
+      scenario.user_values["fuel_production_uranium_oxide"] = 0.0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_30_132228) do
+ActiveRecord::Schema.define(version: 2021_05_12_100520) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false


### PR DESCRIPTION
This PR sets all new fuel production sliders for all scenarios to zero. This is the case for most scenarios. If the time curve had a production value for a future year, this will be changed to zero. This could impact the import / export balance of scenarios, but this impact will be very small.