### PR TITLE
Coupling transparancy: show coupling of scenario, inputs and uncouple

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'ruby-progressbar'
 # own gems
 gem 'quintel_merit', ref: 'c722536', github: 'quintel/merit'
 
-gem 'atlas',         ref: '0dad20e', github: 'quintel/atlas'
+gem 'atlas',         ref: '6ea3589', github: 'quintel/atlas'
 gem 'fever',         ref: 'bf092b2', github: 'quintel/fever'
 gem 'refinery',      ref: '72eacf8', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 0dad20efae3fb80447eb867ed2fb25e9d8de7b05
-  ref: 0dad20e
+  revision: 6ea35897d4ad2a841da9166ac093efe310752944
+  ref: 6ea3589
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -304,7 +304,7 @@ module Api
       # Returns a ActionController::Parameters
       def filtered_params
         params.permit(
-          :autobalance, :force, :reset, gqueries: []
+          :autobalance, :force, :reset, :coupling, gqueries: []
         ).merge(scenario: scenario_params)
       end
 

--- a/app/models/input.rb
+++ b/app/models/input.rb
@@ -27,6 +27,10 @@ class Input
     all.select { |input| input.coupling_groups.present? }
   end
 
+  def self.coupling_groups_for(q)
+    Input.by_name(q).flat_map(&:coupling_groups)
+  end
+
   def self.by_name(q)
     q.present? ? all.select{|input| input.key.include?(q)} : all
   end
@@ -60,6 +64,10 @@ class Input
 
   def disabled_by=(disabled_by)
     @disabled_by = Array(disabled_by).map { |key| key.to_s.freeze }.freeze
+  end
+
+  def disabled_by_coupling_groups
+    disabled_by.flat_map { |i| Input.coupling_groups_for(i) }.uniq
   end
 
   def before_update?

--- a/app/models/input.rb
+++ b/app/models/input.rb
@@ -23,6 +23,10 @@ class Input
     all.select{|input| input.share_group == q}
   end
 
+  def self.with_coupling_group
+    all.select { |input| input.coupling_groups.present? }
+  end
+
   def self.by_name(q)
     q.present? ? all.select{|input| input.key.include?(q)} : all
   end
@@ -44,6 +48,10 @@ class Input
 
   def self.inputs_grouped
     @inputs_grouped ||= Input.with_share_group.group_by(&:share_group)
+  end
+
+  def self.coupling_sliders_keys
+    @coupling_sliders_keys ||= Input.with_coupling_group.map(&:id)
   end
 
   def disabled_by

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -287,6 +287,10 @@ class Scenario < ApplicationRecord
     actor.private_scenarios?
   end
 
+  def coupled?
+    coupled_sliders.any?
+  end
+
   private
 
   # Validation method for when a user sets their metadata.

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -287,6 +287,10 @@ class Scenario < ApplicationRecord
     actor.private_scenarios?
   end
 
+  def coupling
+    coupled?
+  end
+
   def coupled?
     coupled_sliders.any?
   end

--- a/app/models/scenario/input_groups.rb
+++ b/app/models/scenario/input_groups.rb
@@ -38,7 +38,7 @@ module Scenario::InputGroups
     end
   end
 
-  # A hash of input (share-) groups and their inputs.
+  # A hash of input groups and their inputs.
   #
   # @return [Hash] group name => [Array<Input>]
   #
@@ -55,5 +55,12 @@ module Scenario::InputGroups
     end
 
     hash
+  end
+
+  # An array of coupled slider keys. For now we ignore what coupling group they belong to.
+  def coupled_sliders
+    input_keys = user_values.keys + balanced_values.keys
+
+    Input.coupling_sliders_keys & input_keys
   end
 end

--- a/app/serializers/input_serializer.rb
+++ b/app/serializers/input_serializer.rb
@@ -108,6 +108,7 @@ class InputSerializer
 
     json[:disabled] = !@can_change || values[:disabled] || @scenario.inputs.disabled?(@input)
     json[:disabled_by] = @input.disabled_by if @input.disabled_by.present?
+    json[:coupling_groups] = @input.disabled_by_coupling_groups.any?
 
     json[:share_group] = @input.share_group if @input.share_group.present?
 

