### PR TITLE
Support mutually-exclusive inputs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'ruby-progressbar'
 # own gems
 gem 'quintel_merit', ref: '7ab6abf', github: 'quintel/merit'
 
-gem 'atlas',         ref: 'c9e447b', github: 'quintel/atlas'
+gem 'atlas',         ref: 'd52c340', github: 'quintel/atlas'
 gem 'fever',         ref: 'f80677d', github: 'quintel/fever'
 gem 'refinery',      ref: '72eacf8', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: c9e447b755228273b040d62bc1f3234a6d9fa05f
-  ref: c9e447b
+  revision: d52c34061b5897671c1efbc8cffadc575141174c
+  ref: d52c340
   specs:
     atlas (1.0.0)
       activemodel (>= 4.1.14.1)

--- a/app/models/gql/gql.rb
+++ b/app/models/gql/gql.rb
@@ -294,7 +294,7 @@ module Gql
 
     def update_present
       instrument('gql.performance.present.update_present') do
-        scenario.inputs_present.each do |input, value|
+        scenario.inputs.present.each do |input, value|
           update_graph(present, input, value)
         end
       end
@@ -302,11 +302,11 @@ module Gql
 
     def update_future
       instrument('gql.performance.future.update_future') do
-        scenario.inputs_before.each do |input, value|
+        scenario.inputs.before.each do |input, value|
           update_graph(future, input, value)
         end
 
-        scenario.inputs_future.each do |input, value|
+        scenario.inputs.future.each do |input, value|
           update_graph(future, input, value)
         end
       end

--- a/app/models/input.rb
+++ b/app/models/input.rb
@@ -46,6 +46,14 @@ class Input
     @inputs_grouped ||= Input.with_share_group.group_by(&:share_group)
   end
 
+  def disabled_by
+    @disabled_by || []
+  end
+
+  def disabled_by=(disabled_by)
+    @disabled_by = Array(disabled_by).map { |key| key.to_s.freeze }.freeze
+  end
+
   def before_update?
     update_period == 'before'
   end

--- a/app/models/scenario/copies.rb
+++ b/app/models/scenario/copies.rb
@@ -14,10 +14,7 @@ module Scenario::Copies
   #
   def initialize_copy(orig)
     super
-    @gql            = nil
-    @inputs_before  = nil
-    @inputs_present = nil
-    @inputs_future  = nil
+    @gql    = nil
+    @inputs = nil
   end
-
 end # Scenario::Copies

