### PR TITLE
Set various industry CHP inputs using electricity capacity

### DIFF
--- a/db/migrate/20220825115850_convert_chp_heat_inputs_to_electricity.rb
+++ b/db/migrate/20220825115850_convert_chp_heat_inputs_to_electricity.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'etengine/scenario_migration'
+
+# Updates various industry capacity input values to set electricity output rather than heat output.
+#
+# See https://github.com/quintel/etsource/issues/2716
+class ConvertChpHeatInputsToElectricity < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  INPUTS = {
+    capacity_of_industry_chp_combined_cycle_gas_power_fuelmix:
+      :industry_chp_combined_cycle_gas_power_fuelmix,
+    capacity_of_industry_chp_engine_gas_power_fuelmix:
+      :industry_chp_engine_gas_power_fuelmix,
+    capacity_of_industry_chp_turbine_gas_power_fuelmix:
+      :industry_chp_turbine_gas_power_fuelmix,
+    capacity_of_industry_chp_ultra_supercritical_coal:
+      :industry_chp_ultra_supercritical_coal,
+    capacity_of_industry_chp_wood_pellets:
+      :industry_chp_wood_pellets
+  }
+
+  def up
+    migrate_scenarios do |scenario|
+      INPUTS.each do |input, node|
+        value = scenario.user_values[input]
+
+        next if value.nil? || !value.is_a?(Numeric) || value.zero?
+
+        scenario.user_values[input] = relative_efficiency(scenario.area_code, input) * value
+      end
+    end
+  end
+
+  private
+
+  # Internal: Returns the relative efficiency (electricity / heat) for the node which is updated by
+  # the given input key.
+  #
+  # If there are values in the cache, they will be read. Otherwise, we calculate values for all the
+  # inputs/nodes and store them in the cache for use by other scenarios.
+  def relative_efficiency(dataset, input)
+    @values_cache ||= {}
+    @values_cache[dataset] ||= create_values(dataset)
+
+    @values_cache[dataset][input]
+  end
+
+  def create_values(dataset)
+    say("Calculating values for #{dataset}", :subitem)
+
+    graph = Scenario.default(area_code: dataset).gql.present.graph
+
+    INPUTS.each_with_object({}) do |(input, node), hash|
+      node = graph.node(node).query
+
+      hash[input] = (
+        node.query.electricity_output_conversion / #
+        node.query.steam_hot_water_output_conversion
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_04_084323) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_25_115850) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/lib/etengine/scenario_migration.rb
+++ b/lib/etengine/scenario_migration.rb
@@ -31,10 +31,14 @@ module ETEngine
       total = collection.count
       changed = 0
 
-      say "#{total} candidate scenarios for migration"
+      say("#{total} candidate scenarios for migration")
 
       collection.find_each.with_index do |scenario, index|
-        yield(scenario)
+        begin
+          yield(scenario)
+        rescue Psych::DisallowedClass
+          say("Skipping #{scenario.id} - invalid YAML", true)
+        end
 
         if scenario.changed?
           scenario.save(validate: false, touch: false)
@@ -42,11 +46,11 @@ module ETEngine
         end
 
         if index.positive? && ((index + 1) % 1000).zero?
-          say "#{index + 1}/#{total} (#{changed} migrated)"
+          say("#{index + 1}/#{total} (#{changed} migrated)")
         end
       end
 
-      say "#{total}/#{total} (#{changed} migrated)"
+      say("#{total}/#{total} (#{changed} migrated)")
 
       # With continuous deployment, it might go unnoticed if no scenarios are
       # migrated. If the developer knows that zero migrated scenarios is an


### PR DESCRIPTION
Currently, five industry CHPs have their total capacity set by setting the heat output capacity. This will be changed soon in ETSource and ETModel to set the total capacity using the electricity output capacity.

This pull request updates the stored user values to the (normally higher) electricity capacity. These values are dataset-dependent, so the migration will calculate each dataset the first time it encounters it and stores the values to be reused by later scenarios in the migration.

⚠️ **Don't merge this yet!** This PR needs to be paired with a corresponding change in ETSource.

@noracato: If you have the time, a code review would be appreciated.
@marliekeverweij: Will you merge this when you have the ETSource changes ready?

---

Ref quintel/etsource#2716
Closes quintel/etsource#2735
See https://3.basecamp.com/3797409/buckets/24616302/todos/5249810906