### PR TITLE
Fix mismatch between heat curves and output

### DIFF
--- a/app/models/qernel/causality/lazy_curve.rb
+++ b/app/models/qernel/causality/lazy_curve.rb
@@ -15,7 +15,7 @@ module Qernel
 
       def to_a
         if @values.last.present?
-          @values.dup
+          @values.length > length ? @values[0...length] : @values.dup
         else
           Array.new(length) { |frame| get(frame) }
         end

--- a/app/models/qernel/recursive_factor/base.rb
+++ b/app/models/qernel/recursive_factor/base.rb
@@ -332,7 +332,10 @@ module Qernel::RecursiveFactor::Base
   #
   # Returns a numeric.
   def output_efficiency_compensation_factor
-    factor = outputs.sum { |output| output.loss? ? 0.0 : output.conversion }
+    factor = outputs.sum do |output|
+      output.carrier.loss? || output.carrier.coupling_carrier? ? 0.0 : output.conversion
+    end
+
     factor > 1 ? 1.0 / factor : 1.0
   end
 
@@ -343,7 +346,7 @@ module Qernel::RecursiveFactor::Base
   #
   # Returns a numeric.
   def input_compensation_factor
-    1.0 / inputs.sum(&:conversion)
+    1.0 / inputs.sum { |input| input.carrier.coupling_carrier? ? 0.0 : input.conversion }
   end
 
   # Public: The parent share of the edge.

--- a/spec/models/qernel/causality/lazy_curve_spec.rb
+++ b/spec/models/qernel/causality/lazy_curve_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Qernel::Causality::LazyCurve do
+  let(:curve) do
+    described_class.new { |frame| frame }
+  end
+
+  it 'can fetch values with get' do
+    expect(curve.get(5)).to eq(5)
+  end
+
+  it 'can fetch values with []' do
+    expect(curve[5]).to eq(5)
+  end
+
+  it 'returns self when calling values' do
+    expect(curve.values).to eq(curve)
+  end
+
+  context 'when calling the first two values' do
+    let!(:first) { curve.get(0) }
+    let!(:second) { curve.get(1) }
+
+    it 'returns the value for the first frame' do
+      expect(first).to eq(0)
+    end
+
+    it 'returns the value for the second frame' do
+      expect(second).to eq(1)
+    end
+
+    it 'can be summed' do
+      expect(curve.sum).to eq((1..8759).sum)
+    end
+
+    describe '#to_a' do
+      subject { curve.to_a }
+
+      it 'is an array' do
+        expect(subject).to be_a(Array)
+      end
+
+      it 'has 8760 elements' do
+        expect(subject.length).to eq(8760)
+      end
+
+      it 'has the called values' do
+        expect(subject[0..1]).to eq([0, 1])
+      end
+
+      it 'populates any uncalled values' do
+        expect(subject[2..]).to eq((2..8759).to_a)
+      end
+
+      it 'returns a different object each time' do
+        expect(subject.object_id).not_to eq(curve.to_a.object_id)
+      end
+    end
+  end
+
+  context 'when calling the all values' do
+    before do
+      8760.times { |frame| curve.get(frame) }
+    end
+
+    it 'can be summed' do
+      expect(curve.sum).to eq((1..8759).sum)
+    end
+
+    describe '#to_a' do
+      subject { curve.to_a }
+
+      it 'is an array' do
+        expect(subject).to be_a(Array)
+      end
+
+      it 'has 8760 elements' do
+        expect(subject.length).to eq(8760)
+      end
+
+      it 'has the called values' do
+        expect(subject).to eq((0..8759).to_a)
+      end
+
+      it 'returns a different object each time' do
+        expect(subject.object_id).not_to eq(curve.to_a.object_id)
+      end
+    end
+  end
+
+  context 'when calling a value beyond index 8759' do
+    before do
+      8760.times { |frame| curve.get(frame) }
+    end
+
+    let!(:extra_value) { curve.get(8760) }
+
+    it 'returns the extra value' do
+      expect(extra_value).to eq(8760)
+    end
+
+    it 'can be summed' do
+      expect(curve.sum).to eq((1..8759).sum)
+    end
+
+    describe '#to_a' do
+      subject { curve.to_a }
+
+      it 'is an array' do
+        expect(subject).to be_a(Array)
+      end
+
+      it 'has 8760 elements' do
+        expect(subject.length).to eq(8760)
+      end
+
+      it 'has the called values' do
+        expect(subject).to eq((0..8759).to_a)
+      end
+
+      it 'returns a different object each time' do
+        expect(subject.object_id).not_to eq(curve.to_a.object_id)
+      end
+    end
+  end
+end

--- a/spec/models/qernel/recursive_factor/primary_co2_spec.rb
+++ b/spec/models/qernel/recursive_factor/primary_co2_spec.rb
@@ -313,6 +313,32 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
     end
   end
 
