### PR TITLE
Add CSV data export of storage technologies parameters

### DIFF
--- a/app/controllers/api/v3/export_controller.rb
+++ b/app/controllers/api/v3/export_controller.rb
@@ -53,6 +53,17 @@ module Api
         )
       end
 
+      # GET /api/v3/scenarios/:id/storage_parameters
+      #
+      # Creates a CSV by reading a configuration file from ETSource consisting of literal values and
+      # queries to be executed.
+      def storage_parameters
+        send_csv(
+          ConfiguredCSVSerializer.new(Etsource::Config.storage_parameters_csv, @scenario.gql),
+          'storage_parameters.%d.csv'
+        )
+      end
+
       # GET /api/v3/scenarios/:id/costs_parameters
       #
       # Returns a CSV file containing the cost paramaters of nodes belonging to costs groups.

--- a/app/models/etsource/config.rb
+++ b/app/models/etsource/config.rb
@@ -64,6 +64,16 @@ module Etsource
       read('sankey_csv')
     end
 
+    # Public: Contains a configuration for the storage parameters CSV export.
+    #
+    # See ConfiguredCSVSerializer.
+    #
+    # Returns a hash.
+    def storage_parameters_csv
+      read('storage_parameters_csv')
+    end
+
+
     # Public: Contains a configuration for the residual load CSV export.
     #
     # Returns an array of hashes.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
           get :molecule_flow, to: 'export#molecule_flow'
           get :costs_parameters, to: 'export#costs_parameters'
           get :sankey, to: 'export#sankey'
+          get :storage_parameters, to: 'export#storage_parameters'
           get :merit
           put :dashboard
           post :interpolate


### PR DESCRIPTION
The data export contains for each storage technology for electricity, hydrogen, network gas and heat on the district heating the following parameters:

- Energy input
- Energy output
- Energy losses
- Storage volume
- Installed input capacity
- Installed output capacity
- Peak input capacity
- Peak output capacity

See for reference [Documentation of Storage parameters data-export.xlsx](https://github.com/quintel/etengine/files/11027008/Documentation.of.Storage.parameters.data-export.xlsx)

Goes with https://github.com/quintel/etsource/pull/2862 and https://github.com/quintel/etmodel/pull/4091