### PR TITLE
Add analysis of flexibility on different timescales

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -151,6 +151,7 @@ Style/MethodCallWithArgsParentheses:
   - puts
   - raise
   - render
+  - render_serializer
   - require
   - require_dependency
   - require_relative

--- a/app/controllers/api/v3/curves_controller.rb
+++ b/app/controllers/api/v3/curves_controller.rb
@@ -113,6 +113,17 @@ module Api
         )
       end
 
+      # Downloads the residual loads of various carriers.
+      #
+      # GET /api/v3/scenarios/:scenario_id/curves/residual_load.csv
+      def residual_load
+        render_serializer QueryCurveCSVSerializer.new(
+          Etsource::Config.residual_load_csv,
+          @scenario.gql,
+          'residual_load'
+        )
+      end
+
       private
 
       def merit_required

--- a/app/models/etsource/config.rb
+++ b/app/models/etsource/config.rb
@@ -57,6 +57,13 @@ module Etsource
       read('sankey_csv')
     end
 
+    # Public: Contains a configuration for the residual load CSV export.
+    #
+    # Returns an array of hashes.
+    def residual_load_csv
+      read('residual_load_csv').map(&:symbolize_keys)
+    end
+
     # Public: Reads the hash of curves for which users may upload a custom curve.
     #
     # Returns a Hash of {String => CurveHandler::Config}.

--- a/app/models/gql/runtime/functions/constants.rb
+++ b/app/models/gql/runtime/functions/constants.rb
@@ -19,6 +19,7 @@ module Gql::Runtime
       #NIL = nil if !defined?(NIL)
       EURO_SIGN = '&euro;'
       MONTHS_PER_YEAR = 12.0
+      INFINITY = Float::INFINITY
 
 
       # 2011-12-09 GQL grammar does not allow "." inside V(...; ___ ).

--- a/app/models/gql/runtime/functions/curves.rb
+++ b/app/models/gql/runtime/functions/curves.rb
@@ -21,6 +21,28 @@ module Gql::Runtime
         Merit::Curve.reader.read(path)
       end
 
+      # Public: Restricts the values in a curve to be between the minimum and maximum. Raises an
+      # error if min > max.
+      #
+      # Returns an array.
+      def CLAMP_CURVE(curve, min, max)
+        unless min.is_a?(Numeric)
+          raise ArgumentError, "CLAMP_CURVE: min must be numeric, was #{min.inspect}"
+        end
+
+        unless max.is_a?(Numeric)
+          raise ArgumentError, "CLAMP_CURVE: max must be numeric, was #{max.inspect}"
+        end
+
+        if min >= max
+          raise ArgumentError, "CLAMP_CURVE: min must be less than max, was #{min} > #{max}"
+        end
+
+        return [] if curve.blank?
+
+        curve.map { |value| value.clamp(min, max) }
+      end
+
       # Public: If the given `curve` is an array of non-zero length, it is
       # returned. If the curve is nil or empty, a new curve of `length` length
       # is created, with each value set to `default`.

