### PR TITLE
Allow updating ESDL file attachment on a scenario

### DIFF
--- a/app/models/file_upload_handler.rb
+++ b/app/models/file_upload_handler.rb
@@ -18,7 +18,7 @@ class FileUploadHandler
 
   # Public: attaches the file to the scenario as content type xml
   def call
-    attachment = ScenarioAttachment.create!(key: @key, scenario: @scenario)
+    attachment = update_or_create_attachment
 
     attachment.file.attach(
       io: @file,
@@ -30,11 +30,6 @@ class FileUploadHandler
   def valid?
     @errors = []
 
-    if @scenario.attachments.find_by(key: @key)
-      @errors.push("This scenario already has a file of type #{@key} attached.")
-      return false
-    end
-
     unless ScenarioAttachment.valid_non_curve_keys.include?(@key)
       @errors.push("This handler cannot attach files of type #{@key}.")
     end
@@ -45,5 +40,17 @@ class FileUploadHandler
     end
 
     @errors.none?
+  end
+
+  private
+
+  def current_attachment
+    return @current_attachment if defined?(@current_attachment)
+
+    @current_attatchment = @scenario.attachments.find_by(key: @key)
+  end
+
+  def update_or_create_attachment
+    current_attachment || ScenarioAttachment.create!(key: @key, scenario: @scenario)
   end
 end

--- a/spec/models/file_upload_handler_spec.rb
+++ b/spec/models/file_upload_handler_spec.rb
@@ -12,8 +12,8 @@ describe 'FileUploadHandler' do
 
     before { file_handler.call }
 
-    it 'is not valid' do
-      expect(file_handler).not_to be_valid
+    it 'replaces the file' do
+      expect(file_handler).to be_valid
     end
   end
 


### PR DESCRIPTION
I found we were explicitly not allowing updating the file. @redekok do you remember why we chose to do that? 

This PR allows for the file to be updated through the ESDL files API endpoint.

Closes #1334 
References quintel/etm-esdl#94