--- a/app/models/scenario/inputs.rb
+++ b/app/models/scenario/inputs.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+class Scenario < ApplicationRecord
+  # Helper class which provides a list of inputs to be executed for a scenario.
+  class Inputs
+    def initialize(scenario)
+      @scenario = scenario
+    end
+
+    # Public: Returns a hash containing the "before" inputs and their values.
+    #
+    # Returns a Hash[Input => Object].
+    def before
+      @before ||= Input.before_inputs.each_with_object({}) do |input, data|
+        data[input] = @scenario.end_year
+      end
+    end
+
+    # Public: Returns a hash containing the inputs that are to be executed on the present graph and
+    # their values.
+    #
+    # Returns a Hash[Input => Object].
+    def present
+      @present ||= inputs_for_graph(:present)
+    end
+
+    # Public: Returns a hash containing the inputs that are to be executed on the present graph and
+    # their values.
+    #
+    # Returns a Hash[Input => Object].
+    def future
+      @future ||= inputs_for_graph(:future)
+    end
+
+    # Public: A set of inputs which are set in the scenario which are disabled due to the presence
+    # of one or more conflicting exclusive inputs.
+    #
+    # input - The input to check for exclusivity conflicts.
+    #
+    # Returns a Set[Input].
+    def disabled_by_exclusivity?(input)
+      input.disabled_by.any? { |key| combined_values.key?(key) }
+    end
+
+    private
+
+    # Internal: A set containing all the inputs which are disabled by exclusivity conflicts.
+    def exclusivity_disabled
+      @exclusivity_disabled ||= Set.new(
+        all
+          .select { |input| input.disabled_by.any? { |key| combined_values.key?(key) } }
+          .map(&:key)
+      )
+    end
+
+    # Internal: A hash of inputs and the values to be set on the named graph.
+    #
+    # name - The "period" of the graph for which you want values; :future or :present.
+    #
+    # Returns a Hash[Input => Object].
+    def inputs_for_graph(period)
+      enabled_inputs
+        .select { |input| input.public_send(:"updates_#{period}?") }
+        .each_with_object({}) { |input, hash| hash[input] = combined_values[input.key] }
+    end
+
+    # Internal: The inputs for which the user - or balancer - has specified a value.
+    #
+    # If any inputs contain a value which result in another input being disabled, the disabled
+    # inputs are omitted from the list.
+    #
+    # Returns an array of inputs, in order of their execution priority.
+    def enabled_inputs
+      @enabled_inputs ||= all
+        .reject { |input| disabled_by_exclusivity?(input) }
+        .sort_by { |input| [-input.priority, input.key] }
+    end
+
+    # Internal: All inputs active in the scenario, including those which may later be considered
+    # disabled.
+    def all
+      @all ||= combined_values.map { |key, _| Input.get(key) }.compact
+    end
+
+    # Internal: All of the inputs values to be set; includes the values
+    # specified by the user, and any values from the balancer.
+    #
+    # Returns an hash.
+    def combined_values
+      @combined_values ||= @scenario.balanced_values.merge(@scenario.user_values)
+    end
+  end
+end

--- a/app/models/scenario/persistable.rb
+++ b/app/models/scenario/persistable.rb
@@ -10,10 +10,10 @@ module Scenario::Persistable
   #
   def reset!
     self.user_values = {}
-    # @inputs_present/future have to be nil, not an empty hash. otherwise
-    # the memoized def inputs_present will not pick up the changes.
-    @inputs_present  = nil
-    @inputs_future   = nil
+
+    # @inputs have to be nil, not an empty hash. otherwise
+    # the memoized inputs will not pick up the changes.
+    @inputs = nil
   end
 
   # Stores the current settings into the attributes. For when we want to save

--- a/app/models/scenario/user_updates.rb
+++ b/app/models/scenario/user_updates.rb
@@ -13,27 +13,9 @@
 module Scenario::UserUpdates
   extend ActiveSupport::Concern
 
-  # Inputs that run all the time and before the regular updates.
-  # These should not be stored in the user_values, because they
-  # will often change, by the researchers.
-  # The inputs get the end_year as value.
-  #
-  def inputs_before
-    unless @inputs_before
-      @inputs_before = {}
-      Input.before_inputs.each do |input|
-        @inputs_before[input] = self.end_year
-      end
-    end
-    @inputs_before
-  end
-
-  def inputs_present
-    @inputs_present ||= input_values_for_graph(:present)
-  end
-
-  def inputs_future
-    @inputs_future ||= input_values_for_graph(:future)
+  # Public: Returns a helper object for retrieving the user-specified values for the scenario.
+  def inputs
+    @inputs ||= Scenario::Inputs.new(self)
   end
 
   # This will process an {:input_id => :value} hash and update the inputs as needed
@@ -98,44 +80,10 @@ module Scenario::UserUpdates
     end
   end
 
+  private
+
   # Validation method for when a user sets their metadata.
   def validate_metadata_size
     errors.add(:metadata, 'can not exceed 64Kb') if metadata.to_s.bytesize > 64.kilobytes
   end
