### PR TITLE
Support availability curves for import and export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: '9aaa526', github: 'quintel/merit'
+gem 'quintel_merit', ref: 'dbbfc43', github: 'quintel/merit'
 
 gem 'atlas',         ref: '7ce81f0', github: 'quintel/atlas'
 gem 'fever',         ref: 'bf092b2', github: 'quintel/fever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: 9aaa526e8387dd81b072a18d6cf6a46620682544
-  ref: 9aaa526
+  revision: dbbfc4395dc49655f89c75fec78957e8fdd8d164
+  ref: dbbfc43
   specs:
     quintel_merit (0.1.0)
       numo-narray

--- a/app/controllers/api/v3/custom_curves_controller.rb
+++ b/app/controllers/api/v3/custom_curves_controller.rb
@@ -39,9 +39,25 @@ module Api
       # Sends the name of the current custom curve for the scenario, or an empty object if none is
       # set.
       #
+      # If the request wants CSV, the file contents will be sent.
+      #
       # GET /api/v3/scenarios/:scenario_id/custom_curves/:name
       def show
-        render json: attachment_json(current_attachment)
+        attachment = current_attachment
+
+        respond_to do |format|
+          format.csv do
+            send_data(
+              attachment.file.blob.download,
+              type: 'text/csv',
+              filename: "#{attachment.key}.#{attachment.scenario_id}.csv"
+            )
+          end
+
+          format.any do
+            render json: attachment_json(attachment)
+          end
+        end
       end
 
       # Creates or updates a custom curve for a scenario.
@@ -54,7 +70,7 @@ module Api
         if handler.valid?
           render json: attachment_json(handler.call)
         else
-          render json: errors_json(handler), status: 422
+          render json: errors_json(handler), status: :unprocessable_entity
         end
       end
 

--- a/app/models/curve_handler/config.rb
+++ b/app/models/curve_handler/config.rb
@@ -107,14 +107,16 @@ module CurveHandler
     # key given does not match a known processor.
     def processor
       case @processor_key
+      when :availability
+        Processors::Availability
+      when :capacity_profile
+        Processors::CapacityProfile
       when :generic
         Processors::Generic
       when :price
         Processors::Price
       when :profile
         Processors::Profile
-      when :capacity_profile
-        Processors::CapacityProfile
       when :temperature
         Processors::Temperature
       else
@@ -122,7 +124,7 @@ module CurveHandler
       end
     end
 
-    # Public: Returns the reudcer callable specified by the config. Raises an error if the reducer
+    # Public: Returns the reducer callable specified by the config. Raises an error if the reducer
     # given does not match a known processor.
     def reducer
       case @reducer_key

--- a/app/models/curve_handler/processors/availability.rb
+++ b/app/models/curve_handler/processors/availability.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module CurveHandler
+  module Processors
+    # Handles a curve where each value represents the availability of a producer or consumer. Each
+    # value is between 0 and 1.
+    class Availability < Generic
+      # Public: Processes the curve to clamp all values to 0..1.
+      def sanitized_curve
+        return nil unless valid?
+
+        @sanitized_curve ||= @curve.map { |value| value.clamp(0.0, 1.0) }
+      end
+    end
+  end
+end

