### PR TITLE
Add support for scenario metadata

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -260,12 +260,13 @@ module Api
         attrs = params.permit(scenario: [
           :area_code, :author, :country, :descale, :description, :end_year,
           :preset_scenario_id, :protected, :region, :scenario_id, :source,
-          :title, user_values: {}
+          :title, user_values: {}, metadata: {}
         ])
 
-        attrs = (attrs[:scenario] || {}).merge(
-          user_values: filtered_user_values(attrs[:scenario])
-        )
+        attrs = (attrs[:scenario] || {}).merge({
+          user_values: filtered_user_values(attrs[:scenario]),
+          metadata: filtered_metadata(attrs[:scenario])
+        })
 
         attrs[:descale] = attrs[:descale] == 'true'
 
@@ -282,6 +283,17 @@ module Api
           .permit!
           .to_h
           .with_indifferent_access
+      end
+
+      # Internal: All metadata for the scenario, filtered.
+      #
+      # Returns a ActionController::Parameters.
+      def filtered_metadata(scenario)
+        return {} unless scenario&.key?(:metadata)
+
+        scenario[:metadata]
+          .permit!
+          .to_h
       end
 
       # Internal: Attributes for creating a scaled scenario.

--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -263,10 +263,13 @@ module Api
           :title, user_values: {}, metadata: {}
         ])
 
-        attrs = (attrs[:scenario] || {}).merge({
-          user_values: filtered_user_values(attrs[:scenario]),
-          metadata: filtered_metadata(attrs[:scenario])
-        })
+        attrs = (attrs[:scenario] || {}).merge(
+          user_values: filtered_user_values(attrs[:scenario])
+        )
+
+        if attrs[:scenario]&.key?(:metadata)
+          attrs = attrs.merge(metadata: filtered_metadata(attrs[:scenario]))
+        end
 
         attrs[:descale] = attrs[:descale] == 'true'
 

--- a/app/models/api/v3/scenario_updater.rb
+++ b/app/models/api/v3/scenario_updater.rb
@@ -158,7 +158,7 @@ module Api
       end
 
       def validate_metadata_size
-        errors.add(:base, 'Metadata can not exceed 64Kb') if metadata.to_s.bytesize > 64_000
+        errors.add(:base, 'Metadata can not exceed 64Kb') if metadata.to_s.bytesize > 64.kilobytes
       end
 
       # User Values and Balancing --------------------------------------------

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -14,6 +14,7 @@ class Scenario < ApplicationRecord
 
   store :user_values
   store :balanced_values
+  store :metadata, coder: JSON
 
   belongs_to :user
   has_one    :preset_scenario, :foreign_key => 'preset_scenario_id', :class_name => 'Scenario'
@@ -37,6 +38,7 @@ class Scenario < ApplicationRecord
   }
 
   validate  :validate_no_yaml_error
+  validate  :validate_metadata_size
 
   validates_associated :scaler, on: :create
 

--- a/app/models/scenario/user_updates.rb
+++ b/app/models/scenario/user_updates.rb
@@ -100,7 +100,7 @@ module Scenario::UserUpdates
 
   # Validation method for when a user sets their metadata.
   def validate_metadata_size
-    errors.add(:metadata, 'can not exceed 64Kb') if metadata.to_s.bytesize > 64_000
+    errors.add(:metadata, 'can not exceed 64Kb') if metadata.to_s.bytesize > 64.kilobytes
   end
 
   #######

--- a/app/models/scenario/user_updates.rb
+++ b/app/models/scenario/user_updates.rb
@@ -98,6 +98,11 @@ module Scenario::UserUpdates
     end
   end
 
+  # Validation method for when a user sets their metadata.
+  def validate_metadata_size
+    errors.add(:metadata, 'can not exceed 64Kb') if metadata.to_s.bytesize > 64_000
+  end
+
   #######
   private
   #######

