### PR TITLE
Fix recursive factor with efficiencies exceeding 1

### DIFF
--- a/app/models/qernel/recursive_factor/bio_emissions.rb
+++ b/app/models/qernel/recursive_factor/bio_emissions.rb
@@ -86,7 +86,8 @@ module Qernel
       def captured_bio_emissions_from_supplier(edge)
         if edge.demand.positive?
           edge.rgt_node.query.inherited_captured_bio_emissions *
-            edge.parent_share * edge.rgt_output.conversion
+            edge.parent_share * edge.rgt_output.conversion *
+            edge.rgt_node.query.output_compensation_factor
         else
           # Don't recurse through any edge with no demand. There won't be any emissions from
           # this path, and we'll get caught in loops in the graph.

--- a/spec/models/qernel/recursive_factor/bio_emissions_spec.rb
+++ b/spec/models/qernel/recursive_factor/bio_emissions_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Qernel::RecursiveFactor::BioEmissions do
       expect(ccs_plant_1).to have_query_value(:captured_bio_emissions, 50)
     end
 
-    xit 'Terminus inherits 62.5 captures CO2' do
+    it 'Terminus inherits 62.5 captures CO2' do
       expect(terminus).to have_query_value(:inherited_captured_bio_emissions, 62.5)
     end
   end
@@ -127,6 +127,21 @@ RSpec.describe Qernel::RecursiveFactor::BioEmissions do
     before do
       builder.node(:ccs_plant_1).slots.out(:electricity).set(:share, 0.5)
       builder.node(:ccs_plant_1).slots.out.add(:gas, share: 0.5)
+    end
+
+    it 'captures 50 on CCS Plant #1' do
+      expect(ccs_plant_1).to have_query_value(:captured_bio_emissions, 50)
+    end
+
+    it 'Terminus inherits 37.5 captures CO2' do
+      expect(terminus).to have_query_value(:inherited_captured_bio_emissions, 37.5)
+    end
+  end
+
+  context 'when CCS plant #1 has outputs electricity=0.6 gas=0.6' do
+    before do
+      builder.node(:ccs_plant_1).slots.out(:electricity).set(:share, 0.6)
+      builder.node(:ccs_plant_1).slots.out.add(:gas, share: 0.6)
     end
 
     it 'captures 50 on CCS Plant #1' do

--- a/spec/models/qernel/recursive_factor/primary_co2_spec.rb
+++ b/spec/models/qernel/recursive_factor/primary_co2_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       it { is_expected.to have_query_value(:primary_co2_emission, 50) }
       it { is_expected.to have_query_value(:primary_demand_of_sustainable, 25) }
       it { is_expected.to have_query_value(:primary_demand_of_fossil, 75) }
-      xit { is_expected.to have_query_value(:sustainability_share, 0.25) }
+      pending { is_expected.to have_query_value(:sustainability_share, 0.25) }
     end
   end
 
@@ -110,7 +110,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       builder.node(:middle).slots.out.add(:electricity, share: 0.6)
     end
 
-    xdescribe 'the left node' do
+    describe 'the left node' do
       subject { graph.node(:left) }
 
       it { is_expected.to have_query_value(:primary_co2_emission, 25) }
@@ -239,7 +239,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       it { is_expected.to have_query_value(:primary_co2_emission, 50) }
       it { is_expected.to have_query_value(:primary_demand_of_sustainable, 25) }
       it { is_expected.to have_query_value(:primary_demand_of_fossil, 75) }
-      xit { is_expected.to have_query_value(:sustainability_share, 0.25) }
+      pending { is_expected.to have_query_value(:sustainability_share, 0.25) }
     end
   end
 
@@ -263,7 +263,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       it { is_expected.to have_query_value(:primary_co2_emission, 50) }
       it { is_expected.to have_query_value(:primary_demand_of_sustainable, 25) }
       it { is_expected.to have_query_value(:primary_demand_of_fossil, 75) }
-      xit { is_expected.to have_query_value(:sustainability_share, 0.25) }
+      pending { is_expected.to have_query_value(:sustainability_share, 0.25) }
     end
   end
 
@@ -275,7 +275,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       builder.node(:right).slots.out.add(:electricity, share: 0.6)
     end
 
-    xdescribe 'the middle node' do
+    describe 'the middle node' do
       subject { graph.node(:middle) }
 
       it { is_expected.to have_query_value(:primary_co2_emission, 25) }
@@ -290,7 +290,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       it { is_expected.to have_query_value(:primary_co2_emission, 50) }
       it { is_expected.to have_query_value(:primary_demand_of_sustainable, 25) }
       it { is_expected.to have_query_value(:primary_demand_of_fossil, 75) }
-      xit { is_expected.to have_query_value(:sustainability_share, 0.25) }
+      pending { is_expected.to have_query_value(:sustainability_share, 0.25) }
     end
   end
 
@@ -315,7 +315,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       it { is_expected.to have_query_value(:primary_co2_emission, 50) }
       it { is_expected.to have_query_value(:primary_demand_of_sustainable, 25) }
       it { is_expected.to have_query_value(:primary_demand_of_fossil, 75) }
-      xit { is_expected.to have_query_value(:sustainability_share, 0.25) }
+      pending { is_expected.to have_query_value(:sustainability_share, 0.25) }
     end
   end
 end

--- a/spec/models/qernel/recursive_factor/primary_demand_spec.rb
+++ b/spec/models/qernel/recursive_factor/primary_demand_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryDemand do
     include_examples 'zero carrier-specific primary demands'
   end
 
-  xcontext 'when the middle node has two output conversions, each of 0.6' do
+  context 'when the middle node has two output conversions, each of 0.6' do
     # When the sum of output conversions exceed 1.0, the conversion is normalized so that it
     # represents a percentage of the total (two outputs with conversion of 0.6 result in effective
     # conversions of 0.5 each).


### PR DESCRIPTION
When the outputs of a node sum to a value greater than 1, recursive factor values are exaggerated. For example, if we have a graph like where a node outputs energy to two suppliers in different carriers, with a total output greater than 1, recursive factor respects the output conversions of the producer and calculates an incorrect primary demand for the consumers:

![1-current](https://user-images.githubusercontent.com/4383/120673160-d8659900-c48a-11eb-866f-bf2d5710cc03.png)

The expected behaviour is that each consumer should have 50 *primary* demand: although they each have 60 *demand*, they require 50 *primary demand* on the producer node to generate that 60.

![2-expected](https://user-images.githubusercontent.com/4383/120673172-da2f5c80-c48a-11eb-8eed-ffbc73f119c1.png)

This commit adds an `output_efficiency_compensation_factor` which is used by `recursive_factor` (but not `recursive_factor_without_losses`) to compensate for nodes with output shares exceeding 1.

The "without losses" does not have this compensation, as it is typically used to calculate shares (`sustainability_share`).

Fixes #1172

---

```ruby
EACH(
  SUM(V(
    households_final_demand_steam_hot_water,
    households_final_demand_electricity,
    energy_heat_dumped_steam_hot_water,
    primary_demand_of_wood_pellets
  )),
  V(energy_production_wood_pellets, primary_demand_of_wood_pellets)
)
```

### Before

```
[
  1,724,900,051.4137213,
  1,553,964,010.2826319,
]
```

### After

```
[
  1,553,964,010.2826319,
  1,553,964,010.2826319,
]
```