### PR TITLE
Fix incorrect FLH for flex technologies

### DIFF
--- a/app/models/qernel/merit_facade/flex_adapter.rb
+++ b/app/models/qernel/merit_facade/flex_adapter.rb
@@ -103,7 +103,7 @@ module Qernel
 
       # Internal: Sets demand and related attributes on the target API.
       def inject_demand!
-        full_load_hours = participant.full_load_hours / input_efficiency
+        full_load_hours = participant.full_load_hours
 
         full_load_seconds =
           if !full_load_hours || full_load_hours.nan?
@@ -116,7 +116,7 @@ module Qernel
         target_api[:full_load_seconds] = full_load_seconds
 
         target_api.demand =
-          full_load_seconds *
+          (full_load_seconds / input_efficiency) *
           participant.input_capacity_per_unit *
           participant.number_of_units
       end


### PR DESCRIPTION
Fixes incorrect FLH assigned to flex technologies when their electricity input conversion is not 1.0.

The problem was that merit calculates the FLH of each participant based on its demand for electricity and input efficiency. We were wrongly dividing that by the input efficiency _again_ when assigning the value back to the node.

I tested with the II3050 National scenario described in #1271 and, fortunately, the only merit order participant affected is the P2H heat pump. All other flex technologies in that scenario were unaffected and had the correct FLH already assigned.

Closes #1271