### PR TITLE
Fix price set to VoLL when the most expensive dispatchable is used to meet flexible demand

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: 'c504a27', github: 'quintel/merit'
+gem 'quintel_merit', ref: '280cb72', github: 'quintel/merit'
 
 gem 'atlas',         ref: '7ce81f0', github: 'quintel/atlas'
 gem 'fever',         ref: 'bf092b2', github: 'quintel/fever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: c504a2704741837e8ce1ce1baa1b1b71114e0890
-  ref: c504a27
+  revision: 280cb72ce8d427746f36e78832366ba9fd2bb5a3
+  ref: 280cb72
   specs:
     quintel_merit (0.1.0)
       numo-narray


### PR DESCRIPTION
Merit has been adjusted so that the price is only set to €3000 when there is insufficient capacity to meet _inflexible_ demand. Previously, if the most expensive dispatchable/flexible producer was fully-loaded, we'd treat that as a deficit. That's not correct as we now have flexible consumers; it's possible for the most expensive dispatchable to be fully loaded without this being a loss of load event.

These screenshots were taken from a local scenario, and may not exactly match the version on production. In my scenario, the number of hours at €3000 exactly matches the number of blackout hours (which is to be expected since a blackout is inflexible demand > production).

| Before | After |
| :---: | :---: |
| ![b-1](https://user-images.githubusercontent.com/4383/201157645-08f492d4-7e16-4ced-99b8-ebf7b4f068f6.png) | ![a-1](https://user-images.githubusercontent.com/4383/201157656-3177782d-e698-43fc-a386-02bb3d5a96ff.png) |
| ![b-2](https://user-images.githubusercontent.com/4383/201157695-74ddcb32-c475-43bd-b1f2-92e1f69a2d87.png) | ![a-2](https://user-images.githubusercontent.com/4383/201157702-9f88498b-3f6f-435e-bb71-971a8f5faef8.png) |
| ![b-3](https://user-images.githubusercontent.com/4383/201157712-6fab3e5b-9251-4426-8ce5-c80412813f6d.png) | ![a-3](https://user-images.githubusercontent.com/4383/201157725-47136b12-0c24-41c8-9876-ddc7fb118b43.png) |
| ![b-jan](https://user-images.githubusercontent.com/4383/201157739-53116870-6a57-4dab-9243-69e462d19ccc.png) | ![a-jan](https://user-images.githubusercontent.com/4383/201157753-19f5f7b5-0aed-49f5-82ac-0ec8c64fa8b8.png) |

Closes #1286