-
-  #######
-  private
-  #######
-
-  # Internal: The inputs for which the user - or balancer - has specified a
-  # value.
-  #
-  # Returns an array of inputs, in order of their execution priority.
-  def inputs
-    @inputs ||=
-      combined_values.map { |key, _| Input.get(key) }.
-      compact.sort_by { |input| [-input.priority, input.key] }
-  end
-
-  # Internal: A hash of inputs, and the values to be set on the named graph.
-  #
-  # name - The "name" of the graph for which you want values; :future or
-  #        :present.
-  #
-  # Returns a hash.
-  def input_values_for_graph(name)
-    inputs.select { |input| input.public_send(:"updates_#{ name }?") }.
-      each_with_object(Hash.new) do |input, hash|
-        hash[input] = combined_values[input.key]
-      end
-  end
-
-  # Internal: All of the inputs values to be set; includes the values
-  # specified by the user, and any values from the balancer.
-  #
-  # Returns an hash.
-  def combined_values
-    @combined_values ||= balanced_values.merge(user_values)
-  end
-
-end  # Input
+end

--- a/app/serializers/input_serializer.rb
+++ b/app/serializers/input_serializer.rb
@@ -52,26 +52,30 @@ class InputSerializer
   #   The Hash containing the input attributes.
   #
   def as_json(*)
-    json     = Hash.new
+    json = {}
+    values = Input.cache(@scenario.original).read(@scenario.original, @input)
 
-    values   = Input.cache(@scenario.original).read(@scenario.original, @input)
-
-    user_values      = @scenario.user_values
-    balanced_values  = @scenario.balanced_values
+    user_values = @scenario.user_values
+    balanced_values = @scenario.balanced_values
 
     user_val = user_values[@input.key] || balanced_values[@input.key]
 
-    json[:min]         = values[:min]
-    json[:max]         = values[:max]
-    json[:default]     = values[:default]
+    json[:min] = values[:min]
+    json[:max] = values[:max]
+    json[:default] = values[:default]
 
-    json[:user]        = user_val           if user_val.present?
-    json[:disabled]    = true               if values[:disabled]
-    json[:cache_error] = values[:error]     if values[:error]
+    json[:unit] = @input.unit
+
+    json[:user] = user_val if user_val.present?
+    json[:cache_error] = values[:error] if values[:error]
+
+    # An input is disabled if the cache says so, or if a mutually-exclusive input is present.
+    json[:disabled] = true if values[:disabled] || @scenario.inputs.disabled_by_exclusivity?(@input)
+    json[:disabled_by] = @input.disabled_by if @input.disabled_by.present?
 
     json[:share_group] = @input.share_group if @input.share_group.present?
 
-    if parent = @scenario.parent
+    if (parent = @scenario.parent)
       json[:default] =
         parent.user_values[@input.key] ||
         parent.balanced_values[@input.key] ||
@@ -81,12 +85,9 @@ class InputSerializer
     if @extra_attributes
       json[:step] = values[:step] || @input.step_value
       json[:code] = @input.key
-      json[:unit] = @input.unit
     end
 
-    if values[:label].present?
-      json[:label] = { value: values[:label], suffix: @input.label }
-    end
+    json[:label] = { value: values[:label], suffix: @input.label } if values[:label].present?
 
     json
   end
@@ -96,6 +97,8 @@ class InputSerializer
   # hashes for each and every input being presented.
   class IndifferentScenario
     attr_reader :original
+
+    delegate :inputs, to: :original
 
     def self.from(scenario)
       scenario.is_a?(self) ? scenario : new(scenario)

--- a/app/serializers/scenario_update_serializer.rb
+++ b/app/serializers/scenario_update_serializer.rb
@@ -83,9 +83,6 @@ class ScenarioUpdateSerializer
         present: present, future: future, unit: query.unit
       }
     end
-  rescue Exception => exception
-    # An error while setting up the graph.
-    @errors.push(([exception.message] + exception.backtrace).join("\n"))
   end
 
   # Performs an individual query.

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -23,10 +23,9 @@
 
 .row
   .span10
-    - {future: :inputs_future, present: :inputs_present}.each do |name, method|
+    - {future: @scenario.inputs.future, present: @scenario.inputs.present}.each do |name, inputs|
 
       %h3== Inputs #{name}
-      - inputs = @scenario.send(method)
       - if inputs.empty?
         %p No updates
       - else