--- a/app/serializers/causality_curves_csv_serializer.rb
+++ b/app/serializers/causality_curves_csv_serializer.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# The CSV contains the key of each node and the direction of energy
+# flow (input or output) and the hourly load in MWh.
+class CausalityCurvesCSVSerializer
+  # Provides support for multiple carriers in the serializer.
+  class Adapter
+    attr_reader :attribute
+
+    def initialize(carrier, attribute)
+      @carrier = carrier.to_sym
+      @attribute = attribute.to_sym
+    end
+
+    def supported?(graph)
+      Qernel::Plugins::Causality.enabled?(graph)
+    end
+
+    def nodes(graph)
+      graph.nodes.select(&@attribute)
+    end
+
+    def node_curve(node, direction)
+      node.node_api.public_send("#{@carrier}_#{direction}_curve")
+    end
+
+    def node_config(node)
+      node.public_send(@attribute)
+    end
+  end
+
+  def initialize(graph, carrier, attribute = carrier)
+    @graph = graph
+    @adapter = Adapter.new(carrier, attribute)
+  end
+
+  # Used as the name of the CSV file when sent to the user. Omit the file
+  # extension.
+  def filename
+    @adapter.attribute
+  end
+
+  # Public: Creates an array of rows for a CSV file containing the loads of
+  # hydrogen producers and consumers.
+  #
+  # Returns an array of arrays.
+  def to_csv_rows
+    # Empty CSV if time-resolved calculations are not enabled.
+    unless @adapter.supported?(@graph)
+      return [['Merit order and time-resolved calculation are not ' \
+               'enabled for this scenario']]
+    end
+
+    CurvesCSVSerializer.new(
+      [*producer_columns, *consumer_columns, *extra_columns],
+      @graph.year,
+      ''
+    ).to_csv_rows
+  end
+
+  private
+
+  def producer_columns
+    producers.map { |node| column_from_node(node, :output) }
+  end
+
+  def consumer_columns
+    consumers.map { |node| column_from_node(node, :input) }
+  end
+
+  def extra_columns
+    []
+  end
+
+  def producers
+    nodes_of_type(producer_types).select do |producer|
+      @adapter.node_curve(producer, :output)&.any?
+    end
+  end
+
+  def consumers
+    nodes_of_type(consumer_types) do |consumer|
+      @adapter.node_curve(consumer, :output)&.any?
+    end
+  end
+
+  # Internal: Creates a column representing data for a node's energy
+  # flows in a chosen direction.
+  def column_from_node(node, direction)
+    {
+      name: "#{node.key}.#{direction} (MW)",
+      curve: @adapter.node_curve(node, direction).map { |v| v.round(4) }
+    }
+  end
+
+  def nodes_of_type(types)
+    @adapter.nodes(@graph)
+      .select { |c| types.include?(@adapter.node_config(c).type) }
+      .sort_by(&:key)
+  end
+end

--- a/app/serializers/merit_csv_serializer.rb
+++ b/app/serializers/merit_csv_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Creates CSV rows describing merit order production and consumption.
-class MeritCSVSerializer < CurvesCSVSerializer
+class MeritCSVSerializer < CausalityCurvesCSVSerializer
   # Selects extra nodes to be included in or excluded from the CSV,
   # based on groups assigned to nodes.
   class NodeCustomisation
@@ -86,6 +86,6 @@ class MeritCSVSerializer < CurvesCSVSerializer
         (amount - production[index]).round(4)
       end
 
-    ['deficit', *deficit]
+    { name: 'deficit', curve: deficit }
   end
 end

--- a/app/serializers/query_curve_csv_serializer.rb
+++ b/app/serializers/query_curve_csv_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Queries the graph to extract curves and serializes the results as a CSV.
+class QueryCurveCSVSerializer
+  attr_reader :filename
+
+  def initialize(config, gql, filename)
+    @config   = config
+    @gql      = gql
+    @filename = filename
+  end
+
+  def to_csv_rows
+    curves = @config.map do |curve_config|
+      {
+        name: curve_config[:name],
+        curve: @gql.future.subquery(curve_config[:query])
+      }
+    end
+
+    CurvesCSVSerializer.new(curves, @gql.future.graph.year, @filename).to_csv_rows
+  end
+end

--- a/app/serializers/reconciliation_csv_serializer.rb
+++ b/app/serializers/reconciliation_csv_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Creates CSV rows describing hydrogen production.
-class ReconciliationCSVSerializer < CurvesCSVSerializer
+class ReconciliationCSVSerializer < CausalityCurvesCSVSerializer
   private
 
   def producer_types

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -17,6 +17,7 @@ MILLIONS = 10.0**6
 THOUSANDS = 1000.0
 #NIL = nil if !defined?(NIL)
 EURO_SIGN = '&euro;'
+INFINITY = Float::INFINITY
 
 # Periods in which peak loads are measured: sd = summer day, se = summer
 # evening, wd = winter day, we = winter evening.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,10 @@ Rails.application.routes.draw do
         get 'curves/network_gas',
           to: 'curves#network_gas',
           as: :curves_network_gas_download
+
+        get 'curves/residual_load',
+          to: 'curves#residual_load',
+          as: :curves_residual_load_download
       end
 
       resources :inputs, :only => [:index, :show] do

--- a/spec/models/gql/runtime/functions/curve_spec.rb
+++ b/spec/models/gql/runtime/functions/curve_spec.rb
@@ -267,5 +267,80 @@ module Gql::Runtime::Functions
         expect(result).to eq([3.5, 3.5, 3.5, 3.5, 3.5, 3.5])
       end
     end