+  context 'when the middle node has inputs natural_gas=1.0 and coupling_carrier=1.0' do
+    # Coupling carrier does not count.
+    before do
+      builder.node(:middle).slots.in(:natural_gas).set(:share, 1.0)
+      builder.node(:middle).slots.in.add(:coupling_carrier, share: 1.0)
+    end
+
+    describe 'the left node' do
+      subject { graph.node(:left) }
+
+      it { is_expected.to have_query_value(:primary_co2_emission, 50) }
+      it { is_expected.to have_query_value(:primary_demand_of_sustainable, 25) }
+      it { is_expected.to have_query_value(:primary_demand_of_fossil, 75) }
+      it { is_expected.to have_query_value(:sustainability_share, 0.25) }
+    end
+
+    describe 'the middle node' do
+      subject { graph.node(:middle) }
+
+      it { is_expected.to have_query_value(:primary_co2_emission, 50) }
+      it { is_expected.to have_query_value(:primary_demand_of_sustainable, 25) }
+      it { is_expected.to have_query_value(:primary_demand_of_fossil, 75) }
+      it { is_expected.to have_query_value(:sustainability_share, 0.25) }
+    end
+  end
+
   context 'when the right node has outputs natural_gas=2.0' do
     before do
       builder.node(:right).slots.out(:natural_gas).set(:share, 2.0)

--- a/spec/models/qernel/recursive_factor/primary_demand_spec.rb
+++ b/spec/models/qernel/recursive_factor/primary_demand_spec.rb
@@ -156,6 +156,25 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryDemand do
     include_examples 'zero carrier-specific primary demands'
   end
 
+  context 'when the middle node has two output conversions, natural_gas=1 coupling_carrier=1' do
+    # Coupling carrier does not count.
+    before do
+      builder.node(:middle).slots.out(:natural_gas).set(:share, 1.0)
+      builder.node(:middle).slots.out.add(:coupling_carrier, share: 1.0)
+    end
+
+    it { expect(left).to have_query_value(:primary_demand, 100) }
+    it { expect(left).to have_query_value(:primary_demand_of_natural_gas, 100) }
+
+    it { expect(middle).to have_query_value(:primary_demand, 100) }
+    it { expect(middle).to have_query_value(:primary_demand_of_natural_gas, 100) }
+
+    it { expect(right).to have_query_value(:primary_demand, 100) }
+    it { expect(right).to have_query_value(:primary_demand_of_natural_gas, 100) }
+
+    include_examples 'zero carrier-specific primary demands'
+  end
+
   context 'when the right (PD) node has 20% loss' do
     # Energy lost on the PD node itself (but not others on the path) is not counted towards primary
     # demand.


### PR DESCRIPTION
When a heat producer also participates in the electricity merit order, the heat curve does not have a load to represent the final hour in the year (all heat loads a shifted one hour into the future, so this manifests with no heat load in the _first_ element of the load curve).

This results in slightly too much heat leaving the producer in the graph since the share of heat output does not account for the hour in which none is produced.

`ProducerAdapter` has been adjusted to change the share of heat to ensure that graph flows match the heat output curve. 

## Query from #1175

```ruby
SUM(V(G(primary_energy_demand),primary_demand)) - 
  SUM(V(
    G(final_demand_group),
    G(energy_export),
    energy_flexibility_curtailment_electricity,
    industry_locally_available_refinery_gas_for_chemical,
    primary_demand
  ))
```

### Beta scenario 1435329

| Branch | Result |
| :-- | --: |
| master | `27,196,895.7 ~ ~ ~ ~ ~` |
| issues/1175-chp-outputs | `0.00024414063` |

### Beta scenario 1436077

[The simplified scenario](https://github.com/quintel/etengine/issues/1175#issuecomment-846000417) which uses coal CHPs instead of gas.

| Branch | Result |
| :-- | --: |
| master | `32,488,799.5            ` |
| issues/1175-chp-outputs | `0.0` |

### Default scenario

However, this change doesn't seem to have much impact on the mismatch in a default scenario. A mismatch remains for both the present and future.

| Branch | Present | Future |
| :-- | --: | --: |
| master | `27,634,968,521` | `27,638,966,692` |
| issues/1175-chp-outputs | `27,634,968,521` | `27,635,452,303` |

This is 1000× larger than the example scenarios. 😕 

## Heat output vs heat output curve

```ruby
EACH(
  V(energy_chp_ultra_supercritical_coal, output_of_steam_hot_water),
  PRODUCT(SUM(V(energy_chp_ultra_supercritical_coal, steam_hot_water_output_curve)), MJ_PER_MWH)
)
```

### Default scenario

To account for the missing hour, the heat output is adjusted down from 15% to 14.99828747573924%.

| Branch | Output of heat | Sum of heat curve in PJ | Diff |
| :-- | --: | --: | --: |
| master | `14,389,564,393` | `14,391,207,225` | `-1,642,832` |
| issues/1175-chp-outputs | `14,389,564,393` | `14,389,564,393` | `0` |

---

Closes #1175