### PR TITLE
Rename NL2019 dataset to NL, NL to NL2015

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -116,6 +116,8 @@ module Api
           end
         end
 
+        attrs[:area_code] = 'nl' if attrs[:area_code] == 'nl2019'
+
         # The scaler needs to be in place before assigning attributes when the
         # scenario inherits from a preset.
         @scenario.descale    = attrs[:descale]

--- a/db/migrate/20211215120425_rename_nl2019_dataset_to_nl.rb
+++ b/db/migrate/20211215120425_rename_nl2019_dataset_to_nl.rb
@@ -1,0 +1,21 @@
+class RenameNl2019DatasetToNl < ActiveRecord::Migration[5.2]
+  def up
+    say_with_time 'Rename nl dataset to nl2015' do
+      Scenario.where(area_code: 'nl').update_all(area_code: 'nl2015')
+    end
+
+    say_with_time 'Rename nl2019 dataset to nl' do
+      Scenario.where(area_code: 'nl2019').update_all(area_code: 'nl')
+    end
+  end
+
+  def down
+    say_with_time 'Rename nl dataset to nl2019' do
+      Scenario.where(area_code: 'nl').update_all(area_code: 'nl2019')
+    end
+
+    say_with_time 'Rename nl2015 dataset to nl' do
+      Scenario.where(area_code: 'nl2015').update_all(area_code: 'nl')
+    end
+  end
+end

--- a/spec/requests/api/v3/create_scenario_spec.rb
+++ b/spec/requests/api/v3/create_scenario_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+# rubocop:disable RSpec/MultipleExpectations
+
 describe 'APIv3 Scenarios', :etsource_fixture do
   before(:all) do
     NastyCache.instance.expire!
@@ -84,7 +86,7 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(data['end_year']).to eql(2031)
     end
 
-    it 'should save custom end years' do
+    it 'saves custom area codes' do
       pending 'awaiting reintroduction of non-NL regions'
       running_this = -> {
         post '/api/v3/scenarios', params: { scenario: { area_code: 'uk' } }
@@ -96,6 +98,19 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       data = JSON.parse(response.body)
 
       expect(data['area_code']).to eql('de')
+    end
+
+    it 'converts nl2019 area code to nl' do
+      running_this = lambda do
+        post '/api/v3/scenarios', params: { scenario: { area_code: 'nl2019' } }
+      end
+
+      expect(&running_this).to change(Scenario, :count).by(1)
+      expect(response.status).to be(200)
+
+      data = JSON.parse(response.body)
+
+      expect(data['area_code']).to eql('nl')
     end
   end
 
@@ -452,3 +467,5 @@ describe 'APIv3 Scenarios', :etsource_fixture do
   end # when scaling the area
 
 end
+
+# rubocop:enable RSpec/MultipleExpectations


### PR DESCRIPTION
quintel/etsource#2555