+
+    # CLAMP_CURVE
+    # -----------
+
+    describe 'CLAMP_CURVE(nil, 0, 2)' do
+      it 'returns []' do
+        expect(result).to eq([])
+      end
+    end
+
+    describe 'CLAMP_CURVE([], 0, 2)' do
+      it 'returns []' do
+        expect(result).to eq([])
+      end
+    end
+
+    describe 'CLAMP_CURVE([], 2, 0)' do
+      it 'raises an error' do
+        expect { result }.to raise_error(/min must be less than max, was 2 > 0/)
+      end
+    end
+
+    describe 'CLAMP_CURVE([], 2, 2)' do
+      it 'raises an error' do
+        expect { result }.to raise_error(/min must be less than max, was 2 > 2/)
+      end
+    end
+
+    describe 'CLAMP_CURVE([], INFINITY, -INFINITY)' do
+      it 'raises an error' do
+        expect { result }.to raise_error(/min must be less than max, was Infinity > -Infinity/)
+      end
+    end
+
+    describe 'CLAMP_CURVE([], nil, INFINITY)' do
+      it 'raises an error' do
+        expect { result }.to raise_error(/min must be numeric, was nil/)
+      end
+    end
+
+    describe 'CLAMP_CURVE([], 0, "oops")' do
+      it 'raises an error' do
+        expect { result }.to raise_error(/max must be numeric, was "oops"/)
+      end
+    end
+
+    describe 'CLAMP_CURVE([-1, 0, 1, 2, 3, 4], 2, INFINITY)' do
+      it 'returns [2, 2, 2, 2, 3, 4]' do
+        expect(result).to eq([2, 2, 2, 2, 3, 4])
+      end
+    end
+
+    describe 'CLAMP_CURVE([-1, 0, -1, 2, -3, 4], 0, INFINITY)' do
+      it 'returns [0, 0, 0, 2, 0, 4]' do
+        expect(result).to eq([0, 0, 0, 2, 0, 4])
+      end
+    end
+
+    describe 'CLAMP_CURVE([-1, 0, -1, 2, -3, 4], -1, INFINITY)' do
+      it 'returns [-1, 0, -1, 2, -1, 4]' do
+        expect(result).to eq([-1, 0, -1, 2, -1, 4])
+      end
+    end
+
+    describe 'CLAMP_CURVE([-1, 0, -1, 2, -3, 4], -INFINITY, 0)' do
+      it 'returns [-1, 0, -1, 0, -3, 0]' do
+        expect(result).to eq([-1, 0, -1, 0, -3, 0])
+      end
+    end
+
+    describe 'CLAMP_CURVE([-1, 0, -1, 2, -3, 4], -INFINITY, INFINITY)' do
+      it 'returns [-1, 0, -1, 2, -3, 4]' do
+        expect(result).to eq([-1, 0, -1, 2, -3, 4])
+      end
+    end
   end
 end

