### PR TITLE
Resolve double-counting final demand industry in ETM-CTM coupling

### DIFF
--- a/app/helpers/inspect_helper.rb
+++ b/app/helpers/inspect_helper.rb
@@ -97,7 +97,7 @@ module InspectHelper
   # Since the group table has been dropped we need to fetch the list from ETSource
   def node_groups(graph)
     Rails.cache.fetch("#{graph.name}_node_group_list") do
-      graph.nodes.flat_map(&:groups).sort.uniq
+      graph.nodes.flat_map { |n| n.groups.to_a }.sort.uniq
     end
   end
 

--- a/app/models/qernel/graph.rb
+++ b/app/models/qernel/graph.rb
@@ -286,7 +286,7 @@ class Graph
 
   # Return the node with given key.
   #
-  # @param id [Integer,String] lookup key for node
+  # @param id [String, Symbol] lookup key for node
   # @return [Node]
   #
   def node(id)

--- a/app/models/qernel/node.rb
+++ b/app/models/qernel/node.rb
@@ -127,7 +127,7 @@ class Node
 
     @id         = opts[:id] || Hashpipe.hash(opts[:key])
     @key        = opts[:key]
-    @groups     = opts[:groups] || []
+    @groups     = Set.new(opts[:groups] || [])
     @use_key    = opts[:use_id]
     @sector_key = opts[:sector_id]
     @presentation_group = opts[:presentation_group]

--- a/spec/models/qernel/recursive_factor/primary_co2_spec.rb
+++ b/spec/models/qernel/recursive_factor/primary_co2_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       subject { graph.node(:left) }
 
       it { is_expected.to have_query_value(:primary_co2_emission, 50) }
+      it { is_expected.to have_query_value(:primary_co2_emission_of_fossil, 50) }
       it { is_expected.to have_query_value(:primary_demand_of_sustainable, 25) }
       it { is_expected.to have_query_value(:primary_demand_of_fossil, 75) }
       it { is_expected.to have_query_value(:sustainability_share, 0.25) }
@@ -62,6 +63,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       subject { graph.node(:left) }
 
       it { is_expected.to have_query_value(:primary_co2_emission, 0) }
+      it { is_expected.to have_query_value(:primary_co2_emission_of_fossil, 0) }
       it { is_expected.to have_query_value(:primary_demand_of_sustainable, 0) }
       it { is_expected.to have_query_value(:primary_demand_of_fossil, 0) }
       it { is_expected.to have_query_value(:sustainability_share, 0.25) }
@@ -96,6 +98,7 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
       subject { graph.node(:left) }
 
       it { is_expected.to have_query_value(:primary_co2_emission, 50) }
+      it { is_expected.to have_query_value(:primary_co2_emission_of_fossil, 50) }
       it { is_expected.to have_query_value(:primary_demand_of_sustainable, 0) }
       it { is_expected.to have_query_value(:primary_demand_of_fossil, 0) }
       it { is_expected.to have_query_value(:sustainability_share, 0.25) }

--- a/spec/models/qernel/recursive_factor/primary_co2_spec.rb
+++ b/spec/models/qernel/recursive_factor/primary_co2_spec.rb
@@ -53,6 +53,73 @@ RSpec.describe Qernel::RecursiveFactor::PrimaryCo2 do
     end
   end
 
+  context 'when the right node does not belong to the PD group' do
+    before do
+      builder.node(:right).set(:groups, [])
+    end
+
+    describe 'the left node' do
+      subject { graph.node(:left) }
+
+      it { is_expected.to have_query_value(:primary_co2_emission, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_sustainable, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_fossil, 0) }
+      it { is_expected.to have_query_value(:sustainability_share, 0.25) }
+    end
+
+    describe 'the middle node' do
+      subject { graph.node(:middle) }
+
+      it { is_expected.to have_query_value(:primary_co2_emission, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_sustainable, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_fossil, 0) }
+      it { is_expected.to have_query_value(:sustainability_share, 0.25) }
+    end
+
+    describe 'the right node' do
+      subject { graph.node(:right) }
+
+      it { is_expected.to have_query_value(:primary_co2_emission, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_sustainable, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_fossil, 0) }
+      it { is_expected.to have_query_value(:sustainability_share, 0.25) }
+    end
+  end
+
+  context 'when the right node does not belong to the PD group, but does belong to ' \
+          'include_primary_co2' do
+    before do
+      builder.node(:right).set(:groups, [:force_primary_co2])
+    end
+
+    describe 'the left node' do
+      subject { graph.node(:left) }
+
+      it { is_expected.to have_query_value(:primary_co2_emission, 50) }
+      it { is_expected.to have_query_value(:primary_demand_of_sustainable, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_fossil, 0) }
+      it { is_expected.to have_query_value(:sustainability_share, 0.25) }
+    end
+
+    describe 'the middle node' do
+      subject { graph.node(:middle) }
+
+      it { is_expected.to have_query_value(:primary_co2_emission, 50) }
+      it { is_expected.to have_query_value(:primary_demand_of_sustainable, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_fossil, 0) }
+      it { is_expected.to have_query_value(:sustainability_share, 0.25) }
+    end
+
+    describe 'the right node' do
+      subject { graph.node(:right) }
+
+      it { is_expected.to have_query_value(:primary_co2_emission, 50) }
+      it { is_expected.to have_query_value(:primary_demand_of_sustainable, 0) }
+      it { is_expected.to have_query_value(:primary_demand_of_fossil, 0) }
+      it { is_expected.to have_query_value(:sustainability_share, 0.25) }
+    end
+  end
+
   describe 'when the right node has free_co2_factor=0.5' do
     before do
       builder.node(:right).set(:free_co2_factor, 0.5)

--- a/spec/support_specs/from_refinery_spec.rb
+++ b/spec/support_specs/from_refinery_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe FromRefinery do
     end
 
     it 'sets the groups on A1' do
-      expect(graph.node(:a1).groups).to eq(%w[one two three])
+      expect(graph.node(:a1).groups).to eq(Set.new(%w[one two three]))
     end
   end
 


### PR DESCRIPTION
This PR adds support for the node group `force_primary_co2`. 

_"This will ensure that the node does not contribute to primary demand, but will contribute to primary_co2_emission, primary_co2_emission_of_fossil, primary_co2_emission_without_capture, etc."_