### PR TITLE
Remove aggregate inputs

### DIFF
--- a/db/migrate/20230125153925_remove_redundant_aggregate_inputs.rb
+++ b/db/migrate/20230125153925_remove_redundant_aggregate_inputs.rb
@@ -11,9 +11,9 @@ class RemoveRedundantAggregateInputs < ActiveRecord::Migration[7.0]
 
 
   def up
-    migrate_scenarios(since: Date.new(2021, 1, 1)) do |scenario|
+    migrate_scenarios(since: Date.new(2022, 1, 1)) do |scenario|
       REDUNDANT_AGGREGATE_KEYS.each do |key|
-        scenario.user_values.delete(key)
+        scenario.user_values.delete(key) if scenario.user_values.include? key
       end
     end
   end

--- a/db/migrate/20230125153925_remove_redundant_aggregate_inputs.rb
+++ b/db/migrate/20230125153925_remove_redundant_aggregate_inputs.rb
@@ -1,0 +1,20 @@
+require 'etengine/scenario_migration'
+
+class RemoveRedundantAggregateInputs < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  REDUNDANT_AGGREGATE_KEYS = %w[
+    industry_useful_demand_for_chemical_aggregated_industry
+    industry_useful_demand_for_chemical_aggregated_industry_electricity_efficiency
+    industry_useful_demand_for_chemical_aggregated_industry_useable_heat_efficiency
+  ].freeze
+
+
+  def up
+    migrate_scenarios(since: Date.new(2021, 1, 1)) do |scenario|
+      REDUNDANT_AGGREGATE_KEYS.each do |key|
+        scenario.user_values.delete(key)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_13_121420) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_25_153925) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -188,23 +188,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_13_121420) do
     t.index ["user_id"], name: "index_staff_applications_on_user_id"
   end
 
-  create_table "transition_path_scenarios", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "transition_path_id"
-    t.integer "scenario_id", null: false
-    t.index ["scenario_id"], name: "index_transition_path_scenarios_on_scenario_id"
-    t.index ["transition_path_id"], name: "index_transition_path_scenarios_on_transition_path_id"
-  end
-
-  create_table "transition_paths", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "owner_id", null: false
-    t.string "title", null: false
-    t.integer "source_scenario_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["owner_id"], name: "fk_rails_e4d384d760"
-    t.index ["source_scenario_id"], name: "fk_rails_464d59c95d"
-  end
-
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -247,8 +230,4 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_13_121420) do
   add_foreign_key "scenarios", "users", column: "owner_id"
   add_foreign_key "staff_applications", "oauth_applications", column: "application_id"
   add_foreign_key "staff_applications", "users"
-  add_foreign_key "transition_path_scenarios", "scenarios"
-  add_foreign_key "transition_path_scenarios", "transition_paths"
-  add_foreign_key "transition_paths", "scenarios", column: "source_scenario_id", on_delete: :nullify
-  add_foreign_key "transition_paths", "users", column: "owner_id", on_delete: :cascade
 end


### PR DESCRIPTION
This migration concerns the following keys:

- [industry_useful_demand_for_chemical_aggregated_industry](https://github.com/quintel/etsource/blob/master/inputs/demand/industry/industry_useful_demand_for_chemical_aggregated_industry.ad)
- [industry_useful_demand_for_chemical_aggregated_industry_electricity_efficiency](https://github.com/quintel/etsource/blob/master/inputs/demand/industry/industry_useful_demand_for_chemical_aggregated_industry_electricity_efficiency.ad)
- [industry_useful_demand_for_chemical_aggregated_industry_useable_heat_efficiency](https://github.com/quintel/etsource/blob/master/inputs/demand/industry/industry_useful_demand_for_chemical_aggregated_industry_useable_heat_efficiency.ad)

These keys stem from a time when the fertilizer sector was not explicitly modelled for every dataset. This was the case in datasets where `has_aggregated_chemical_industry = true`.

When these aggregate inputs are set in combination with the individual inputs of the fertilizer and other chemical sector however, the demand from the fertilizer sector goes to 0. This is not intentional and can present problems for scenarios where these inputs have been set. 

Since all datasets currently have an explicit fertilizer sector and the aggregate inputs are not accessible in the frontend, we want to remove the aggregate inputs from all recent scenarios (>2021). We can then remove the inputs from ETSource altogether.

@noracato when I check the presence of each slider in migratable scenarios I get 682, 1564 and 1564 cases. However, when I run the migration I get 7663 migrated scenarios. Could you look into this to see where this difference comes from?

Merging is on hold until cleared by ENTSO.