### PR TITLE
Update the MeritConfigSerializer

### DIFF
--- a/app/serializers/merit_config_serializer.rb
+++ b/app/serializers/merit_config_serializer.rb
@@ -1,35 +1,38 @@
 # Creates JSON with the data necessary to run the merit order externally.
 #
-# The JSON contains two keys: "profiles" and "participants". The latter
+# The JSON contains two keys: "curves" and "participants". The latter
 # contains an array of hashes describing each producer which may be
-# included. Instead of duplicating the load profiles, each participant
-# specifies a "key" specifying the profile to use from the "profiles" hash.
+# included. Instead of duplicating the load curves, each participant
+# specifies a "key" specifying the profile to use from the "curves" hash.
 #
 # For example:
 #
 #   {
-#     "profiles": { "profile_1": [1, 2, ...] },
+#     "curves": { "curve_1": [1, 2, ...] },
 #     "participants": [
-#       { "key": "parti_1", "profile": "profile_1" },
-#       { "key": "parti_2", "profile": "profile_1" },
+#       { "key": "parti_1", "curve": "curve_1" },
+#       { "key": "parti_2", "curve": "curve_1" },
 #     ]
 #   }
 class MeritConfigSerializer
   # Keys which should be included for each participant.
-  DISPATCHABLE_KEYS = %w(
+  DISPATCHABLE_KEYS = %i[
     key marginal_costs output_capacity_per_unit number_of_units
     availability fixed_costs_per_unit fixed_om_costs_per_unit
-  ).map(&:to_sym).freeze
+  ].freeze
 
-  # TODO: how will we handle the new cost calculations?
   FLEX_KEYS = %i[
     key marginal_costs input_capacity_per_unit output_capacity_per_unit
     number_of_units
   ].freeze
 
+  STORAGE_KEYS = %i[
+    volume_per_unit input_efficiency output_efficiency reserve_class decay
+  ].freeze
+
   USER_KEYS = %i[
     key
-  ]
+  ].freeze
 
   # Public: Creates a new serializer. Requires a copy of the Qernel::Graph
   # from which it can retrieve information about each participant. Typically
@@ -41,34 +44,19 @@ class MeritConfigSerializer
   # Public: Creates a hash with the merit order data.
   def as_json(*)
     @manager = Qernel::MeritFacade::Manager.new(@graph)
-    data  = { profiles: {}, participants: [] }
-    area  = Atlas::Dataset.find(@graph.area.area_code)
+    @area = Atlas::Dataset.find(@graph.area.area_code)
+    data = { curves: {}, participants: [] }
 
-    # TODO: refactor these three in something more generic
-    @manager.order.participants.producers.each do |producer|
-      data[:participants].push(participant_data(producer)) if include_participant?(producer)
+    # Add participant data
+    participants.each do |participant|
+      data[:participants].push(participant_data(participant)) if include_participant?(participant)
     end.compact
 
-    # TODO: add interconnector price curves if there is one
-    @manager.order.participants.flex.each do |flex|
-      data[:participants].push(participant_data(flex)) if include_participant?(flex)
-    end.compact
+    # Add curves
+    data[:participants].pluck(:curve).uniq.compact.each do |joined_curve_key|
+      next unless joined_curve_key
 
-    @manager.order.participants.users.each do |user|
-      data[:participants].push(participant_data(user)) if include_user?(user)
-    end
-
-    data[:participants].pluck(:profile).uniq.compact.each do |profile_key|
-      next unless profile_key
-
-      participant, profile = profile_key.split('.', 2)
-
-      data[:profiles][profile_key] ||=
-        if participant && profile # dynamic curve
-          @manager.curves.curve(profile, @graph.node(participant).node_api).to_a
-        else
-          area.load_profile(profile_key).to_a
-        end
+      data[:curves][joined_curve_key] ||= curve_data(joined_curve_key)
     end
 
     data
@@ -76,29 +64,68 @@ class MeritConfigSerializer
 
   private
 