--- a/app/serializers/scenario_serializer.rb
+++ b/app/serializers/scenario_serializer.rb
@@ -36,6 +36,7 @@ class ScenarioSerializer < PresetSerializer
 
     if @detailed
       json[:user_values] = @resource.user_values
+      json[:metadata] = @resource.metadata
     else
       json.delete(:description)
     end

--- a/db/migrate/20220114094227_add_metadata_to_scenarios.rb
+++ b/db/migrate/20220114094227_add_metadata_to_scenarios.rb
@@ -1,0 +1,5 @@
+class AddMetadataToScenarios < ActiveRecord::Migration[5.2]
+  def change
+    add_column :scenarios, :metadata, :text, limit: 65535
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_14_084245) do
+ActiveRecord::Schema.define(version: 2022_01_14_094227) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2021_12_14_084245) do
     t.string "area_code"
     t.string "source"
     t.text "balanced_values", limit: 16777215
+    t.text "metadata"
     t.index ["created_at"], name: "index_scenarios_on_created_at"
   end
 

--- a/spec/controllers/api/v3/scenarios_controller_spec.rb
+++ b/spec/controllers/api/v3/scenarios_controller_spec.rb
@@ -96,5 +96,64 @@ describe Api::V3::ScenariosController do
       expect(@scenario.reload.area_code).to eq('nl')
     end
 
+    # The whole object should be overwritten
+    context 'when updating the metadata' do
+      before do
+        @scenario.metadata = { 'kittens' => 'milk', 'ctm_scenario_id' => 3445 }
+        put :update, params: {
+          id: @scenario.id,
+          scenario: { metadata: { kittens: 'mew', my_secret: [2, 3, 4] } }
+        }
+        response
+      end
+
+      it 'updates the old fields' do
+        expect(@scenario.reload.metadata['kittens']).to eq('mew')
+      end
+
+      it 'removes the fields that were already there' do
+        expect(@scenario.reload.metadata).not_to have_key('ctm_scenario_id')
+      end
+
+      it 'adds the new fields' do
+        expect(@scenario.reload.metadata).to have_key('my_secret')
+      end
+    end
+  end
+
+  describe 'POST create' do
+    context 'with supplied metadata' do
+      before do
+        post :create, params: { scenario: { area_code: 'nl', metadata: metadata } }
+      end
+
+      let(:metadata) { { ctm_scenario_id: 123 } }
+
+      it 'is successful' do
+        expect(response).to be_successful
+      end
+
+      it 'sets the metadata' do
+        scenario = Scenario.find(JSON.parse(response.body)['id'])
+        expect(scenario.metadata).to eq({ 'ctm_scenario_id' => '123' })
+      end
+
+      it 'makes the ctm_scenario_id available' do
+        scenario = Scenario.find(JSON.parse(response.body)['id'])
+        expect(scenario.metadata[:ctm_scenario_id]).to eq('123')
+      end
+
+      context 'when metadata is huge' do
+        let(:metadata) { (0..15_000).to_h { |i| [i, i] } }
+
+        it 'fails' do
+          expect(response).not_to be_successful
+        end
+
+        it 'gives an error message' do
+          expect(JSON.parse(response.body)['errors']).to have_key('metadata')
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/api/v3/scenarios_controller_spec.rb
+++ b/spec/controllers/api/v3/scenarios_controller_spec.rb
@@ -99,7 +99,7 @@ describe Api::V3::ScenariosController do
     # The whole object should be overwritten
     context 'when updating the metadata' do
       before do
