### PR TITLE
Updates to the costs data-export

### DIFF
--- a/app/serializers/costs_parameters_serializer.rb
+++ b/app/serializers/costs_parameters_serializer.rb
@@ -147,7 +147,8 @@ class CostsParametersSerializer
   # If no subgroup was supplied, gets the query with the name of the main group
   def group_total_row(group, subgroup = nil)
     query = subgroup ? "#{group}_#{subgroup}" : group.to_s
-    query_row(group, subgroup, query, 'Total')
+    subgroup_name = subgroup ? subgroup : 'Group total'
+    query_row(group, subgroup_name, query, 'Total')
   end
 
   # Internal: Returns a row based on a query.

--- a/app/serializers/costs_parameters_serializer.rb
+++ b/app/serializers/costs_parameters_serializer.rb
@@ -21,7 +21,7 @@ class CostsParametersSerializer
       costs_infrastructure_heat
     ],
     costs_infrastructure_hydrogen: %w[
-      costs_infrastructure_hydrogen
+      
     ],
     costs_infrastructure_network_gas: %w[
       gas_network_total_costs

--- a/app/serializers/costs_parameters_serializer.rb
+++ b/app/serializers/costs_parameters_serializer.rb
@@ -240,7 +240,7 @@ class CostsParametersSerializer
   # This group only needs subtotal group queries
   def costs_carriers
     %w[biomass oil_and_products coal_and_products uranium heat natural_gas waste
-       electricity hydrogen]
+       electricity hydrogen ammonia]
   end
 
   # Internal: Carriers for which the costs_infrastructure group is valid

--- a/app/serializers/costs_parameters_serializer.rb
+++ b/app/serializers/costs_parameters_serializer.rb
@@ -27,10 +27,10 @@ class CostsParametersSerializer
       gas_network_total_costs
     ],
     costs_co2_molecule_nodes: %w[
-      costs_co2_ccs
+      costs_co2_energy_graph
     ],
     costs_co2_energy_nodes: %w[
-      costs_co2_ccs
+      costs_molecule_graph
     ]
   }.freeze
 

--- a/app/serializers/costs_parameters_serializer.rb
+++ b/app/serializers/costs_parameters_serializer.rb
@@ -18,7 +18,7 @@ class CostsParametersSerializer
       total_costs_of_electricity_network_calculation
     ],
     costs_infrastructure_heat: %w[
-      heat_infrastructure_total_annualised_costs
+      costs_infrastructure_heat
     ],
     costs_infrastructure_hydrogen: %w[
       costs_infrastructure_hydrogen

--- a/spec/serializers/costs_parameters_serializer_spec.rb
+++ b/spec/serializers/costs_parameters_serializer_spec.rb
@@ -9,9 +9,9 @@ describe CostsParametersSerializer do
 
   let(:scenario) { FactoryBot.create(:scenario) }
 
-  it 'has 39 rows' do
-    # 10 queries, 6 totals, 23 subtotals = 39 rows minimum (when no nodes in groups)
-    expect(subject.length).to eq(39)
+  it 'has 40 rows' do
+    # 10 queries, 6 totals, 24 subtotals = 40 rows minimum (when no nodes in groups)
+    expect(subject.length).to eq(40)
   end
 
   it 'has a row for each node' do

--- a/spec/serializers/costs_parameters_serializer_spec.rb
+++ b/spec/serializers/costs_parameters_serializer_spec.rb
@@ -9,9 +9,9 @@ describe CostsParametersSerializer do
 
   let(:scenario) { FactoryBot.create(:scenario) }
 
-  it 'has 31 rows' do
-    # 10 queries, 6 totals, 24 subtotals = 40 rows minimum (when no nodes in groups)
-    expect(subject.length).to eq(40)
+  it 'has 39 rows' do
+    # 10 queries, 6 totals, 23 subtotals = 39 rows minimum (when no nodes in groups)
+    expect(subject.length).to eq(39)
   end
 
   it 'has a row for each node' do


### PR DESCRIPTION
There are a number of issues with the costs data-export, as described in https://github.com/quintel/etsource/issues/2859:

Goes with https://github.com/quintel/etsource/pull/2860

Fixes include the following:

- Structure of totals is changed slightly so that Group totals are clearly defined
- Hydrogen storage costs is now assigned the right query, so that a value is displayed
- CO2 costs are now assigned the right queries, so that values are displayed
- Heat infrastructure costs query is now assigned the right query, so that double-counting with the heat storage costs is avoided
- Hydrogen infrastructure costs total query is now removed from the data-export, so that double-counting with the two underlying queries that are also in the data-export is avoided

Fixes do **not** include the following:

- All CCS costs are included in the CO2 costs queries in the row "Total ex ccs". Conceptually this does not make sense and it should be addressed