--- a/spec/fixtures/etsource/inputs/both_input.ad
+++ b/spec/fixtures/etsource/inputs/both_input.ad
@@ -1,0 +1,6 @@
+- query =
+- priority = 1
+- update_period = both
+- min_value = 0.0
+- max_value = 100.0
+- start_value = 50.0

--- a/spec/fixtures/etsource/inputs/future_input.ad
+++ b/spec/fixtures/etsource/inputs/future_input.ad
@@ -1,0 +1,6 @@
+- query =
+- priority = 1
+- update_period = future
+- min_value = 0.0
+- max_value = 100.0
+- start_value = 50.0

--- a/spec/fixtures/etsource/inputs/mutually_exclusive/disabled_by_both.ad
+++ b/spec/fixtures/etsource/inputs/mutually_exclusive/disabled_by_both.ad
@@ -1,0 +1,7 @@
+- query =
+- priority = 1
+- update_period = both
+- min_value = 0.0
+- max_value = 100.0
+- start_value = 50.0
+- disabled_by = exclusive

--- a/spec/fixtures/etsource/inputs/mutually_exclusive/disabled_by_future.ad
+++ b/spec/fixtures/etsource/inputs/mutually_exclusive/disabled_by_future.ad
@@ -1,0 +1,7 @@
+- query =
+- priority = 1
+- update_period = future
+- min_value = 0.0
+- max_value = 100.0
+- start_value = 50.0
+- disabled_by = exclusive

--- a/spec/fixtures/etsource/inputs/mutually_exclusive/disabled_by_present.ad
+++ b/spec/fixtures/etsource/inputs/mutually_exclusive/disabled_by_present.ad
@@ -1,0 +1,7 @@
+- query =
+- priority = 1
+- update_period = present
+- min_value = 0.0
+- max_value = 100.0
+- start_value = 50.0
+- disabled_by = exclusive

--- a/spec/fixtures/etsource/inputs/mutually_exclusive/exclusive.ad
+++ b/spec/fixtures/etsource/inputs/mutually_exclusive/exclusive.ad
@@ -1,0 +1,6 @@
+- query =
+- priority = 1
+- update_period = future
+- min_value = 0.0
+- max_value = 100.0
+- start_value = 50.0

--- a/spec/fixtures/etsource/inputs/present_input.ad
+++ b/spec/fixtures/etsource/inputs/present_input.ad
@@ -1,0 +1,6 @@
+- query =
+- priority = 1
+- update_period = present
+- min_value = 0.0
+- max_value = 100.0
+- start_value = 50.0

--- a/spec/models/scenario/inputs_spec.rb
+++ b/spec/models/scenario/inputs_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Scenario::Inputs do
+  let(:scenario) { Scenario.new }
+  let(:inputs) { described_class.new(scenario) }
+
+  context 'when a scenario has no inputs' do
+    it 'has no before inputs' do
+      expect(inputs.before).to be_empty
+    end
+
+    it 'has no present inputs' do
+      expect(inputs.present).to be_empty
+    end
+
+    it 'has no future inputs' do
+      expect(inputs.future).to be_empty
+    end
+  end
+
+  context 'when a scenario has present and future inputs' do
+    before do
+      scenario.user_values = {
+        both_input: 100,   # both
+        present_input: 50, # present
+        future_input: 25   # future
+      }
+    end
+
+    it 'has two present inputs and their values' do
+      expect(inputs.present).to eq({
+        Input.get(:both_input) => 100,
+        Input.get(:present_input) => 50
+      })
+    end
+
+    it 'has two future inputs and their values' do
+      expect(inputs.future).to eq({
+        Input.get(:both_input) => 100,
+        Input.get(:future_input) => 25
+      })
+    end
+  end
+
+  context 'when a scenario has a mutually-exclusive input' do
+    before do
+      scenario.user_values = {
+        exclusive: 100,         # future, disables both and future
+        disabled_by_both: 50,   # both
+        disabled_by_future: 25, # future
+        input_2: 75             # future, not disabled
+      }
+    end
+
+    it 'has no present inputs' do
+      expect(inputs.present).to be_empty
+    end
+
+    it 'has no future inputs' do
+      expect(inputs.future).to eq({
+        Input.get(:exclusive) => 100,
+        Input.get(:input_2) => 75
+      })
+    end
+  end
+end

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -620,9 +620,7 @@ describe Scenario do
     end
 
     before(:each) do
