### PR TITLE
Update industry values

### DIFF
--- a/db/migrate/20231031093749_split_industry_useful_demand_energetic_non_energetic.rb
+++ b/db/migrate/20231031093749_split_industry_useful_demand_energetic_non_energetic.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'etengine/scenario_migration'
+
+# Renames industry_useful_demand_for_aggregated_other to '...energetic'
+# and adds a non-energetic input with the same value
+#
+# See https://github.com/quintel/etmodel/issues/4116
+class SplitIndustryUsefulDemandEnergeticNonEnergetic < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  old_key   = 'industry_useful_demand_for_aggregated_other'
+  new_key_1 = 'industry_useful_demand_for_aggregated_other_energetic'
+  new_key_1 = 'industry_useful_demand_for_aggregated_other_non_energetic'
+
+  def change
+    migrate_scenarios do |scenario|
+      if scenario.user_values[old_key].present?
+        scenario.user_values[new_key_1] = scenario.user_values[old_key]
+        scenario.user_values[new_key_2] = scenario.user_values[old_key]
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_25_142213) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_31_093749) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
## What?
This PR adds a migration to split the follow inputs into `...energetic` and `...non_energetic` inputs and removes the original input:
```
industry_useful_demand_for_aggregated_other
industry_aggregated_other_industry_coal_share
industry_aggregated_other_industry_crude_oil_share
industry_aggregated_other_industry_hydrogen_share
industry_aggregated_other_industry_network_gas_share
industry_aggregated_other_industry_wood_pellets_share
```

## Why?
See the related etmodel issue for the need behind this change.

## How?
By leveraging etengine's `migration_scenarios` functionality, walking through all scenarios and setting/removing new values.
