### PR TITLE
Don't set el. input curve on battery park outputs

### DIFF
--- a/app/models/qernel/merit_facade/always_on_battery_park_adapter.rb
+++ b/app/models/qernel/merit_facade/always_on_battery_park_adapter.rb
@@ -93,10 +93,6 @@ module Qernel
         # Output node
         # -----------
 
-        output_node.dataset_lazy_set(:electricity_input_curve) do
-          @context.curves.derotate(@park.output_curve)
-        end
-
         output_node.dataset_lazy_set(:electricity_output_curve) do
           @context.curves.derotate(@park.output_curve)
         end


### PR DESCRIPTION
Prevents the node from being included twice in the merit_order.csv file.

Ref #1283