### PR TITLE
Bump Merit to quintel/merit@c504a27

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: 'ef8106a', github: 'quintel/merit'
+gem 'quintel_merit', ref: 'c504a27', github: 'quintel/merit'
 
 gem 'atlas',         ref: '7ce81f0', github: 'quintel/atlas'
 gem 'fever',         ref: 'bf092b2', github: 'quintel/fever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: ef8106acd7307567fe1b4c31639ca3f4e559a3e0
-  ref: ef8106a
+  revision: c504a2704741837e8ce1ce1baa1b1b71114e0890
+  ref: c504a27
   specs:
     quintel_merit (0.1.0)
       numo-narray


### PR DESCRIPTION
Fixes that flexible load shifting would sometimes return a negative number when querying how much capacity was available for load shifting. This would result in erroneous blackout hours.

Closes #1284