-        @scenario.metadata = { 'kittens' => 'milk', 'ctm_scenario_id' => 3445 }
+        @scenario.update(metadata: { 'kittens' => 'milk', 'ctm_scenario_id' => '3445' })
         put :update, params: {
           id: @scenario.id,
           scenario: { metadata: { kittens: 'mew', my_secret: [2, 3, 4] } }
@@ -117,6 +117,24 @@ describe Api::V3::ScenariosController do
 
       it 'adds the new fields' do
         expect(@scenario.reload.metadata).to have_key('my_secret')
+      end
+    end
+
+    context 'when not supplying metadata' do
+      before do
+        @scenario.update(metadata: { 'kittens' => 'milk', 'ctm_scenario_id' => '3445' })
+        put :update, params: {
+          id: @scenario.id,
+          scenario: { user_values: { 'foo' => 56.0 } }
+        }
+      end
+
+      it 'is succesful' do
+        expect(response).to be_successful
+      end
+
+      it 'does not overwrite the current metadata' do
+        expect(@scenario.reload.metadata['ctm_scenario_id']).to eq('3445')
       end
     end
   end

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -757,4 +757,80 @@ describe Scenario do
         .to change(ActiveStorage::Blob, :count).by(-1)
     end
   end
+
+  describe '#metadata' do
+    let(:scenario) { described_class.new }
+
+    context 'with no metadata' do
+      it 'responds with nil when requesting a key' do
+        expect(scenario.metadata[:ctm_scenario_id]).to be_nil
+      end
+    end
+
+    context 'with empty metadata' do
+      before { scenario.metadata = {} }
+
+      it 'responds with nil when requesting a key' do
+        expect(scenario.metadata[:ctm_scenario_id]).to be_nil
+      end
+    end
+
+    context 'with metadata present' do
+      before { scenario.metadata = { ctm_scenario_id: 12_345, kittens: 'mew' } }
+
+      it 'stores numeric data' do
+        expect(scenario.metadata[:ctm_scenario_id]).to eq(12_345)
+      end
+
+      it 'stores string data' do
+        expect(scenario.metadata[:kittens]).to eq('mew')
+      end
+
+      it 'does not have metadata accesible by accessor' do
+        expect { scenario.kittens }.to raise_error(NoMethodError)
+      end
+    end
+
+    context 'when setting metadata' do
+      it 'permits JSON object' do
+        scenario.metadata = JSON.generate({})
+        expect(scenario.metadata).to eq({})
+      end
+
+      it 'permits a hash' do
+        scenario.metadata = {}
+        expect(scenario.metadata).to eq({})
+      end
+
+      it 'permits nil' do
+        scenario.metadata = nil
+        expect(scenario.metadata).to eq({})
+      end
+
+      it 'permits empty string' do
+        scenario.metadata = ''
+        expect(scenario.metadata).to eq({})
+      end
+
+      it 'denies objects larger than 64Kb' do
+        scenario.metadata = (0..15_000).to_h { |i| [i, i] }
+
+        expect(scenario).not_to be_valid
+      end
+    end
+
+    context 'when creating a clone of a scenario' do
+      before { scenario.metadata = { ctm_scenario_id: 12_345, kittens: 'mew' } }
+
+      let(:scenario_clone) { described_class.new(scenario_id: scenario.id) }
+
+      it 'keeps the original metadata' do
+        expect(scenario.metadata).not_to eq({})
+      end
+
+      it 'does not copy the metadata' do
+        expect(scenario_clone.metadata).to eq({})
+      end
+    end
+  end
 end

--- a/spec/serializers/scenario_serializer_spec.rb
+++ b/spec/serializers/scenario_serializer_spec.rb
@@ -42,6 +42,8 @@ describe ScenarioSerializer do
     it_should_behave_like 'a scenario serializer'
 
     it { is_expected.to include(description: 'Hello!') }
+
+    it { is_expected.to include(metadata: {}) }
   end
 
   context 'when "include_inputs=true"' do


### PR DESCRIPTION
Adds a metadata field to Scenario's.

The metadata field can be set through the scenario API enpoint by a user, and can contain any data in JSON format up to 64Kb. When a new metadata object is set through the API by a user, the old metadata object is overwritten. Users can view the metadata object by setting the `detailed` parameter to `true` in their API request (similar to viewing `user_values`).