--- a/spec/serializers/curves_csv_serializer_spec.rb
+++ b/spec/serializers/curves_csv_serializer_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CurvesCSVSerializer do
+  let(:serializer) { described_class.new(curves, 2050, 'mine.csv') }
+
+  context 'when given a valid config' do
+    let(:curves) do
+      [
+        { name: 'Query one',   curve: [1, 2, 3] + ([0] * 8757) },
+        { name: 'Query two',   curve: [4, 5, 6] + ([0] * 8757) },
+        { name: 'Query three', curve: [7, 8, 9] + ([0] * 8757) }
+      ]
+    end
+
+    it 'includes the CSV headers' do
+      expect(serializer.to_csv_rows[0]).to eq(['Time', 'Query one', 'Query two', 'Query three'])
+    end
+
+    it 'includes the first row' do
+      expect(serializer.to_csv_rows[1]).to eq(['2050-01-01 00:00', 1, 4, 7])
+    end
+
+    it 'includes the second row' do
+      expect(serializer.to_csv_rows[2]).to eq(['2050-01-01 01:00', 2, 5, 8])
+    end
+
+    it 'includes the third row' do
+      expect(serializer.to_csv_rows[3]).to eq(['2050-01-01 02:00', 3, 6, 9])
+    end
+
+    it 'creates a CSV' do
+      expect(serializer.as_csv.lines.take(4)).to eq([
+        "Time,Query one,Query two,Query three\n",
+        "2050-01-01 00:00,1,4,7\n",
+        "2050-01-01 01:00,2,5,8\n",
+        "2050-01-01 02:00,3,6,9\n"
+      ])
+    end
+  end
+
+  context 'when given an empty curve' do
+    let(:curves) do
+      [
+        { name: 'Query one', curve: [1, 2, 3] + ([0] * 8757) },
+        { name: 'Query two', curve: [] }
+      ]
+    end
+
+    it 'includes the CSV headers' do
+      expect(serializer.to_csv_rows[0]).to eq(['Time', 'Query one', 'Query two'])
+    end
+
+    it 'includes the first row' do
+      expect(serializer.to_csv_rows[1]).to eq(['2050-01-01 00:00', 1, 0])
+    end
+
+    it 'includes the second row' do
+      expect(serializer.to_csv_rows[2]).to eq(['2050-01-01 01:00', 2, 0])
+    end
+
+    it 'includes the third row' do
+      expect(serializer.to_csv_rows[3]).to eq(['2050-01-01 02:00', 3, 0])
+    end
+
+    it 'creates a CSV' do
+      expect(serializer.as_csv.lines.take(4)).to eq([
+        "Time,Query one,Query two\n",
+        "2050-01-01 00:00,1,0\n",
+        "2050-01-01 01:00,2,0\n",
+        "2050-01-01 02:00,3,0\n"
+      ])
+    end
+  end
+
+  context 'when given a curve that is nil' do
+    let(:curves) do
+      [
+        { name: 'Query one', curve: [1, 2, 3] + ([0] * 8757) },
+        { name: 'Query two', curve: nil }
+      ]
+    end
+
+    it 'includes the CSV headers' do
+      expect(serializer.to_csv_rows[0]).to eq(['Time', 'Query one', 'Query two'])
+    end
+
+    it 'includes the first row' do
+      expect(serializer.to_csv_rows[1]).to eq(['2050-01-01 00:00', 1, 0])
+    end
+
+    it 'includes the second row' do
+      expect(serializer.to_csv_rows[2]).to eq(['2050-01-01 01:00', 2, 0])
+    end
+
+    it 'includes the third row' do
+      expect(serializer.to_csv_rows[3]).to eq(['2050-01-01 02:00', 3, 0])
+    end
+
+    it 'creates a CSV' do
+      expect(serializer.as_csv.lines.take(4)).to eq([
+        "Time,Query one,Query two\n",
+        "2050-01-01 00:00,1,0\n",
+        "2050-01-01 01:00,2,0\n",
+        "2050-01-01 02:00,3,0\n"
+      ])
+    end
+  end
+end

--- a/spec/serializers/query_curve_csv_serializer_spec.rb
+++ b/spec/serializers/query_curve_csv_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe QueryCurveCSVSerializer do
       {
         name: 'Query two',
         query: 'query_2'
-      },
+      }
     ]
   end
 

--- a/spec/serializers/query_curve_csv_serializer_spec.rb
+++ b/spec/serializers/query_curve_csv_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe QueryCurveCSVSerializer do
+  let(:config) do
+    [
+      {
+        name: 'Query one',
+        query: 'query_1'
+      },
+      {
+        name: 'Query two',
+        query: 'query_2'
+      },
+    ]
+  end
+
+  let(:query_1) { Gquery.new(query: '[1, 2] * 4380', unit: 'curve') }
+  let(:query_2) { Gquery.new(query: '[3, 4] * 4380', unit: 'curve') }
+
+  let(:serializer) { described_class.new(config, Scenario.default.gql, 'export.csv') }
+
+  before do
+    allow(Gquery).to receive(:get).with('query_1').and_return(query_1)
+    allow(Gquery).to receive(:get).with('query_2').and_return(query_2)
+  end
+
+  # ------------------------------------------------------------------------------------------------
+
+  context 'when given a valid config' do
+    it 'includes the CSV headers' do
+      expect(serializer.to_csv_rows[0]).to eq(['Time', 'Query one', 'Query two'])
+    end
+
+    it 'includes the first row' do
+      expect(serializer.to_csv_rows[1]).to eq(['2050-01-01 00:00', 1, 3])
+    end
+
+    it 'includes the second row' do
+      expect(serializer.to_csv_rows[2]).to eq(['2050-01-01 01:00', 2, 4])
+    end
+  end
+end


### PR DESCRIPTION
This PR enables the analysis of the need for flexibility on a short and long timescale. It does so for hydrogen and network gas by applying a moving average to the residual load curves. The resulting curves are analysed in a new table.

This goes with:

- ETSource: https://github.com/quintel/etsource/pull/2797
- ETModel: https://github.com/quintel/etmodel/pull/4027