### PR TITLE
Update SMR capacity in scenarios

### DIFF
--- a/db/migrate/20221108095859_update_smr_capacity.rb
+++ b/db/migrate/20221108095859_update_smr_capacity.rb
@@ -1,0 +1,29 @@
+require 'etengine/scenario_migration'
+
+# The full load hours of the SMR have been updated from 7500 to 8322. For 7500 was no source in
+# ETDataset and the 8322 is based on this datasheet
+#
+# This migration scales SMRs in existing scenarios to account for the change.
+#
+# See https://github.com/quintel/etengine/issues/1292
+class UpdateSmrCapacity < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  def up
+    do_migrate(7500.0 / 8322.0)
+  end
+
+  def down
+    do_migrate(8322.0 / 7500.0)
+  end
+
+  private
+
+  def do_migrate(multiplier)
+    migrate_scenarios do |scenario|
+      if scenario.user_values.key?(:capacity_of_energy_hydrogen_steam_methane_reformer)
+        scenario.user_values[:capacity_of_energy_hydrogen_steam_methane_reformer] *= multiplier
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_26_130938) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_08_095859) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
Updates the capacity of steam methane reformers to account for changes in the datasets.

Closes #1292