--- a/app/models/qernel/dataset_curve_attributes.rb
+++ b/app/models/qernel/dataset_curve_attributes.rb
@@ -2,15 +2,28 @@ module Qernel
   module DatasetCurveAttributes
     def dataset_curve_reader(name)
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def #{name}
-          dataset_get(#{name.to_sym.inspect}) || []
-        end
+        def #{name}                                   # def availability_curve
+          dataset_get(#{name.to_sym.inspect}) || []   #   dataset_get(:availability_curve) || []
+        end                                           # end
+      RUBY
+    end
+
+    def dataset_curve_writer(name)
+      class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        def #{name}=(value)                           # def availability_curve=(value)
+          dataset_set(#{name.to_sym.inspect}, value)  #   dataset_set(:availability_curve, value)
+        end                                           # end
       RUBY
     end
 
     def dataset_carrier_curve_reader(carrier)
       dataset_curve_reader("#{carrier}_input_curve")
       dataset_curve_reader("#{carrier}_output_curve")
+    end
+
+    def dataset_curve_accessor(name)
+      dataset_curve_reader(name)
+      dataset_curve_writer(name)
     end
   end
 end

--- a/app/models/qernel/merit_facade/export_adapter.rb
+++ b/app/models/qernel/merit_facade/export_adapter.rb
@@ -5,6 +5,7 @@ module Qernel
     # Implements behaviour specific to the export interconnector.
     class ExportAdapter < FlexAdapter
       include OptionalCostCurve
+      include OptionalAvailabilityCurve
 
       def initialize(*)
         super
@@ -40,19 +41,20 @@ module Qernel
 
       private
 
+      def non_variable_availability_producer_class
+        Merit::Flex::Base
+      end
+
+      def variable_availability_producer_class
+        Merit::Flex::VariableConsumer
+      end
+
       def cost_strategy
         if cost_curve?
           Merit::CostStrategy::FromCurve.new(nil, cost_curve)
         else
           Merit::CostStrategy::Constant.new(nil, marginal_costs)
         end
-      end
-
-      def inner_consumer
-        @inner_consumer ||= Merit::User.create(
-          key: source_api.key,
-          load_curve: Merit::Curve.new([total_input_capacity] * Merit::POINTS)
-        )
       end
 
       # Internal: Creates the attributes for initializing the participant.

--- a/app/models/qernel/merit_facade/import_adapter.rb
+++ b/app/models/qernel/merit_facade/import_adapter.rb
@@ -5,6 +5,7 @@ module Qernel
     # Implements behaviour specific to the import interconnector.
     class ImportAdapter < ProducerAdapter
       include OptionalCostCurve
+      include OptionalAvailabilityCurve
 
       def initialize(*)
         super
@@ -38,8 +39,12 @@ module Qernel
 
       private
 
-      def producer_class
+      def non_variable_availability_producer_class
         Merit::DispatchableProducer
+      end
+
+      def variable_availability_producer_class
+        Merit::VariableDispatchableProducer
       end
 
       def output_capacity_per_unit

--- a/app/models/qernel/merit_facade/optional_availability_curve.rb
+++ b/app/models/qernel/merit_facade/optional_availability_curve.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Qernel
+  module MeritFacade
+    # A module builder which can be used to support availability curves on a Merit participant.
+    #
+    # Merit itself supports this only on a few participant types, and generally requires that you
+    # use one of these over the more general participants. The module therefore requires that you
+    # name the alternate class to be used when an availability curve is set.
+    #
+    # For example, if an import participant is normally specified with a DispatchableProducer, it
+    # might use a VariableDispatchableProducer when an availability curve is present. The adapter
+    # would be defined like so:
+    #
+    #   class ImportAdapter
+    #     include OptionalAvailabilityCurve.new(Merit::VariableDispatchableProducer)
+    #
+    #     private
+    #
+    #     def producer_class
+    #       Merit::DispatchableProducer
+    #     end
+    #   end
+    module OptionalAvailabilityCurve
+      def producer_attributes
+        attrs = super
+
+        if availability_curve?
+          attrs[:availability] = Merit::Curve.new(@context.curves.rotate(availability_curve))
+        end
+
+        attrs
+      end
+
+      def producer_class
+        if availability_curve?
+          variable_availability_producer_class
+        else
+          non_variable_availability_producer_class
+        end
+      end
+
+      def inject!
+        super
+
+        if availability_curve?
+          target_api.availability = availability_curve.sum / availability_curve.length
+        end
+      end
+
+      private
+
+      def variable_availability_producer_class
+        raise NotImplementedError
+      end
+
+      def availability_curve?
+        availability_curve&.any?
+      end
+
+      def availability_curve
+        source_api.availability_curve
+      end
+    end
+  end
+end

--- a/app/models/qernel/node_api/base.rb
+++ b/app/models/qernel/node_api/base.rb
@@ -62,9 +62,14 @@ module Qernel
         storage
       ]
 
+      # Curves which may be set by an external source.
+      dataset_curve_accessor :availability_curve
+      dataset_curve_accessor :marginal_cost_curve
+
+      # Curves set by Causality.
       dataset_curve_reader :curtailment_output_curve
-      dataset_curve_reader :marginal_cost_curve
       dataset_curve_reader :storage_curve
+
       dataset_carrier_curve_reader :electricity
       dataset_carrier_curve_reader :hydrogen
       dataset_carrier_curve_reader :heat

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -19,5 +19,6 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'ETEngine'
   inflect.acronym 'HHP' # Hybrid heat pump
   inflect.irregular 'serie', 'series'
+  inflect.irregular 'curve', 'curves'
 end
 # rubocop:enable Style/MethodCallWithArgsParentheses

--- a/spec/requests/api/v3/custom_curve_spec.rb
+++ b/spec/requests/api/v3/custom_curve_spec.rb
@@ -175,6 +175,34 @@ describe 'Custom curves', :etsource_fixture do
       end
     end
 
+    context 'when downloading a curve as CSV' do
+      before do
+        put url, params: {
+          file: fixture_file_upload('price_curve.csv', 'text/csv')
+        }
+
+        get(url, headers: { 'Accept' => 'text/csv' })
+      end
+
+      it 'succeeds' do
+        expect(response).to be_successful
+      end
+
+      it 'sends back CSV data about the curve' do
+        expect(response.body.strip).to eq(File.read('spec/fixtures/files/price_curve.csv').strip)
+      end
+    end
+
+    context 'when downloading an unattached curve as CSV' do
+      before do
+        get(url, headers: { 'Accept' => 'text/csv' })
+      end
+
+      it 'response with Not Found' do
+        expect(response).to be_not_found
+      end
+    end
+
     context 'when uploading a valid curve file' do
       let(:request) do
         put url, params: {


### PR DESCRIPTION
When an `availability_curve` is set on an electricity import or export node it will be used instead of the `availability` attribute. The [corresponding ETModel PR](https://github.com/quintel/etmodel/pull/3953/files) allows users to upload these files in addition to being able to upload them through the API.

I've also tackled an outstanding request to enable downloading custom curves. This was discussed in a sprint meeting last week, and it was decided that since scenarios are already public there's no reason to prevent users from downloading the curves.