--- a/app/serializers/input_serializer.rb
+++ b/app/serializers/input_serializer.rb
@@ -108,7 +108,7 @@ class InputSerializer
 
     json[:disabled] = !@can_change || values[:disabled] || @scenario.inputs.disabled?(@input)
     json[:disabled_by] = @input.disabled_by if @input.disabled_by.present?
-    json[:coupling_groups] = @input.disabled_by_coupling_groups.any?
+    json[:coupling_groups] = @input.disabled_by_coupling_groups.any? if @input.disabled_by.present?
 
     json[:share_group] = @input.share_group if @input.share_group.present?
 

--- a/app/serializers/scenario_serializer.rb
+++ b/app/serializers/scenario_serializer.rb
@@ -22,7 +22,7 @@ class ScenarioSerializer
         id area_code end_year source private keep_compatible
         created_at updated_at user_values balanced_values metadata
       ],
-      methods: %i[start_year]
+      methods: %i[start_year coupling]
     ).symbolize_keys
 
     json[:owner]    = @resource.owner&.as_json(only: %i[id name])

--- a/spec/controllers/api/v3/scenarios_controller_spec.rb
+++ b/spec/controllers/api/v3/scenarios_controller_spec.rb
@@ -80,6 +80,21 @@ describe Api::V3::ScenariosController do
       expect(@scenario.reload.area_code).to eq('nl')
     end
 
+    context 'when uncoupling the scenario' do
+      before do
+        allow_any_instance_of(Scenario).to receive(:coupled_sliders).and_return(['exclusive'])
+        @scenario.update(user_values: { 'foo' => 23.0, 'exclusive' => 10.0 })
+
+        put :update, params: { id: @scenario.id, coupling: false }
+
+        response
+      end
+
+      it "removes the coupled inputs" do
+        expect(@scenario.reload.user_values).to eq({ 'foo' => 23.0 })
+      end
+    end
+
     # The whole object should be overwritten
     context 'when updating the metadata' do
       before do

--- a/spec/controllers/api/v3/scenarios_controller_spec.rb
+++ b/spec/controllers/api/v3/scenarios_controller_spec.rb
@@ -82,7 +82,7 @@ describe Api::V3::ScenariosController do
 
     context 'when uncoupling the scenario' do
       before do
-        allow_any_instance_of(Scenario).to receive(:coupled_sliders).and_return(['exclusive'])
+        allow(Input).to receive(:coupling_sliders_keys).and_return(['exclusive'])
         @scenario.update(user_values: { 'foo' => 23.0, 'exclusive' => 10.0 })
 
         put :update, params: { id: @scenario.id, coupling: false }

--- a/spec/fixtures/etsource/inputs/mutually_exclusive/exclusive.ad
+++ b/spec/fixtures/etsource/inputs/mutually_exclusive/exclusive.ad
@@ -4,3 +4,4 @@
 - min_value = 0.0
 - max_value = 100.0
 - start_value = 50.0
+- coupling_groups = [coupled]

--- a/spec/models/api/v3/scenario_updater_spec.rb
+++ b/spec/models/api/v3/scenario_updater_spec.rb
@@ -282,6 +282,11 @@ describe Api::V3::ScenarioUpdater, :etsource_fixture do
       updater.apply
       expect(scenario.reload.user_values).to have_key('foo_demand')
     end
+
+    it 'shows as not coupled' do
+      updater.apply
+      expect(scenario.reload.coupled?).to be_falsey
+    end
   end
 
   context 'when uncoupling a scenario that was not coupled' do
@@ -310,6 +315,11 @@ describe Api::V3::ScenarioUpdater, :etsource_fixture do
     it 'sets new input values' do
       updater.apply
       expect(scenario.reload.user_values).to have_key('foo_demand')
+    end
+
+    it 'shows as not coupled' do
+      updater.apply
+      expect(scenario.reload.coupled?).to be_falsey
     end
   end
 
@@ -340,6 +350,11 @@ describe Api::V3::ScenarioUpdater, :etsource_fixture do
     it 'removes coupled input values' do
       updater.apply
       expect(scenario.reload.user_values).not_to have_key('exclusive')
+    end
+
+    it 'shows as not coupled' do
+      updater.apply
+      expect(scenario.reload.coupled?).to be_falsey
     end
   end
 

