### PR TITLE
Make curves optional in the Merit config serializer

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -29,7 +29,9 @@ module Api
       # information about each producer in the scenario, and the load profiles.
       #
       def merit
-        render json: MeritConfigSerializer.new(@scenario.gql.future_graph)
+        render json: MeritConfigSerializer.new(
+          @scenario.gql.future_graph, include_curves: include_curves_in_merit?
+        )
       end
 
       # GET /api/v3/scenarios/:id1,:id2,:id3,...,:id20/batch
@@ -326,6 +328,20 @@ module Api
             :has_agriculture, :has_energy, :has_industry
           )
         end
+      end
+
+      # Internal: Parameters for the merit config
+      #
+      # Returns a ActionController::Parameters.
+      def merit_parameters
+        params.permit(:include_curves)
+      end
+
+      # Internal: Checks if curves should be included in the merit config
+      #
+      # Returns a Bool
+      def include_curves_in_merit?
+        merit_parameters[:include_curves] != 'false'
       end
 
       # Internal: Wraps an action with information about a scenario, so that if

--- a/spec/controllers/api/v3/scenarios_controller_spec.rb
+++ b/spec/controllers/api/v3/scenarios_controller_spec.rb
@@ -189,4 +189,29 @@ describe Api::V3::ScenariosController do
       end
     end
   end
+
+  describe 'GET merit' do
+    context 'with no extra settings' do
+      before { get :merit,  params: { id: scenario.id } }
+
+      it 'returns the merit config' do
+        expect(response).to be_successful
+      end
+
+      it 'includes curves and participants' do
+        parsed = JSON.parse(response.body)
+        expect(parsed.keys).to include('curves', 'participants')
+      end
+    end
+
+    context 'with include_curves=false' do
+      it 'does not include curves' do
+        get :merit, params: { id: scenario.id, include_curves: false }
+
+        parsed = JSON.parse(response.body)
+
+        expect(parsed.keys).not_to include('curves')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The merit API endpoint on scenarios now takes an optional parameter called `include_curves` which can be set to `false` if you don't want the curves that should go into Merit be part of the response.

The response time feels a bit quicker but not _that_ much..

Closes #1254 

@robcalon I also removed the extra curves from the `with_curve` participants in this PR. Thanks for spotting that one!