### PR TITLE
Fix heat network following price-sensitive flex changes

### DIFF
--- a/app/models/qernel/merit_facade/flex_adapter.rb
+++ b/app/models/qernel/merit_facade/flex_adapter.rb
@@ -52,6 +52,9 @@ module Qernel
         attrs[:output_capacity_per_unit] = output_capacity
         attrs[:input_capacity_per_unit] = input_capacity
 
+        # We don't ever want heat flex technologies to consume from dispatchables.
+        attrs[:consume_from_dispatchables] = @context.attribute != :heat_network
+
         attrs
       end
 

--- a/app/models/qernel/merit_facade/user_defined_sorter.rb
+++ b/app/models/qernel/merit_facade/user_defined_sorter.rb
@@ -9,7 +9,7 @@ module Qernel
       end
 
       def cost(node, _config)
-        @order.index(node.key) || Float::INFINITY
+        (@order.index(node.key) || Float::INFINITY) + 1
       end
     end
   end


### PR DESCRIPTION
This PR fixes that heat storage was not behaving correctly following the addition of price-sensitive flex for electricity.

We (ab)use the marginal_costs attribute for heat network participants to sort them according to the user's choice. However, the first participant was assigned a cost of 0 which meant that it would never receive energy. This PR changes heat network participants to be assigned 1, 2, 3, ..., according to their order instead of 0, 1, 2, ... This ensures that the first option (normally storage) will be able to consume excess heat.

This commit also disables consumption from dispatchables, so that only excess is used by flex options.

Closes quintel/etsource#2627