### PR TITLE
Ensure electrolyser shares are consistent with flows

### DIFF
--- a/app/models/qernel/causality/reconciliation_wrapper.rb
+++ b/app/models/qernel/causality/reconciliation_wrapper.rb
@@ -29,6 +29,15 @@ module Qernel
         end
       end
 
+      # Internal: A hook which is called by Causality prior to the recalculation of the energy
+      # graph.
+      #
+      # This is needed to allow electrolyzers to set the shares of some edges prior to the graph
+      # being recalculated.
+      def before_graph_recalculation
+        @managers.each(&:before_graph_recalculation)
+      end
+
       private
 
       def create_manager(graph, carrier, node_key_map)

--- a/app/models/qernel/plugins/causality.rb
+++ b/app/models/qernel/plugins/causality.rb
@@ -85,6 +85,12 @@ module Qernel::Plugins
       @fever.inject_values!
       @heat_network.inject_values!
       @merit.inject_values!
+
+      # Adapters which need to make changes to the graph must do so prior to its re-calculation.
+      #
+      # Note that Reconciliation has not been calculated at this point; only adapters whose demands
+      # are not changed by Fever/Merit can perform this action.
+      @reconciliation.before_graph_recalculation
     end
 
     # Internal: Calculate and inject "Reconciliation" curves.

--- a/app/models/qernel/reconciliation/adapter.rb
+++ b/app/models/qernel/reconciliation/adapter.rb
@@ -62,6 +62,18 @@ module Qernel
       # Returns nothing.
       def inject!(_calculator); end
 
+      # Public: Performs actions prior to the recalculation of the graph triggered by Causality.
+      #
+      # Note that most adapters will not have been configured - let alone calculated - at this
+      # point. Changes to the graph are only possible when you are sure the adapter and its node
+      # will not be influenced by any change resulting from Merit/Fever.
+      #
+      # You should only implement this method when the `demand_phase` is `:manual` and you will
+      # trigger the adapter set-up manually.
+      #
+      # Returns nothing.
+      def before_graph_recalculation!; end
+
       private
 
       def calculate_carrier_demand

--- a/app/models/qernel/reconciliation/electrolyser_adapter.rb
+++ b/app/models/qernel/reconciliation/electrolyser_adapter.rb
@@ -32,6 +32,8 @@ module Qernel
 
         # Pre-compute electricity while demand is set on the node.
         max_available_electricity
+
+        setup(phase: demand_phase)
       end
 
       # Public: Capacity-limited demand curve describing the amount of
@@ -44,9 +46,7 @@ module Qernel
         end
       end
 
-      def inject!(*)
-        super
-
+      def before_graph_recalculation!
         return if carrier_demand.zero?
 
         @node.demand =
@@ -64,6 +64,10 @@ module Qernel
       end
 
       private
+
+      def demand_phase
+        :manual
+      end
 
       # Internal: The maximum amount of electricity available for conversion to
       # the carrier.

--- a/app/models/qernel/reconciliation/manager.rb
+++ b/app/models/qernel/reconciliation/manager.rb
@@ -32,6 +32,11 @@ module Qernel
         setup_adapters(phase: :final)
       end
 
+      # Public: Assigns electrolyzer shares prior to graph recalculation.
+      def before_graph_recalculation
+        each_adapter(&:before_graph_recalculation!)
+      end
+
       # Public: Sets up and returns the time-resolved reconciliation calculator.
       # Memoizes after the first call.
       #


### PR DESCRIPTION
Sets electrolyser shares prior to recalculation of the graph. 2d5733f required that Reconciliation be moved to after recalculation of the graph so that demand changes made by Merit/Fever were reflected in and hydrogen.

This had the effect of setting electrolyser shares too late: the graph would already have been calculated, and flows were therefore not consistent with the shares set by ElectrolyserAdapter.

As electrolyser demand is known prior to Merit, and cannot be changed (due to them having dedicated electricity sources which are excluded from Merit), we can set their demands prior to recalculation of the graph.

A `before_graph_recalculation` method is added to Reconciliation which is triggered by Causality.

Closes #1174