### PR TITLE
Handle inputs with boolean values correctly

### DIFF
--- a/app/models/api/v3/scenario_updater.rb
+++ b/app/models/api/v3/scenario_updater.rb
@@ -94,7 +94,7 @@ module Api
       # Validation -----------------------------------------------------------
 
       # Asserts that the values provided by the user are within the permitted
-      # mininum and maximum.
+      # mininum and maximum, and of the correct type (e.g. boolean).
       def validate_user_values
         provided_values_without_resets.each do |key, value|
           input = Input.get(key)
@@ -104,6 +104,8 @@ module Api
             errors.add(:base, "Input #{key} does not exist")
           elsif input.enum?
             validate_enum_input(key, input_data, value)
+          elsif input.unit == 'bool'
+            validate_bool_input(key, value)
           else
             validate_numeric_input(key, input_data, value)
           end
@@ -162,6 +164,12 @@ module Api
         elsif value > (max = input[:max])
           errors.add(:base, "Input #{key} cannot be greater than #{max}")
         end
+      end
+
+      def validate_bool_input(key, value)
+        return if value.present? && value.in?([0, 1])
+
+        errors.add(:base, "Input '#{key}' had value '#{value}', but must be one 0 or 1")
       end
 
       def validate_metadata_size

--- a/app/models/scenario/year_interpolator.rb
+++ b/app/models/scenario/year_interpolator.rb
@@ -3,7 +3,6 @@
 # Receives a scenario and creates a new scenario with a new end year. Input
 # values will be adjusted to linearly interpolate new values based on the year.
 class Scenario::YearInterpolator
-  class InterpolationError < RuntimeError; end
 
   def self.call(scenario, year, current_user = nil)
     new(scenario, year, current_user).run
@@ -85,11 +84,13 @@ class Scenario::YearInterpolator
   #
   # Returns a Numeric or String value for the new user values.
   def interpolate_input(input, value, total_years, num_years)
-    return value if input.enum?
+    return value if input.enum? || input.unit == 'bool'
 
     start = input.start_value_for(@scenario)
     change_per_year = (value - start) / total_years
 
-    start + change_per_year * (total_years - num_years)
+    start + (change_per_year * (total_years - num_years))
   end
+
+  class InterpolationError < RuntimeError; end
 end

--- a/spec/fixtures/etsource/inputs/bool.ad
+++ b/spec/fixtures/etsource/inputs/bool.ad
@@ -1,0 +1,7 @@
+- query =
+- start_value = present:0.0
+- min_value = 0.0
+- max_value = 1.0
+- step_value = 1.0
+- unit = bool
+

--- a/spec/models/scenario/year_interpolator_spec.rb
+++ b/spec/models/scenario/year_interpolator_spec.rb
@@ -94,6 +94,35 @@ RSpec.describe Scenario::YearInterpolator do
     end
   end
 
+  context 'with a scenario containing a boolean input' do
+    let(:source) do
+      FactoryBot.create(:scenario, {
+        id: 99999,
+        end_year: 2050,
+        user_values: {
+          'grouped_input_one' => 75,
+          'bool' => 0
+        }
+      })
+    end
+
+    let(:interpolated) { described_class.call(source, 2030) }
+
+    it 'sets the inputs' do
+      expect(interpolated.user_values.keys.sort)
+        .to eq(%w[bool grouped_input_one])
+    end
+
+    it 'interpolates the numeric inputs' do
+      expect(interpolated.user_values['grouped_input_one'])
+        .to be_within(1e-2).of(87.82)
+    end
+
+    it 'retains the value of the boolean input' do
+      expect(interpolated.user_values['bool']).to eq(0)
+    end
+  end
+
   context 'with a year older than the analysis year' do
     let(:source) do
       FactoryBot.create(:scenario, {

--- a/spec/models/scenario/year_interpolator_spec.rb
+++ b/spec/models/scenario/year_interpolator_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Scenario::YearInterpolator do
         end_year: 2050,
         user_values: {
           'grouped_input_one' => 75,
-          'bool' => 0
+          'bool' => 1
         }
       })
     end
@@ -119,7 +119,7 @@ RSpec.describe Scenario::YearInterpolator do
     end
 
     it 'retains the value of the boolean input' do
-      expect(interpolated.user_values['bool']).to eq(0)
+      expect(interpolated.user_values['bool']).to eq(1)
     end
   end
 

--- a/spec/requests/api/v3/update_input_spec.rb
+++ b/spec/requests/api/v3/update_input_spec.rb
@@ -51,7 +51,19 @@ describe 'Updating inputs with API v3' do
           :input,
           key: 'nongrouped',
           priority: 0
-        )
+        ),
+      'boolean_one' =>
+        FactoryBot.build(
+          :input,
+          key: 'boolean_one',
+          start_value: 0.0,
+          min_value: 0.0,
+          max_value: 1.0,
+          step_value: 1.0,
+          unit: 'bool',
+          share_group: '',
+          priority: 0
+        ),
     )
 
     allow(Input).to receive(:all).and_return(Input.records.values)
@@ -696,6 +708,42 @@ describe 'Updating inputs with API v3' do
     it 'has an error message' do
       expect(JSON.parse(response.body)['errors'])
         .to include('Input nongrouped cannot be less than 0')
+    end
+  end
+
+  context 'when the value for a boolean input is set' do
+    it 'returns 200 for value 0' do
+      put_scenario(values: { boolean_one: 0 })
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns 200 for value 1' do
+      put_scenario(values: { boolean_one: 1 })
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when the value for a boolean input is set to an invalid value' do
+    before do
+      put_scenario(values: { boolean_one: 1.5 })
+    end
+
+    it 'responds 422 Unprocessable Entity' do
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'has an error message' do
+      expect(
+        response.parsed_body['errors']
+      ).to include(
+        "Input 'boolean_one' had value '1.5', but must be one 0 or 1"
+      )
+    end
+
+    it 'does not set the scenario attributes' do
+      expect(scenario.user_values).not_to have_key('boolean_one')
     end
   end
 


### PR DESCRIPTION
## What?
This PR adds validation for inputs that contain boolean values. It also makes sure the values for those inputs are skipped values for transition paths are interpolated.

## Why?
As described in [this](https://github.com/quintel/multi-year-charts/issues/31) and [this](https://github.com/quintel/etengine/issues/1321) issue boolean values are currently not handled properly: they were not validated properly and their value was interpolated and recalculated for scenarios in transition paths.

## How?
- Validation for inputs with boolean values is now added to the `Api::V3::ScenarioUpdater`
- Interpolation for inputs with boolean values is now skipped in the `Scenario::YearInterpolator`

Closes #1321
Closes quintel/multi-year-charts#31