### PR TITLE
Show value of keep_compatible flag for scenarios

### DIFF
--- a/app/helpers/scenarios_helper.rb
+++ b/app/helpers/scenarios_helper.rb
@@ -40,9 +40,9 @@ module ScenariosHelper
 
   def formatted_scenario_compatibility(scenario)
     if scenario.keep_compatible?
-      tag.a('Keep compatible', class: 'tag green', href: 'https://docs.energytransitionmodel.com/api/scenario-basics#forward-compatibility')
+      tag.a('Fully compatible', class: 'tag green', href: 'https://docs.energytransitionmodel.com/api/scenarios#forward-compatibility')
     elsif scenario.outdated?
-      tag.span('Outdated - not guaranteed', class: 'tag red')
+      tag.span('Possibly outdated - not guaranteed', class: 'tag red')
     else
       tag.span('Current model version only', class: 'tag gray')
     end

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -22,6 +22,7 @@
       %th Owner
       %th End Year
       %th Area
+      %th.narrow Keep compatible?
       %th.narrow Compatibility
       %th
   %tfoot
@@ -50,6 +51,8 @@
             %span.muted No owner
         %td= s.end_year
         %td= s.area_code
+        %td.narrow
+          = s.keep_compatible ? 'True' : 'False'
         %td.narrow
           = formatted_scenario_compatibility(s)
         %td.actions

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -44,6 +44,9 @@
           - else
             %span.tag.gray Public
       %tr
+        %th Keep compatible?
+        %td= @scenario.keep_compatible ? 'True' : 'False'
+      %tr
         %th Compatibility
         %td= formatted_scenario_compatibility(@scenario)
 


### PR DESCRIPTION
## What?
This PR shows the value of the `keep_compatible` flag as `True` or `False` in ETEngine. It also slightly changes the text for the `Compatibility` description, and updates the link to for the documentation where the concept for compatibility is explained.

## Why?
To make it more transparant if a scenario's compatibility is 'locked', and what this means.

## How?
See code changes.

Closes #1361 