-      scenario.inputs_present
-      scenario.inputs_future
-      scenario.inputs_before
+      scenario.inputs
       scenario.gql
     end
 
@@ -648,26 +646,16 @@ describe Scenario do
       expect(dup.id).to be_nil
     end
 
-    it 'does not clone inputs_present' do
-      expect(dup.inputs_present).to_not equal(scenario.inputs_present)
+    it 're-generates the same present inputs as for the original' do
+      expect(dup.inputs.present).to eq(scenario.inputs.present)
     end
 
-    it 'preserves inputs_present of the original' do
-      old_obj = scenario.inputs_present
-      dup
-      expect(scenario.inputs_present).to equal(old_obj)
+    it 're-generates the same present future as for the original' do
+      expect(dup.inputs.future).to eq(scenario.inputs.future)
     end
 
-    it 're-generates the same inputs_present as for the original' do
-      expect(dup.inputs_present).to eq(scenario.inputs_present)
-    end
-
-    it 'does not clone inputs_before' do
-      expect(dup.inputs_before).not_to equal(scenario.inputs_before)
-    end
-
-    it 'does not clone inputs_future' do
-      expect(dup.inputs_future).not_to equal(scenario.inputs_future)
+    it 'does not clone inputs' do
+      expect(dup.inputs).not_to equal(scenario.inputs)
     end
   end
 

--- a/spec/serializers/input_serializer_spec.rb
+++ b/spec/serializers/input_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe InputSerializer do
+  let(:scenario) { Scenario.default }
+  let(:json) { described_class.new(input, scenario, false).as_json }
+
+  context 'when the input is configured to be disabled by another' do
+    let(:input) { Input.get(:disabled_by_future) }
+
+    it 'contains the disabled_by key' do
+      expect(json[:disabled_by]).to eq(%w[exclusive])
+    end
+  end
+
+  context 'when the input is not configured be disabled by another' do
+    let(:input) { Input.get(:exclusive) }
+
+    it 'does not contain the disabled_by key' do
+      expect(json.key?(:disabled_by)).to be(false)
+    end
+  end
+
+  context 'when the input is disabled by a set mutually-exclusive input' do
+    let(:input) { Input.get(:disabled_by_future) }
+
+    context 'when the exclusive input has no value' do
+      it 'does not have a "disabled" key' do
+        expect(json.key?(:disabled)).to be(false)
+      end
+    end
+
+    context 'when the exclusive input has a value' do
+      before do
+        scenario.user_values = { exclusive: 1.0 }
+      end
+
+      it 'does not disable the input' do
+        expect(json[:disabled]).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is a companion to https://github.com/quintel/atlas/pull/150 which adds support for mutually-exclusive inputs. This allows us to disable one or more inputs when an "exclusive input" has a value set. Disabling an input means that:

- It is shown as disabled in the scenario's inputs.json.
- Any values set for that input are ignored by ETEngine.

If the value for the exclusive input is later removed by the user, the disabled inputs become enabled and any previously-set values once again take effect.

I refactored the handling of inputs in `Scenario` slightly. Previously we had methods on Scenario itself – `Scenario#inputs_before`, `Scenario#inputs_future`, etc – but have extracted these to a separate helper class. This helps reduce Scenario's responsibilities slightly, and makes it easier to check if an input is disabled.

The API has also been updated to indicate which inputs would become disabled when setting an exclusive input. [Preview documentation is available](https://deploy-preview-106--etm-docs.netlify.app/api/inputs#mutually-exclusive-inputs) describing the changes.