--- a/spec/models/api/v3/scenario_updater_spec.rb
+++ b/spec/models/api/v3/scenario_updater_spec.rb
@@ -247,6 +247,100 @@ describe Api::V3::ScenarioUpdater, :etsource_fixture do
     end
   end
 
+  context 'when uncoupling a scenario that was coupled' do
+    let(:params) do
+      {
+        coupling: false,
+        scenario: { user_values: { foo_demand: 1 } }
+      }
+    end
+
+    before do
+      scenario.user_values = {
+        exclusive: 10.0,
+        input_2: 100
+      }
+
+      scenario.save!
+    end
+
+    it_behaves_like 'a successful scenario update'
+
+    it 'removes coupled input values' do
+      updater.apply
+      expect(scenario.reload.user_values).not_to have_key('exclusive')
+    end
+
+    it 'keeps other input values' do
+      updater.apply
+      expect(scenario.reload.user_values).to have_key('input_2')
+    end
+
+    it 'sets new input values' do
+      updater.apply
+      expect(scenario.reload.user_values).to have_key('foo_demand')
+    end
+  end
+
+  context 'when uncoupling a scenario that was not coupled' do
+    let(:params) do
+      {
+        coupling: false,
+        scenario: { user_values: { foo_demand: 1 } }
+      }
+    end
+
+    before do
+      scenario.user_values = {
+        input_2: 100
+      }
+
+      scenario.save!
+    end
+
+    it_behaves_like 'a successful scenario update'
+
+    it 'keeps other input values' do
+      updater.apply
+      expect(scenario.reload.user_values).to have_key('input_2')
+    end
+
+    it 'sets new input values' do
+      updater.apply
+      expect(scenario.reload.user_values).to have_key('foo_demand')
+    end
+  end
+
+  context 'when resetting and uncoupling a scenario simultaneously' do
+    let(:params) do
+      {
+        coupling: false,
+        reset: true
+      }
+    end
+
+    before do
+      scenario.user_values = {
+        exclusive: 10.0,
+        input_2: 100
+      }
+
+      scenario.save!
+    end
+
+    it_behaves_like 'a successful scenario update'
+
+    it 'removes other input values' do
+      updater.apply
+      expect(scenario.reload.user_values).not_to have_key('input_2')
+    end
+
+    it 'removes coupled input values' do
+      updater.apply
+      expect(scenario.reload.user_values).not_to have_key('exclusive')
+    end
+  end
+
   context 'when resetting a single value' do
     let(:params) do
       {

--- a/spec/models/api/v3/scenario_updater_spec.rb
+++ b/spec/models/api/v3/scenario_updater_spec.rb
@@ -256,6 +256,8 @@ describe Api::V3::ScenarioUpdater, :etsource_fixture do
     end
 
     before do
+      allow(Input).to receive(:coupling_sliders_keys).and_return(['exclusive'])
+
       scenario.user_values = {
         exclusive: 10.0,
         input_2: 100

--- a/spec/models/scenario_spec.rb
+++ b/spec/models/scenario_spec.rb
@@ -411,6 +411,37 @@ describe Scenario do
     end
   end
 
+  describe "#coupled?" do
+    subject { @scenario.coupled? }
+
+    before do
+      @scenario = Scenario.default
+      allow(Input).to receive(:coupling_sliders_keys).and_return(
+        ['coupled_slider_1']
+      )
+    end
+
+    context 'when no coupled input is set' do
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when a coupled input is set' do
+      before do
+        @scenario.user_values = { coupled_slider_1: 1 }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when a coupled input is part of balanced values' do
+      before do
+        @scenario.balanced_values = { coupled_slider_1: 1 }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
   describe 'with a preset scenario' do
     let(:preset) do
       FactoryBot.create(:scenario, {


### PR DESCRIPTION
Adds support for a more transparant coupling witrh other models:
- A new attribute for scenarios the is available through the scenario API (closes #1340)
- Show if inputs that can be disabled are part of a `coupling_group` though the inputs API (closes #1341 )
- Uncouple a scenario by passing `coupling: false` in the scenario endpoint

I made it so that there is space in the future to communicate which coupling the scenario is part of. Instead of a `true`/`false` we could communicate the actual coupling groups.

---
Goes with
quintel/atlas#158
quintel/etmodel#4114
quintel/etsource#2902