+  # Internal: All elegible participants from Merit
+  def participants
+    @manager.order.participants.producers + @manager.order.participants.flex +
+      @manager.order.participants.users
+  end
+
   def participant_data(participant)
     data = {
-      profile:  profile_key(participant),
-      type:     participant_type(participant)
+      curve:  curve_key(participant),
+      type:   participant_type(participant)
     }
 
     attribute_keys(data).each_with_object(data) do |key, hash|
       hash[key] =
         if key == :total_consumption
           @manager.adapters[participant.key].input_of_carrier
-        else
+        elsif participant.respond_to?(key)
           format_value(participant.public_send(key))
         end
     end
   end
 
-  def profile_key(participant)
-    key = load_profile_key(participant)
-    key&.start_with?('dynamic', 'weather', 'fever') ? "#{participant.key}.#{key}" : key
+  # Internal: Returns the key of the curve that should accompany the participant. Multiple
+  # participants can have the same key. Most curves are load profiles, but for interconnectors
+  # the price curve is used.
+  #
+  # Returns the curve key
+  def curve_key(participant)
+    if participant.key.to_s.include?('interconnector')
+      interconnector_price_curve_key(participant)
+    else
+      key = load_profile_key(participant)
+      key&.start_with?('dynamic', 'weather', 'fever') ? "#{participant.key}.#{key}" : key
+    end
   end
 
   def load_profile_key(participant)
     @graph.node(participant.key).node_api.load_profile_key
+  end
+
+  def interconnector_price_curve_key(participant)
+    return if @graph.node(participant.key).node_api.marginal_cost_curve.empty?
+
+    "#{participant.key}.marginal_cost_curve"
+  end
+
+  # Internal: splits the joined participant.curve key if possible, and determines the way on how
+  # to access the curve data. For dynamic, fever and weather curves, the MeritFacadeManagers
+  # curveset is used. The interconnectors use the general node API, and the standard curves
+  # come directly from the area.
+  #
+  # Returns the curve as an array
+  def curve_data(joined_key)
+    participant_key, curve_name = joined_key.split('.', 2)
+
+    if curve_name == 'marginal_cost_curve' # interconnector
+      @graph.node(participant_key).node_api.marginal_cost_curve
+    elsif participant_key && curve_name # dynamic curve
+      @manager.curves.curve(curve_name, @graph.node(participant_key).node_api).to_a
+    else
+      @area.load_profile(joined_key).to_a
+    end
   end
 
   def participant_type(participant)
@@ -110,14 +137,14 @@ class MeritConfigSerializer
     if data[:type] == 'generic'
       FLEX_KEYS
     elsif data[:type] == 'storage'
-      FLEX_KEYS + [:volume_per_unit]
+      FLEX_KEYS + STORAGE_KEYS
     elsif data[:type] == 'total_consumption'
       USER_KEYS + [:total_consumption]
     elsif data[:type] == 'with_curve'
       USER_KEYS + [:load_curve]
     elsif data[:type] == 'consumption_loss'
       USER_KEYS + [:consumption_share]
-    elsif data[:profile].present?
+    elsif data[:curve].present?
       DISPATCHABLE_KEYS + [:full_load_hours]
     else
       DISPATCHABLE_KEYS
@@ -125,14 +152,10 @@ class MeritConfigSerializer
   end
 
   def include_participant?(participant)
+    return true if participant.is_a?(Merit::User)
     return false unless participant.number_of_units.positive?
     return false if participant.is_a?(Merit::Flex::BlackHole)
 
-    true
-  end
-
-  # TODO: specify which users should be included
-  def include_user?(user)
     true
   end
 


### PR DESCRIPTION
Adds support for dynamic curves to the `MeritConfigSerializer`, and now also incorporates `Merit::Users`, and most flex options. Except from the interconnectors, the curves that accompany the participants are load profiles. For interconnectors it's their price curve.

Little slow, but does its job.