### PR TITLE
Add multi-user support to scenarios (backend)

### DIFF
--- a/app/controllers/api/v3/saved_scenarios_controller.rb
+++ b/app/controllers/api/v3/saved_scenarios_controller.rb
@@ -65,7 +65,7 @@ module Api
         scenarios = Scenario
           .accessible_by(current_ability)
           .where(id: saved_scenarios.map { |s| s['scenario_id'] })
-          .includes(:scaler, :owner)
+          .includes(:scaler, :users)
           .index_by(&:id)
 
         saved_scenarios.map do |saved_scenario|

--- a/app/controllers/api/v3/scenario_users_controller.rb
+++ b/app/controllers/api/v3/scenario_users_controller.rb
@@ -84,7 +84,7 @@ module Api
       def destroy
         param_user_ids = permitted_params[:scenario_users].pluck(:id).compact.uniq
         param_user_emails = permitted_params[:scenario_users].pluck(:email).compact.uniq
-        users_ids = User.where(email: param_user_emails).pluck(:id)
+        user_ids = User.where(email: param_user_emails).pluck(:id)
 
         scenario_users = @scenario.scenario_users.where(
           'user_id IN (?) OR user_id IN (?) OR user_email IN (?)',
@@ -95,7 +95,7 @@ module Api
         # a) Could not find one of the requested users, or
         # b) There are duplicate entries in the request that we filtered out
         if scenario_users.count < permitted_params[:scenario_users].length
-          diff = user_ids - scenario_users.pluck(:user_id)
+          diff = (param_user_ids + param_user_emails) - scenario_users.pluck(:user_id)
 
           if diff.present?
             render json: { error: "Could not find user(s) with id: #{diff.join(',')}" }, status: :not_found

--- a/app/controllers/api/v3/scenario_users_controller.rb
+++ b/app/controllers/api/v3/scenario_users_controller.rb
@@ -128,8 +128,6 @@ module Api
         # Check if all scenario_users have the requested attributes
         permitted_params[:scenario_users].each do |user_params|
           attributes.each do |attribute|
-            pp attribute
-
             # If this is an array of attributes, at least one of the entries should be present
             valid = \
               if attribute.is_a? Array

--- a/app/controllers/api/v3/scenario_users_controller.rb
+++ b/app/controllers/api/v3/scenario_users_controller.rb
@@ -1,0 +1,108 @@
+module Api
+  module V3
+    # Allows owners of a Scenario to manage the roles for users on a given scenario
+    class ScenarioUsersController < BaseController
+      respond_to :json
+
+      check_authorization
+
+      authorize_resource class: Scenario
+
+      before_action :find_scenario, except: :index
+
+      def index
+        render json: users_return_values
+      end
+
+      def create
+        render json: users_return_values and return if scenario_params[:users].blank?
+
+        scenario_params[:users].each do |user_params|
+          @scenario.scenario_users << build_scenario_user(user_params)
+        end
+
+        if @scenario.save
+          render json: users_return_values, status: :created
+        else
+          render json: scenario.errors, status: :unprocessable_entity
+        end
+      end
+
+      def update
+        render json: users_return_values and return if scenario_params[:users].blank?
+
+        scenario_users_updated = true
+        scenario_user_error = nil
+        http_error_status = :unprocessable_entity
+
+        scenario_params[:users].each do |user_params|
+          su = @scenario.scenario_users.find_by(
+            user_id: user_params.try(:[], :id)
+          )
+
+          if su.blank?
+            scenario_users_updated = false
+            http_error_status = :not_found
+
+            break
+          end
+
+          unless (scenario_users_updated = su.update(role_id: User::ROLES.key(user_params.try(:[], :role).to_sym)))
+            scenario_user_error = su.errors
+
+            break
+          end
+        end
+
+        if scenario_users_updated
+          render json: users_return_values, status: :ok
+        else
+          render json: scenario_user_error, status: http_error_status
+        end
+      end
+
+      def destroy
+        render json: users_return_values and return if scenario_params[:user_ids].blank?
+
+        @scenario.scenario_users.where(
+          user_id: scenario_params[:user_ids]
+        ).destroy_all
+
+        head :ok
+      end
+
+      private
+
+      def scenario_params
+        params.permit(:scenario_id, users: [%i[id role email]], user_ids: [])
+      end
+
+      def find_scenario
+        @scenario = current_user.scenarios.find(scenario_params[:scenario_id])
+      end
+
+      def users_return_values
+        user_ids = scenario_params[:users].pluck(:id) if scenario_params[:users].present?
+
+        scenario_users = @scenario.scenario_users
+        scenario_users = scenario_users.where(user_id: user_ids) if user_ids.present?
+
+        scenario_users.map do |u|
+          { id: u.user_id, email: u.user_email, role: User::ROLES[u.role_id] }
+        end
+      end
+
+      def build_scenario_user(user_params)
+        user = User.find_by(email: user_params.try(:[], :email))
+
+        ScenarioUser.new(
+          user_id: user_params.try(:[], :id),
+          scenario_id: scenario_params[:scenario_id],
+          role_id: User::ROLES.key(user_params.try(:[], :role).to_sym),
+          user_email: user.present? ? nil : user_params.try(:[], :email)
+        )
+      end
+    end
+  end
+end
+

--- a/app/controllers/api/v3/scenario_users_controller.rb
+++ b/app/controllers/api/v3/scenario_users_controller.rb
@@ -29,9 +29,7 @@ module Api
           end
 
           # Send an email invitation to the added user
-          if permitted_params.dig(:invitation_args, :invite) == true
-            send_invitation_mail_for(scenario_user)
-          end
+          send_invitation_mail_for(scenario_user) if invite?
 
           scenario_user
         end
@@ -44,6 +42,13 @@ module Api
       end
 
       def update
+        # TODO: render sucessful users in the same way as create
+        # TODO: return errors in the same json structure as create
+        # TODO: clean up this method
+        # TODO: check if specs work now (they are already converted to the 'new' format)
+
+        # TODO: this line can go - we validate when updating each record. If one is invalid we
+        # continue and collect errors and successes
         return unless validate_scenario_user_params(['role', ['id', 'user_id', 'user_email']])
 
         http_error_status, scenario_user_error = nil, nil
@@ -74,6 +79,10 @@ module Api
       end
 
       def destroy
+        # TODO: update specs to see if we missed anything, and to use common response format
+        # TODO: return errors in the same json structure as create
+        # TODO: clean up this method
+
         return unless validate_scenario_user_params([['id', 'user_id', 'user_email']])
 
         # Find scenario_users by id, user_id, user_email,
@@ -122,6 +131,12 @@ module Api
         end
       end
 
+      def invite?
+        permitted_params.dig(:invitation_args, :invite) == true
+      end
+
+      # TODO: this method can probably go, as we update one by one anyway and the model contains a
+      # lot of validations
       def validate_scenario_user_params(attributes)
         if permitted_params[:scenario_users].blank?
           render json: { error: 'No users given to perform action on.' }, status: :unprocessable_entity
@@ -154,6 +169,8 @@ module Api
 
       # Find an existing ScenarioUser record by given user_params
       def find_scenario_user_by_params(user_params)
+
+        # TODO: why not just use a return in the if statements?
         scenario_user = nil
 
         if user_params[:id]&.present?
@@ -178,6 +195,8 @@ module Api
         scenario_user
       end
 
+      # TODO: after correcting the responses, this method should go. Only for INDEX we have to find
+      # another solution
       # Format the return values for the users in the given scenario
       def users_return_values
         if permitted_params[:scenario_users].present?

--- a/app/controllers/api/v3/scenario_users_controller.rb
+++ b/app/controllers/api/v3/scenario_users_controller.rb
@@ -1,88 +1,148 @@
 module Api
   module V3
-    # Allows owners of a Scenario to manage the roles for users on a given scenario
     class ScenarioUsersController < BaseController
       respond_to :json
 
-      check_authorization
+      before_action { doorkeeper_authorize!(:'scenarios:delete') }
 
-      authorize_resource class: Scenario
+      before_action :find_and_authorize_scenario
 
-      before_action :find_scenario, except: :index
+      before_action :validate_users_presence, only: %i[create update destroy]
 
       def index
         render json: users_return_values
       end
 
       def create
-        render json: users_return_values and return if scenario_params[:users].blank?
-
-        scenario_params[:users].each do |user_params|
-          @scenario.scenario_users << build_scenario_user(user_params)
+        permitted_params[:scenario_users].each do |user_params|
+          begin
+            scenario_user = new_scenario_user_from(user_params)
+            scenario_user.save!
+          rescue ActiveRecord::RecordInvalid
+            render json: user_params.merge({ error: "#{scenario_user.errors.first.attribute} is invalid." }),
+              status: :unprocessable_entity and return
+          rescue ActiveRecord::RecordNotUnique
+            render json: user_params.merge({ error: 'A user with this ID or email already exists for this scenario' }),
+              status: :unprocessable_entity and return
+          end
         end
 
         if @scenario.save
           render json: users_return_values, status: :created
         else
-          render json: scenario.errors, status: :unprocessable_entity
+          render json: @scenario.errors, status: :unprocessable_entity
         end
       end
 
       def update
-        render json: users_return_values and return if scenario_params[:users].blank?
-
-        scenario_users_updated = true
         scenario_user_error = nil
         http_error_status = :unprocessable_entity
 
-        scenario_params[:users].each do |user_params|
-          su = @scenario.scenario_users.find_by(
-            user_id: user_params.try(:[], :id)
-          )
+        permitted_params[:scenario_users].each do |user_params|
+          if user_params.try(:[], :role).blank?
+            scenario_user_error = user_params.merge({ error: 'No role given to update with.' })
+
+            break
+          end
+
+          if user_params.try(:[], :id).present?
+            su = @scenario.scenario_users.find_by(user_id: user_params.try(:[], :id))
+          elsif user_params.try(:[], :email).present?
+            su = @scenario.scenario_users.find_by(user_email: user_params.try(:[], :email))
+
+            # Maybe the 'nameless' user got converted to actual user already. Search for them
+            if su.blank?
+              user = User.find_by(email: user_params.try(:[], :email))
+
+              if user.present?
+                su = @scenario.scenario_users.find_by(user_id: user.id)
+              end
+            end
+          end
 
           if su.blank?
-            scenario_users_updated = false
+            scenario_user_error = user_params.merge({ error: 'Scenario user not found' })
             http_error_status = :not_found
 
             break
           end
 
-          unless (scenario_users_updated = su.update(role_id: User::ROLES.key(user_params.try(:[], :role).to_sym)))
+          unless (scenario_users_updated = su.update(role_id: User::ROLES.key(user_params.try(:[], :role).try(:to_sym))))
             scenario_user_error = su.errors
 
             break
           end
         end
 
-        if scenario_users_updated
-          render json: users_return_values, status: :ok
-        else
+        if scenario_user_error
           render json: scenario_user_error, status: http_error_status
+        else
+          render json: users_return_values, status: :ok
         end
       end
 
       def destroy
-        render json: users_return_values and return if scenario_params[:user_ids].blank?
+        param_user_ids = permitted_params[:scenario_users].pluck(:id).compact.uniq
+        param_user_emails = permitted_params[:scenario_users].pluck(:email).compact.uniq
+        users_ids = User.where(email: param_user_emails).pluck(:id)
 
-        @scenario.scenario_users.where(
-          user_id: scenario_params[:user_ids]
-        ).destroy_all
+        scenario_users = @scenario.scenario_users.where(
+          'user_id IN (?) OR user_id IN (?) OR user_email IN (?)',
+          user_ids, param_user_ids, param_user_emails
+        )
+
+        # If we found less users than requested, we either:
+        # a) Could not find one of the requested users, or
+        # b) There are duplicate entries in the request that we filtered out
+        if scenario_users.count < permitted_params[:scenario_users].length
+          diff = user_ids - scenario_users.pluck(:user_id)
+
+          if diff.present?
+            render json: { error: "Could not find user(s) with id: #{diff.join(',')}" }, status: :not_found
+          else
+            render json: { error: "Duplicate user ids found in request, please revise." }, status: :unprocessable_entity
+          end
+
+          return
+        end
+
+        scenario_users.destroy_all
 
         head :ok
       end
 
       private
 
-      def scenario_params
-        params.permit(:scenario_id, users: [%i[id role email]], user_ids: [])
+      def permitted_params
+        params.permit(:scenario_id, scenario_users: [%i[id role email]])
       end
 
-      def find_scenario
-        @scenario = current_user.scenarios.find(scenario_params[:scenario_id])
+      def find_and_authorize_scenario
+        if current_user.blank?
+          render json: { error: "Saved scenario with id #{permitted_params[:scenario_id]} not found." }, status: :not_found
+
+          return false
+        end
+
+        @scenario = current_user.scenarios.find(permitted_params[:scenario_id])
+
+        if @scenario.blank? || (@scenario.present? && !@scenario.owner?(current_user))
+          render json: { error: "Saved scenario with id #{permitted_params[:scenario_id]} not found." }, status: :not_found
+
+          return false
+        end
+      end
+
+      def validate_users_presence
+        return true if permitted_params[:scenario_users].present?
+
+        render json: { error: 'No users given to perform action on.' }, status: :unprocessable_entity
+
+        return false
       end
 
       def users_return_values
-        user_ids = scenario_params[:users].pluck(:id) if scenario_params[:users].present?
+        user_ids = permitted_params[:scenario_users].pluck(:id) if permitted_params[:scenario_users].present?
 
         scenario_users = @scenario.scenario_users
         scenario_users = scenario_users.where(user_id: user_ids) if user_ids.present?
@@ -92,13 +152,13 @@ module Api
         end
       end
 
-      def build_scenario_user(user_params)
+      def new_scenario_user_from(user_params)
         user = User.find_by(email: user_params.try(:[], :email))
 
         ScenarioUser.new(
-          user_id: user_params.try(:[], :id),
-          scenario_id: scenario_params[:scenario_id],
-          role_id: User::ROLES.key(user_params.try(:[], :role).to_sym),
+          scenario: @scenario,
+          role_id: User::ROLES.key(user_params.try(:[], :role).try(:to_sym)),
+          user_id: user.present? ? user.id : user_params.try(:[], :id),
           user_email: user.present? ? nil : user_params.try(:[], :email)
         )
       end

--- a/app/controllers/api/v3/scenario_users_controller.rb
+++ b/app/controllers/api/v3/scenario_users_controller.rb
@@ -3,11 +3,10 @@ module Api
     class ScenarioUsersController < BaseController
       respond_to :json
 
+      # Only scenario owners, having the delete authority, may manage scenario users
       before_action { doorkeeper_authorize!(:'scenarios:delete') }
 
       before_action :find_and_authorize_scenario
-
-      before_action :validate_users_presence, only: %i[create update destroy]
 
       def index
         render json: users_return_values
@@ -27,9 +26,9 @@ module Api
               status: :unprocessable_entity and return
           end
 
-          # Send an invitation if stated in the params
+          # Send an email invitation to the added user only if stated in the params
           if permitted_params.dig(:invitation_args, :invite) == true
-            send_invitation_mail(scenario_user)
+            send_invitation_mail_for(scenario_user)
           end
         end
 
@@ -41,30 +40,23 @@ module Api
       end
 
       def update
-        scenario_user_error = nil
-        http_error_status = :unprocessable_entity
+        return unless validate_scenario_user_params(['role', ['id', 'user_id', 'user_email']])
+
+        http_error_status, scenario_user_error = nil, nil
 
         permitted_params[:scenario_users].each do |user_params|
-          if user_params.try(:[], :role).blank?
-            scenario_user_error = user_params.merge({ error: 'No role given to update with.' })
-
-            break
-          end
-
-          scenario_user = find_scenario_user_by_params(user_params)
-          if scenario_user.blank?
+          # Find the user
+          unless (scenario_user = find_scenario_user_by_params(user_params))
             scenario_user_error = user_params.merge({ error: 'Scenario user not found' })
             http_error_status = :not_found
 
             break
           end
 
-          unless (
-            scenario_users_updated = scenario_user.update(
-              role_id: User::ROLES.key(user_params.try(:[], :role).try(:to_sym))
-            )
-          )
+          # Attempt to update the user
+          unless scenario_user.update(role_id: User::ROLES.key(user_params[:role].to_sym))
             scenario_user_error = scenario_user.errors
+            http_error_status = :unprocessable_entity
 
             break
           end
@@ -78,36 +70,17 @@ module Api
       end
 
       def destroy
-        param_user_ids = permitted_params[:scenario_users].pluck(:id).compact.uniq
-        param_user_emails = permitted_params[:scenario_users].pluck(:email).compact.uniq
-        user_ids = User.where(email: param_user_emails).pluck(:id)
+        return unless validate_scenario_user_params([['id', 'user_id', 'user_email']])
 
+        # Find scenario_users by id, user_id, user_email,
+        # or the id of users found through their email address indirectly
         scenario_users = @scenario.scenario_users.where(
-          'user_id IN (?) OR user_id IN (?) OR user_email IN (?)',
-          user_ids, param_user_ids, param_user_emails
+          'id in (?) OR user_email IN (?) OR user_id IN (?) OR user_id IN (?)',
+          permitted_params[:scenario_users].pluck('id'),
+          permitted_params[:scenario_users].pluck('user_email'),
+          permitted_params[:scenario_users].pluck('user_id'),
+          User.where(email: permitted_params[:scenario_users].pluck('user_email')).pluck(:id)
         )
-
-        # If we found less users than requested, we either:
-        # a) Could not find one of the requested users, or
-        # b) There are duplicate entries in the request that we filtered out
-        if scenario_users.count < permitted_params[:scenario_users].length
-          missing_ids = param_user_ids - scenario_users.pluck(:id)
-          missing_emails = param_user_emails - scenario_users.map { |su| su.user.email }
-
-          if missing_ids.present? || missing_emails.present?
-            render \
-              json: {
-                error: "Could not find user(s) with id or email: #{(missing_ids + missing_emails).join(',')}"
-              },
-              status: :not_found
-          else
-            render \
-              json: { error: "Duplicate user ids found in request, please revise." },
-              status: :unprocessable_entity
-          end
-
-          return
-        end
 
         scenario_users.destroy_all
 
@@ -117,7 +90,11 @@ module Api
       private
 
       def permitted_params
-        params.permit(:scenario_id, scenario_users: [%i[id role email invite]], invitation_args: %i[invite user_name id title])
+        params.permit(
+          :scenario_id,
+          scenario_users: [%i[id role user_id user_email invite]],
+          invitation_args: %i[invite user_name id title]
+        )
       end
 
       def find_and_authorize_scenario
@@ -141,47 +118,54 @@ module Api
         end
       end
 
-      def validate_users_presence
-        return true if permitted_params[:scenario_users].present?
+      def validate_scenario_user_params(attributes)
+        if permitted_params[:scenario_users].blank?
+          render json: { error: 'No users given to perform action on.' }, status: :unprocessable_entity
 
-        render json: { error: 'No users given to perform action on.' }, status: :unprocessable_entity
+          return false
+        end
 
-        return false
-      end
+        # Check if all scenario_users have the requested attributes
+        permitted_params[:scenario_users].each do |user_params|
+          attributes.each do |attribute|
+            pp attribute
 
-      def users_return_values
-        user_ids = permitted_params[:scenario_users].pluck(:id) if permitted_params[:scenario_users].present?
+            # If this is an array of attributes, at least one of the entries should be present
+            valid = \
+              if attribute.is_a? Array
+                (attribute - user_params.keys).length < attribute.length
+              else
+                user_params.keys.include?(attribute)
+              end
 
-        scenario_users = @scenario.scenario_users
-        scenario_users = scenario_users.where(user_id: user_ids) if user_ids.present?
+            unless valid
+              missing_attr = attribute.is_a?(Array) ? attribute.join(' or ') : attribute
 
-        scenario_users.map do |u|
-          { id: u.user_id, email: u.user_email, role: User::ROLES[u.role_id] }
+              render json: user_params.merge({ error: "Missing attribute(s) for scenario_user: #{missing_attr}" }),
+                status: :unprocessable_entity
+
+              return false
+            end
+          end
         end
       end
 
-      def new_scenario_user_from(user_params)
-        user = User.find_by(email: user_params.try(:[], :email))
-
-        ScenarioUser.new(
-          scenario: @scenario,
-          role_id: User::ROLES.key(user_params.try(:[], :role).try(:to_sym)),
-          user_id: user.present? ? user.id : user_params.try(:[], :id),
-          user_email: user.present? ? nil : user_params.try(:[], :email)
-        )
-      end
-
+      # Find an existing ScenarioUser record by given user_params
       def find_scenario_user_by_params(user_params)
-        if user_params.try(:[], :id).present?
-          scenario_user = @scenario.scenario_users.find_by(user_id: user_params.try(:[], :id))
-        elsif user_params.try(:[], :email).present?
-          scenario_user = @scenario.scenario_users.find_by(user_email: user_params.try(:[], :email))
+        scenario_user = nil
 
-          # It may have happened the user was registered through e-mail but was saved by
+        if user_params[:id]&.present?
+          scenario_user = @scenario.scenario_users.find(user_params[:id])
+        elsif user_params[:user_id]&.present?
+          scenario_user = @scenario.scenario_users.find_by(user_id: user_params[:user_id])
+        elsif user_params[:user_email]&.present?
+          scenario_user = @scenario.scenario_users.find_by(user_email: user_params[:user_email])
+
+          # It may have happened the user was registered through email but was saved by
           # its ID. Search all users for this email, then search for the found ID
           # through the users for this scenario just to be sure.
           if scenario_user.blank?
-            user = User.find_by(email: user_params.try(:[], :email))
+            user = User.find_by(email: user_params[:user_email])
 
             if user.present?
               scenario_user = @scenario.scenario_users.find_by(user_id: user.id)
@@ -192,8 +176,38 @@ module Api
         scenario_user
       end
 
+      # Format the return values for the users in the given scenario
+      def users_return_values
+        if permitted_params[:scenario_users].present?
+          user_ids = permitted_params[:scenario_users].pluck(:user_id)
+        end
+
+        scenario_users = @scenario.scenario_users
+        scenario_users = scenario_users.where(user_id: user_ids) if user_ids.present?
+
+        scenario_users.map do |su|
+          { id: su.id, user_id: su.user_id, user_email: su.user_email, role: User::ROLES[su.role_id] }
+        end
+      end
+
+      # Create a new ScenarioUser record from given user_params
+      def new_scenario_user_from(user_params)
+        if user_params[:user_id].present?
+          user = User.find(user_params[:user_id])
+        elsif user_params[:user_email].present?
+          user = User.find_by(email: user_params[:email])
+        end
+
+        ScenarioUser.new(
+          scenario: @scenario,
+          role_id: User::ROLES.key(user_params.try(:[], :role).try(:to_sym)),
+          user_id: user&.id,
+          user_email: user&.email || user_params.try(:[], :user_email)
+        )
+      end
+
       # Make sure a user knows it was added to a scenario by sending an email notifying them.
-      def send_invitation_mail(scenario_user)
+      def send_invitation_mail_for(scenario_user)
         if scenario_user.user_id.present?
           user_type = 'existing'
           email = scenario_user.user.email

--- a/app/controllers/api/v3/scenario_users_controller.rb
+++ b/app/controllers/api/v3/scenario_users_controller.rb
@@ -124,9 +124,14 @@ module Api
           return false
         end
 
-        @scenario = current_user.scenarios.find(permitted_params[:scenario_id])
+        @scenario = \
+          if current_user.admin?
+            Scenario.find(permitted_params[:scenario_id])
+          else
+            current_user.scenarios.find(permitted_params[:scenario_id])
+          end
 
-        if @scenario.blank? || (@scenario.present? && !@scenario.owner?(current_user))
+        if @scenario.blank? || (@scenario.present? && !@scenario.owner?(current_user) && !current_user.admin?)
           render json: { error: "Saved scenario with id #{permitted_params[:scenario_id]} not found." }, status: :not_found
 
           return false

--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -164,7 +164,7 @@ module Api
         @scenario.descale    = attrs[:descale]
         @scenario.attributes = attrs
 
-        @scenario.owner = current_user
+        @scenario.scenario_users << ScenarioUser(scenario: @scenario, user: current_user, role: User::ROLES.key(:owner))
 
         Scenario.transaction do
           @scenario.save!

--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -82,7 +82,7 @@ module Api
         ids = params[:id].split(',')
 
         scenarios = Scenario.accessible_by(current_ability)
-          .where(id: ids).includes(:owner, :scaler)
+          .where(id: ids).includes(:users, :scaler)
 
         @serializers = scenarios.map do |scenario|
           ScenarioSerializer.new(self, scenario)
@@ -164,7 +164,7 @@ module Api
         @scenario.descale    = attrs[:descale]
         @scenario.attributes = attrs
 
-        @scenario.scenario_users << ScenarioUser(scenario: @scenario, user: current_user, role: User::ROLES.key(:owner))
+        @scenario.scenario_users << ScenarioUser(scenario: @scenario, user: current_user, role: User::ROLES.key(:scenario_owner))
 
         Scenario.transaction do
           @scenario.save!

--- a/app/controllers/inspect/scenarios_controller.rb
+++ b/app/controllers/inspect/scenarios_controller.rb
@@ -5,7 +5,7 @@ class Inspect::ScenariosController < Inspect::BaseController
 
   def index
     @list_params = params.permit(:api_scenario_id, :q, :page)
-    base = Scenario.recent_first.includes(:owner)
+    base = Scenario.recent_first.includes(:users)
     base = base.by_id(@list_params[:q]) if @list_params[:q].present?
     @scenarios = base.page(@list_params[:page]).per(100)
   end

--- a/app/mailers/scenario_invitation_mailer.rb
+++ b/app/mailers/scenario_invitation_mailer.rb
@@ -1,0 +1,15 @@
+class ScenarioInvitationMailer < ApplicationMailer
+  def invite_user(user_type, email, inviter_name, saved_scenario_details)
+    @inviter_name = inviter_name
+    @saved_scenario_id = saved_scenario_details[:id]
+    @saved_scenario_title = saved_scenario_details[:title]
+
+    mail(
+      to: email,
+      from: Settings.mailer.from,
+      subject: t("scenario_invitation_mailer.invite_user.subject"),
+      template_name: "invite_#{user_type}_user"
+    )
+  end
+end
+

--- a/app/models/api/guest_ability.rb
+++ b/app/models/api/guest_ability.rb
@@ -8,7 +8,8 @@ module Api
     def initialize
       can :create, Scenario
       can :read,   Scenario, private: false
-      can :update, Scenario, private: false, owner_id: nil
+      can :update, Scenario, private: false
+      cannot :update, Scenario, private: false, id: ScenarioUser.pluck(:scenario_id)
 
       # Actions that involve reading one scenario and writing to another.
       can :clone,  Scenario, private: false

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -135,6 +135,30 @@ class Scenario < ApplicationRecord
     where(id: id).with_attachments.first!
   end
 
+  def self.owned_by?(user)
+    joins(:scenario_users)
+      .where(
+        'scenario_users.user_id': user.id,
+        'scenario_users.role_id': User::ROLES.key(:scenario_owner)
+      )
+  end
+
+  def self.collaborated_by?(user)
+    joins(:scenario_users)
+      .where(
+        'scenario_users.user_id': user.id,
+        'scenario_users.role_id': User::ROLES.key(:scenario_collaborator)..
+      )
+  end
+
+  def self.viewable_by?(user)
+    joins(:scenario_users)
+      .where(
+        'scenario_users.user_id': user.id,
+        'scenario_users.role_id': User::ROLES.key(:scenario_viewer)..
+      )
+  end
+
   def area
     Area.get(area_code)
   end
@@ -284,8 +308,8 @@ class Scenario < ApplicationRecord
   # @return [Boolean]
   def clone_should_be_private?(actor)
     return false unless actor
-    return false if owner_id.blank?
-    return private if owner_id == actor.id
+    return false if scenario_users.count.zero?
+    return private if owner?(actor)
 
     actor.private_scenarios?
   end
@@ -296,6 +320,41 @@ class Scenario < ApplicationRecord
 
   def coupled?
     coupled_sliders.any?
+  end
+
+  def owned?
+    scenario_users.where(role_id: User::ROLES.key(:scenario_owner)).count.positive?
+  end
+
+  def owner?(user)
+    return false if user.blank?
+
+    ssu = scenario_users.find_by(user_id: user.id)
+    ssu.present? && ssu.role_id == User::ROLES.key(:scenario_owner)
+  end
+
+  def collaborator?(user)
+    return false if user.blank?
+
+    ssu = scenario_users.find_by(user_id: user.id)
+    ssu.present? && ssu.role_id >= User::ROLES.key(:scenario_collaborator)
+  end
+
+  def viewer?(user)
+    return false if user.blank?
+
+    ssu = scenario_users.find_by(user_id: user.id)
+    ssu.present? && ssu.role_id >= User::ROLES.key(:scenario_viewer)
+  end
+
+  # Convenience method to quickly set the owner for a scenario, e.g. when creating it as
+  # Scenario.create(user: User). Only works when no users are associated yet.
+  def user=(user)
+    return false if user.blank? || scenario_users.count > 0
+
+    return false unless valid?
+
+    ScenarioUser.create(scenario: self, user: user, role_id: User::ROLES.key(:scenario_owner))
   end
 
   private
@@ -313,6 +372,8 @@ class Scenario < ApplicationRecord
   end
 
   def validate_visibility
-    errors.add(:private, 'can not be true on an unowned scenario') if private? && owner_id.blank?
+    if private? && scenario_users.map(&:role_id).none?(User::ROLES.key(:scenario_owner))
+      errors.add(:private, 'can not be true on an unowned scenario')
+    end
   end
 end

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -16,7 +16,9 @@ class Scenario < ApplicationRecord
   store :balanced_values
   store :metadata, coder: JSON
 
-  belongs_to :owner, class_name: 'User', optional: true
+  has_many :scenario_users, dependent: :destroy
+  has_many :users, through: :scenario_users
+
   belongs_to :parent, class_name: 'Scenario', foreign_key: :preset_scenario_id, optional: true
 
   has_one    :preset_scenario, :foreign_key => 'preset_scenario_id', :class_name => 'Scenario'

--- a/app/models/scenario/year_interpolator.rb
+++ b/app/models/scenario/year_interpolator.rb
@@ -23,7 +23,7 @@ class Scenario::YearInterpolator
     clone.end_year        = @year
     clone.source          = @scenario.source
     clone.private         = @scenario.clone_should_be_private?(@current_user)
-    clone.scenario_users << ScenarioUser(scenario: clone, user: current_user, role: User::ROLES.key(:owner))
+    clone.scenario_users << ScenarioUser(scenario: clone, user: current_user, role: User::ROLES.key(:scenario_owner))
 
     if @year != @scenario.end_year
       clone.user_values =

--- a/app/models/scenario/year_interpolator.rb
+++ b/app/models/scenario/year_interpolator.rb
@@ -20,10 +20,10 @@ class Scenario::YearInterpolator
     clone = Scenario.new
     clone.copy_scenario_state(@scenario)
 
-    clone.end_year = @year
-    clone.source   = @scenario.source
-    clone.private  = @scenario.clone_should_be_private?(@current_user)
-    clone.owner    = @current_user
+    clone.end_year        = @year
+    clone.source          = @scenario.source
+    clone.private         = @scenario.clone_should_be_private?(@current_user)
+    clone.scenario_users << ScenarioUser(scenario: clone, user: current_user, role: User::ROLES.key(:owner))
 
     if @year != @scenario.end_year
       clone.user_values =

--- a/app/models/scenario/year_interpolator.rb
+++ b/app/models/scenario/year_interpolator.rb
@@ -16,14 +16,17 @@ class Scenario::YearInterpolator
 
   def run
     validate!
-
     clone = Scenario.new
     clone.copy_scenario_state(@scenario)
 
-    clone.end_year        = @year
-    clone.source          = @scenario.source
-    clone.private         = @scenario.clone_should_be_private?(@current_user)
-    clone.scenario_users << ScenarioUser(scenario: clone, user: current_user, role: User::ROLES.key(:scenario_owner))
+    clone.end_year = @year
+    clone.source   = @scenario.source
+
+    clone.scenario_users.destroy_all
+    clone.user = @current_user if @current_user
+    clone.reload unless clone.new_record?
+
+    clone.private = @scenario.clone_should_be_private?(@current_user)
 
     if @year != @scenario.end_year
       clone.user_values =

--- a/app/models/scenario_user.rb
+++ b/app/models/scenario_user.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ScenarioUser < ApplicationRecord
+  belongs_to :scenario
+  belongs_to :user, optional: true
+
+  validate :user_or_email
+
+  def user_or_email
+    unless user_id.present? || user_email.present?
+      errors.add(:user_email, 'Email should be present if no user_id is given')
+    end
+  end
+end
+

--- a/app/models/scenario_user.rb
+++ b/app/models/scenario_user.rb
@@ -8,12 +8,10 @@ class ScenarioUser < ApplicationRecord
   validates :user_email, format: { with: Devise.email_regexp }, allow_blank: true
   validates :role_id, inclusion: { in: User::ROLES.keys }
 
-  # Always make sure one owner is left on the Scenario this record is part of
+  # Always make sure one owner is left on the SavedScenario this record is part of
   # before changing its role or removing it.
-  # Don't check new records and ignore if the role is set to owner.
-  before_save :ensure_one_owner_left,
-    unless: proc { |u| u.new_record? || u.role_id == User::ROLES.key(:scenario_owner) }
-  before_destroy :ensure_one_owner_left
+  before_save :ensure_one_owner_left_before_save
+  before_destroy :ensure_one_owner_left_before_destroy
 
   # Either user_id or user_email should be present, but not both
   def user_id_or_email
@@ -22,12 +20,23 @@ class ScenarioUser < ApplicationRecord
     errors.add(:base, 'Either user_id or user_email should be present.')
   end
 
-  def ensure_one_owner_left
+
+  def ensure_one_owner_left_before_save
+  # Don't check new records and ignore if the role is set to owner.
+    return if new_record? || role_id == User::ROLES.key(:scenario_owner)
+
     # Collect roles for other users of this scenario
-    role_ids = scenario.scenario_users.where.not(id: id).pluck(:role_id).compact.uniq
+    other_role_ids = saved_scenario.saved_scenario_users.where.not(id: id).pluck(:role_id).compact.uniq
 
     # Cancel this action of none of the other users is an owner
-    throw(:abort) if role_ids.none?(User::ROLES.key(:scenario_owner))
+    throw(:abort) if other_role_ids.none?(User::ROLES.key(:scenario_owner))
   end
-end
 
+  def ensure_one_owner_left_before_destroy
+    # Collect roles for other users of this scenario
+    other_users = saved_scenario.saved_scenario_users.where.not(id: id)
+    other_role_ids = other_users.pluck(:role_id).compact.uniq
+
+    # Cancel this action of there are other users and none of them is an owner
+    throw(:abort) if other_users.count > 0 && other_role_ids.none?(User::ROLES.key(:scenario_owner))
+  end

--- a/app/models/scenario_user.rb
+++ b/app/models/scenario_user.rb
@@ -4,12 +4,30 @@ class ScenarioUser < ApplicationRecord
   belongs_to :scenario
   belongs_to :user, optional: true
 
-  validate :user_or_email
+  validate :user_id_or_email
+  validates :user_email, format: { with: Devise.email_regexp }, allow_blank: true
+  validates :role_id, inclusion: { in: User::ROLES.keys }
 
-  def user_or_email
-    unless user_id.present? || user_email.present?
-      errors.add(:user_email, 'Email should be present if no user_id is given')
-    end
+  # Always make sure one owner is left on the Scenario this record is part of
+  # before changing its role or removing it.
+  # Don't check new records and ignore if the role is set to owner.
+  before_save :ensure_one_owner_left,
+    unless: proc { |u| u.new_record? || u.role_id == User::ROLES.key(:scenario_owner) }
+  before_destroy :ensure_one_owner_left
+
+  # Either user_id or user_email should be present, but not both
+  def user_id_or_email
+    return if user_id.blank? ^ user_email.blank?
+
+    errors.add(:base, 'Either user_id or user_email should be present.')
+  end
+
+  def ensure_one_owner_left
+    # Collect roles for other users of this scenario
+    role_ids = scenario.scenario_users.where.not(id: id).pluck(:role_id).compact.uniq
+
+    # Cancel this action of none of the other users is an owner
+    throw(:abort) if role_ids.none?(User::ROLES.key(:scenario_owner))
   end
 end
 

--- a/app/models/scenario_user.rb
+++ b/app/models/scenario_user.rb
@@ -8,7 +8,7 @@ class ScenarioUser < ApplicationRecord
   validates :user_email, format: { with: Devise.email_regexp }, allow_blank: true
   validates :role_id, inclusion: { in: User::ROLES.keys }
 
-  # Always make sure one owner is left on the SavedScenario this record is part of
+  # Always make sure one owner is left on the Scenario this record is part of
   # before changing its role or removing it.
   before_save :ensure_one_owner_left_before_save
   before_destroy :ensure_one_owner_left_before_destroy
@@ -20,13 +20,12 @@ class ScenarioUser < ApplicationRecord
     errors.add(:base, 'Either user_id or user_email should be present.')
   end
 
-
   def ensure_one_owner_left_before_save
   # Don't check new records and ignore if the role is set to owner.
     return if new_record? || role_id == User::ROLES.key(:scenario_owner)
 
     # Collect roles for other users of this scenario
-    other_role_ids = saved_scenario.saved_scenario_users.where.not(id: id).pluck(:role_id).compact.uniq
+    other_role_ids = scenario.scenario_users.where.not(id: id).pluck(:role_id).compact.uniq
 
     # Cancel this action of none of the other users is an owner
     throw(:abort) if other_role_ids.none?(User::ROLES.key(:scenario_owner))
@@ -34,9 +33,10 @@ class ScenarioUser < ApplicationRecord
 
   def ensure_one_owner_left_before_destroy
     # Collect roles for other users of this scenario
-    other_users = saved_scenario.saved_scenario_users.where.not(id: id)
+    other_users = scenario.scenario_users.where.not(id: id)
     other_role_ids = other_users.pluck(:role_id).compact.uniq
 
     # Cancel this action of there are other users and none of them is an owner
     throw(:abort) if other_users.count > 0 && other_role_ids.none?(User::ROLES.key(:scenario_owner))
   end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  ROLES = {
+    1 => :scenario_viewer,
+    2 => :scenario_collaborator,
+    3 => :scenario_owner
+  }.freeze
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable, :registerable
   devise :database_authenticatable, :registerable,
@@ -28,7 +34,8 @@ class User < ApplicationRecord
 
   # rubocop:enable Rails/InverseOf
 
-  has_many :scenarios, foreign_key: :owner_id, dependent: :destroy, inverse_of: :owner
+  has_many :scenario_users, dependent: :destroy
+  has_many :scenarios, through: :scenario_users
   has_many :personal_access_tokens, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 191 }

--- a/app/serializers/scenario_serializer.rb
+++ b/app/serializers/scenario_serializer.rb
@@ -25,7 +25,7 @@ class ScenarioSerializer
       methods: %i[start_year coupling]
     ).symbolize_keys
 
-    json[:users]    = @resource.users&.as_json(only: %i[id email])
+    json[:users]    = @resource.scenario_users.map { |su| { id: su.user.id, email: su.user.email, role: User::ROLES[su.role_id] } }.to_json
     json[:scaling]  = @resource.scaler&.as_json(except: %i[id scenario_id])
     json[:template] = @resource.preset_scenario_id
     json[:url]      = @controller.api_v3_scenario_url(@resource)

--- a/app/serializers/scenario_serializer.rb
+++ b/app/serializers/scenario_serializer.rb
@@ -25,7 +25,7 @@ class ScenarioSerializer
       methods: %i[start_year coupling]
     ).symbolize_keys
 
-    json[:users]    = @resource.scenario_users.map { |su| { id: su.user.id, email: su.user.email, role: User::ROLES[su.role_id] } }.to_json
+    json[:users]    = @resource.scenario_users.map { |su| { id: su.user.id, email: su.user.email, role: User::ROLES[su.role_id] } }
     json[:scaling]  = @resource.scaler&.as_json(except: %i[id scenario_id])
     json[:template] = @resource.preset_scenario_id
     json[:url]      = @controller.api_v3_scenario_url(@resource)

--- a/app/serializers/scenario_serializer.rb
+++ b/app/serializers/scenario_serializer.rb
@@ -25,7 +25,7 @@ class ScenarioSerializer
       methods: %i[start_year coupling]
     ).symbolize_keys
 
-    json[:owner]    = @resource.owner&.as_json(only: %i[id name])
+    json[:users]    = @resource.users&.as_json(only: %i[id email])
     json[:scaling]  = @resource.scaler&.as_json(except: %i[id scenario_id])
     json[:template] = @resource.preset_scenario_id
     json[:url]      = @controller.api_v3_scenario_url(@resource)

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -44,9 +44,9 @@
           - if s.id.to_s == params[:api_scenario_id]
             %span.tag.green &#9733; Current Scenario
         %td
-          - if s.users.present?
-            - s.users.each do |user|
-              = link_to("#{user.name}, #{User::ROLES.key(user.id)}", user_path(user))
+          - if s.scenario_users.present?
+            - s.scenario_users.each do |scenario_user|
+              = link_to("#{scenario_user.user.name} (#{User::ROLES[scenario_user.role_id].to_s.humanize})", user_path(scenario_user.user))
           - else
             %span.muted No owner
         %td= s.end_year

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -19,7 +19,7 @@
     %tr
       %th.narrow.text-center Visibility
       %th ID
-      %th Owner
+      %th Owners
       %th End Year
       %th Area
       %th.narrow Compatibility
@@ -44,8 +44,9 @@
           - if s.id.to_s == params[:api_scenario_id]
             %span.tag.green &#9733; Current Scenario
         %td
-          - if s.owner
-            = link_to(s.owner.name, user_path(s.owner))
+          - if s.users.present?
+            - s.users.each do |user|
+              = link_to("#{user.name}, #{User::ROLES.key(user.id)}", user_path(user))
           - else
             %span.muted No owner
         %td= s.end_year

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -17,9 +17,9 @@
       %tr
         %th Users
         %td
-          - if @scenario.users.present?
-            - @scenario.users.each do |user|
-              = link_to("#{user.name}, #{User::ROLES.key(user.id)}", user_path(user))
+          - if @scenario.scenario_users.present?
+            - @scenario.scenario_users.each do |scenario_user|
+              = link_to("#{scenario_user.user.name} (#{User::ROLES[scenario_user.role_id].to_s.humanize})", user_path(scenario_user.user))
           - else
             %span.muted No owner
       %tr

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -15,10 +15,11 @@
         %th End Year
         %td= @scenario.end_year
       %tr
-        %th Owner
+        %th Users
         %td
-          - if @scenario.owner
-            = link_to(@scenario.owner.name, user_path(@scenario.owner))
+          - if @scenario.users.present?
+            - @scenario.users.each do |user|
+              = link_to("#{user.name}, #{User::ROLES.key(user.id)}", user_path(user))
           - else
             %span.muted No owner
       %tr

--- a/app/views/scenario_invitation_mailer/invite_existing_user.en.text.erb
+++ b/app/views/scenario_invitation_mailer/invite_existing_user.en.text.erb
@@ -1,0 +1,9 @@
+Hello!
+
+<%= @inviter_name %> just invited you to collaborate on scenario '<%= @saved_scenario_title %>' of the Energy Transition Model!
+
+You can use the following link to view the scenario:
+<%= "https://www.energytransitionmodel.com/saved_scenarios/#{@saved_scenario_id}" %>
+
+Best regards,
+Energy Transition Model

--- a/app/views/scenario_invitation_mailer/invite_existing_user.nl.text.erb
+++ b/app/views/scenario_invitation_mailer/invite_existing_user.nl.text.erb
@@ -1,0 +1,9 @@
+Hallo!
+
+<%= @inviter_name %> heeft je net uitgenodigd om samen te werken aan scenario '<%= @saved_scenario_title %>' van het Energie Transitie Model!
+
+Je kan de volgende link gebruiken om te het scenario te bekijken:
+<%= "https://www.energytransitionmodel.com/saved_scenarios/#{@saved_scenario_id}" %>
+
+Met vriendelijke groet,
+Energie Transitie Model

--- a/app/views/scenario_invitation_mailer/invite_new_user.en.text.erb
+++ b/app/views/scenario_invitation_mailer/invite_new_user.en.text.erb
@@ -1,0 +1,13 @@
+Hello!
+
+<%= @inviter_name %> just invited you to collaborate on scenario '<%= @saved_scenario_title %>' of the Energy Transition Model!
+
+If you would like to do so, please create an account
+for logging into the Energy Transition Model at:
+<%= new_user_registration_url %>
+
+Afterwards you can use the following link to view the scenario:
+<%= "https://www.energytransitionmodel.com/saved_scenarios/#{@saved_scenario_id}" %>
+
+Best regards,
+Energy Transition Model

--- a/app/views/scenario_invitation_mailer/invite_new_user.nl.text.erb
+++ b/app/views/scenario_invitation_mailer/invite_new_user.nl.text.erb
@@ -1,0 +1,13 @@
+Hallo!
+
+<%= @inviter_name %> heeft je net uitgenodigd om samen te werken aan scenario '<%= @saved_scenario_title %>' van het Energie Transitie Model!
+
+Mocht je dit willen, maak dan alsjeblieft een account aan
+om in te kunnen loggen op het Energie Transitie Model op:
+<%= new_user_registration_url %>
+
+Daarna kun je de volgende link gebruiken om te het scenario te bekijken:
+<%= "https://www.energytransitionmodel.com/saved_scenarios/#{@saved_scenario_id}" %>
+
+Met vriendelijke groet,
+Energie Transitie Model

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,3 +47,6 @@ en:
         current_password: Current password
         unconfirmed_email: New e-mail address
         name: Your name
+  scenario_invitation_mailer:
+    invite_user:
+      subject: You were invited to participate in an Energy Transition Model scenario!

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -47,3 +47,6 @@ nl:
         current_password: Huidig wachtwoord
         unconfirmed_email: Nieuw e-mailadres
         name: Jouw naam
+  scenario_invitation_mailer:
+    invite_user:
+      subject: Je bent uitgenodigd om deel te nemen aan een Energie Transitie Model scenario!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,8 +96,8 @@ Rails.application.routes.draw do
 
         resources :users, only: %i[index create update destroy], controller: 'scenario_users' do
           collection do
+            post :create
             put :update
-            patch :update
             delete :destroy
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,14 @@ Rails.application.routes.draw do
 
         resource :esdl_file, only: %i[show update]
 
+        resources :users, only: %i[index create update destroy], controller: 'scenario_users' do
+          collection do
+            put :update
+            patch :update
+            delete :destroy
+          end
+        end
+
         get 'curves/buildings_heat',
           to: 'curves#buildings_heat_curves',
           as: :curves_buildings_heat_download

--- a/db/migrate/20231103104416_create_scenario_users.rb
+++ b/db/migrate/20231103104416_create_scenario_users.rb
@@ -2,14 +2,13 @@ class CreateScenarioUsers < ActiveRecord::Migration[7.0]
   def up
     # Create new table + indices
     create_table :scenario_users do |t|
-      t.integer     :user_id, null: false
       t.integer     :scenario_id, null: false
       t.integer     :role_id, null: false
+      t.integer     :user_id, default: nil
       t.string      :user_email, default: nil
     end
 
     add_index :scenario_users, [:scenario_id, :user_id], name: 'scenario_users_scenario_id_user_id_idx'
-    add_index :scenario_users, :user_email, name: 'scenario_users_user_email_idx'
 
     # Create ScenarioUser relations for currently existing scenarios
     Scenario.where.not(owner_id: nil).in_batches.each do |scenario_batch|

--- a/db/migrate/20231103104416_create_scenario_users.rb
+++ b/db/migrate/20231103104416_create_scenario_users.rb
@@ -1,0 +1,35 @@
+class CreateScenarioUsers < ActiveRecord::Migration[7.0]
+  def up
+    # Create new table + indices
+    create_table :scenario_users do |t|
+      t.integer     :user_id, null: false
+      t.integer     :scenario_id, null: false
+      t.integer     :role_id, null: false
+      t.string      :user_email, default: nil
+    end
+
+    add_index :scenario_users, [:scenario_id, :user_id], name: 'scenario_users_scenario_id_user_id_idx'
+    add_index :scenario_users, :user_email, name: 'scenario_users_user_email_idx'
+
+    # Create ScenarioUser relations for currently existing scenarios
+    Scenario.where.not(owner_id: nil).in_batches.each do |scenario_batch|
+      scenario_users = scenario_batch.pluck(:id, :owner_id)
+      scenario_users.map! do |su|
+        {
+          scenario_id: su[0],
+          user_id: su[1],
+          role_id: User::ROLES.key(:scenario_owner),
+          user_email: nil
+        }
+      end
+
+      ScenarioUser.insert_all(scenario_users)
+    end
+  end
+
+  def down
+    remove_index :scenario_users, name: 'scenario_users_scenario_id_user_id_idx'
+    remove_index :scenario_users, name: 'scenario_users_user_email_idx'
+    drop_table :scenario_users
+  end
+end

--- a/db/migrate/20231103104416_create_scenario_users.rb
+++ b/db/migrate/20231103104416_create_scenario_users.rb
@@ -2,15 +2,16 @@ class CreateScenarioUsers < ActiveRecord::Migration[7.0]
   def up
     # Create new table + indices
     create_table :scenario_users do |t|
-      t.integer     :scenario_id, null: false
-      t.integer     :role_id, null: false
-      t.integer     :user_id, default: nil
-      t.string      :user_email, default: nil
+      t.integer :scenario_id, null: false
+      t.integer :role_id, null: false
+      t.integer :user_id, default: nil
+      t.string  :user_email, default: nil
     end
 
-    add_index :scenario_users, [:scenario_id, :user_id], name: 'scenario_users_scenario_id_user_id_idx'
+    add_index :scenario_users, [:scenario_id, :user_id], unique: true,    name: 'scenario_users_scenario_id_user_id_idx'
+    add_index :scenario_users, [:scenario_id, :user_email], unique: true, name: 'scenario_users_scenario_id_user_email_idx'
 
-    # Create ScenarioUser relations for currently existing scenarios
+    # Create ScenarioUser relations for currently existing scenarios, in batches of 1000
     Scenario.where.not(owner_id: nil).in_batches.each do |scenario_batch|
       scenario_users = scenario_batch.pluck(:id, :owner_id)
       scenario_users.map! do |su|
@@ -28,7 +29,7 @@ class CreateScenarioUsers < ActiveRecord::Migration[7.0]
 
   def down
     remove_index :scenario_users, name: 'scenario_users_scenario_id_user_id_idx'
-    remove_index :scenario_users, name: 'scenario_users_user_email_idx'
+    remove_index :scenario_users, name: 'scenario_users_scenario_id_user_email_idx'
     drop_table :scenario_users
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -171,12 +171,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_03_104416) do
   end
 
   create_table "scenario_users", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.integer "user_id", null: false
     t.integer "scenario_id", null: false
     t.integer "role_id", null: false
+    t.integer "user_id"
     t.string "user_email"
-    t.index ["scenario_id", "user_id"], name: "scenario_users_scenario_id_user_id_idx"
-    t.index ["user_email"], name: "scenario_users_user_email_idx"
+    t.index ["scenario_id", "user_email"], name: "scenario_users_scenario_id_user_email_idx", unique: true
+    t.index ["scenario_id", "user_id"], name: "scenario_users_scenario_id_user_id_idx", unique: true
   end
 
   create_table "scenarios", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -170,7 +170,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_03_104416) do
     t.index ["scenario_id"], name: "index_scenario_scalings_on_scenario_id", unique: true
   end
 
-  create_table "scenario_users", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+  create_table "scenario_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "scenario_id", null: false
     t.integer "role_id", null: false
     t.integer "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_31_093749) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_03_104416) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -168,6 +168,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_31_093749) do
     t.boolean "has_industry", default: false, null: false
     t.boolean "has_energy", default: true, null: false
     t.index ["scenario_id"], name: "index_scenario_scalings_on_scenario_id", unique: true
+  end
+
+  create_table "scenario_users", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "scenario_id", null: false
+    t.integer "role_id", null: false
+    t.string "user_email"
+    t.index ["scenario_id", "user_id"], name: "scenario_users_scenario_id_user_id_idx"
+    t.index ["user_email"], name: "scenario_users_user_email_idx"
   end
 
   create_table "scenarios", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/factories/scenario.rb
+++ b/spec/factories/scenario.rb
@@ -1,7 +1,21 @@
 FactoryBot.define do
   factory :scenario do
+    transient do
+      user { nil }
+    end
+
     area_code { "nl" }
     end_year { 2040 }
+
+    after(:build) do |scenario, evaluator|
+      if evaluator.user.present?
+        scenario.scenario_users << build(
+          :scenario_user,
+          user: evaluator.user,
+          scenario: scenario
+        )
+      end
+    end
   end
 
   factory :scenario_with_user_values, parent: :scenario do

--- a/spec/factories/scenario_user.rb
+++ b/spec/factories/scenario_user.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :scenario_user do
     role_id { User::ROLES.key(:scenario_owner) }
     user
+    scenario
   end
 end
 

--- a/spec/factories/scenario_user.rb
+++ b/spec/factories/scenario_user.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :scenario_user do
+    role_id { User::ROLES.key(:scenario_owner) }
+    user
+  end
+end
+
+

--- a/spec/mailers/scenario_invitation_mailer_spec.rb
+++ b/spec/mailers/scenario_invitation_mailer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe ScenarioInvitationMailer, type: :mailer do
+  let(:email) { 'test@quintel.com' }
+  let(:name) { 'Test user' }
+  let(:saved_scenario) { { id: 999, title: 'Some saved scenario' } }
+
+  context 'when inviting an existing user' do
+    let(:mail) { described_class.invite_user('existing', email, name, saved_scenario) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('You were invited to participate in an Energy Transition Model scenario!')
+      expect(mail.to).to eq([email])
+      expect(mail.from).to eq(Mail::Field.parse("From: #{Settings.mailer.from}").addresses)
+    end
+
+    it 'renders the body' do
+      expect(mail.body.raw_source).to include("Test user just invited you to collaborate on scenario 'Some saved scenario' of the Energy Transition Model!")
+      expect(mail.body.raw_source).to include("/saved_scenarios/999")
+      expect(mail.body.raw_source).to_not include("If you would like to do so, please create an account")
+    end
+  end
+
+  context 'when inviting a new user' do
+    let(:mail) { described_class.invite_user('new', email, name, saved_scenario) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('You were invited to participate in an Energy Transition Model scenario!')
+      expect(mail.to).to eq([email])
+      expect(mail.from).to eq(Mail::Field.parse("From: #{Settings.mailer.from}").addresses)
+    end
+
+    it 'renders the body' do
+      expect(mail.body.raw_source).to include("Test user just invited you to collaborate on scenario 'Some saved scenario' of the Energy Transition Model!")
+      expect(mail.body.raw_source).to include("/saved_scenarios/999")
+      expect(mail.body.raw_source).to include("If you would like to do so, please create an account")
+    end
+  end
+end
+

--- a/spec/models/api/guest_ability_spec.rb
+++ b/spec/models/api/guest_ability_spec.rb
@@ -6,58 +6,61 @@ RSpec.describe Api::GuestAbility do
   subject(:ability) { described_class.new }
 
   let(:user) { create(:user) }
+  let!(:public_scenario) { create(:scenario, user: nil, private: false) }
+  let!(:owned_public_scenario) { create(:scenario, user: user, private: false) }
+  let!(:owned_private_scenario) { create(:scenario, user: user, private: true) }
 
   # Read
 
   it 'may view an unowned public scenario' do
-    expect(ability).to be_able_to(:read, create(:scenario, owner: nil, private: false))
+    expect(ability).to be_able_to(:read, public_scenario)
   end
 
   it 'may view an owned public scenario' do
-    expect(ability).to be_able_to(:read, create(:scenario, owner: user, private: false))
+    expect(ability).to be_able_to(:read, owned_public_scenario)
   end
 
   it 'may not view a private scenario' do
-    expect(ability).not_to be_able_to(:read, create(:scenario, owner: user, private: true))
+    expect(ability).not_to be_able_to(:read, owned_private_scenario)
   end
 
   # Update
 
   it 'may change an unowned public scenario' do
-    expect(ability).to be_able_to(:update, create(:scenario, owner: nil, private: false))
+    expect(ability).to be_able_to(:update, public_scenario)
   end
 
   it 'may not change an owned public scenario' do
-    expect(ability).not_to be_able_to(:update, create(:scenario, owner: user, private: false))
+    expect(ability).not_to be_able_to(:update, owned_public_scenario)
   end
 
   it 'may not change an owned private scenario' do
-    expect(ability).not_to be_able_to(:update, create(:scenario, owner: user, private: true))
+    expect(ability).not_to be_able_to(:update, owned_private_scenario)
   end
 
   it 'may clone an unowned public scenario' do
-    expect(ability).to be_able_to(:clone, create(:scenario, owner: nil, private: false))
+    expect(ability).to be_able_to(:clone, public_scenario)
   end
 
   it 'may clone an owned public scenario' do
-    expect(ability).to be_able_to(:clone, create(:scenario, owner: user, private: false))
+    expect(ability).to be_able_to(:clone, owned_public_scenario)
   end
 
   it 'may not clone a private scenario' do
-    expect(ability).not_to be_able_to(:clone, create(:scenario, owner: user, private: true))
+    expect(ability).not_to be_able_to(:clone, owned_private_scenario)
   end
 
   # Delete
 
   it 'may not delete an unowned public scenario' do
-    expect(ability).not_to be_able_to(:destroy, create(:scenario, private: false))
+    expect(ability).not_to be_able_to(:destroy, public_scenario)
   end
 
   it 'may not delete an owned public scenario' do
-    expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: user, private: false))
+    expect(ability).not_to be_able_to(:destroy, owned_public_scenario)
   end
 
   it 'may not delete a private scenario' do
-    expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: user, private: true))
+    expect(ability).not_to be_able_to(:destroy, owned_private_scenario)
   end
 end

--- a/spec/models/api/token_ability_spec.rb
+++ b/spec/models/api/token_ability_spec.rb
@@ -9,41 +9,47 @@ RSpec.describe Api::TokenAbility do
 
   let(:ability) { described_class.new(token, user) }
 
+  let!(:public_scenario) { create(:scenario, user: nil, private: false) }
+  let!(:owned_public_scenario) { create(:scenario, user: user, private: false) }
+  let!(:owned_private_scenario) { create(:scenario, user: user, private: true) }
+  let!(:other_public_scenario) { create(:scenario, user: create(:user), private: false) }
+  let!(:other_private_scenario) { create(:scenario, user: create(:user), private: true) }
+
   # ------------------------------------------------------------------------------------------------
 
   shared_examples_for "a token without the 'scenarios:read' scope" do
     it 'may view an unowned public scenario' do
-      expect(ability).to be_able_to(:read, create(:scenario, owner: nil, private: false))
+      expect(ability).to be_able_to(:read, public_scenario)
     end
 
     it 'may view a self-owned public scenario' do
-      expect(ability).to be_able_to(:read, create(:scenario, owner: user, private: false))
+      expect(ability).to be_able_to(:read, owned_public_scenario)
     end
 
     it 'may view an other-owned public scenario' do
-      expect(ability).to be_able_to(:read, create(:scenario, owner: create(:user), private: false))
+      expect(ability).to be_able_to(:read, other_public_scenario)
     end
 
     it 'may not view an owned private scenario' do
-      expect(ability).not_to be_able_to(:read, create(:scenario, owner: user, private: true))
+      expect(ability).not_to be_able_to(:read, other_private_scenario)
     end
   end
 
   shared_examples_for 'a token with the "scenarios:read" scope' do
     it 'may view an unowned public scenario' do
-      expect(ability).to be_able_to(:read, create(:scenario, owner: nil, private: false))
+      expect(ability).to be_able_to(:read, public_scenario)
     end
 
     it 'may view a self-owned public scenario' do
-      expect(ability).to be_able_to(:read, create(:scenario, owner: user, private: false))
+      expect(ability).to be_able_to(:read, owned_public_scenario)
     end
 
     it 'may view an other-owned public scenario' do
-      expect(ability).to be_able_to(:read, create(:scenario, owner: create(:user), private: false))
+      expect(ability).to be_able_to(:read, other_public_scenario)
     end
 
     it 'may view an owned private scenario' do
-      expect(ability).to be_able_to(:read, create(:scenario, owner: user, private: true))
+      expect(ability).to be_able_to(:read, owned_private_scenario)
     end
   end
 
@@ -53,43 +59,43 @@ RSpec.describe Api::TokenAbility do
     end
 
     it 'may change an unowned public scenario' do
-      expect(ability).to be_able_to(:update, create(:scenario, owner: nil, private: false))
+      expect(ability).to be_able_to(:update, public_scenario)
     end
 
     it 'may change a self-owned public scenario' do
-      expect(ability).to be_able_to(:update, create(:scenario, owner: user, private: false))
+      expect(ability).to be_able_to(:update, owned_public_scenario)
     end
 
     it 'may change a self-owned private scenario' do
-      expect(ability).to be_able_to(:update, create(:scenario, owner: user, private: true))
+      expect(ability).to be_able_to(:update, owned_private_scenario)
     end
 
     it 'may not change an other-owned public scenario' do
-      expect(ability).not_to be_able_to(:update, create(:scenario, owner: create(:user), private: false))
+      expect(ability).not_to be_able_to(:update, other_public_scenario)
     end
 
     it 'may not change an other-owned private scenario' do
-      expect(ability).not_to be_able_to(:update, create(:scenario, owner: create(:user), private: true))
+      expect(ability).not_to be_able_to(:update, other_private_scenario)
     end
 
     it 'may clone an unowned public scenario' do
-      expect(ability).to be_able_to(:clone, create(:scenario, owner: nil, private: false))
+      expect(ability).to be_able_to(:clone, public_scenario)
     end
 
     it 'may clone a self-owned public scenario' do
-      expect(ability).to be_able_to(:clone, create(:scenario, owner: user, private: false))
+      expect(ability).to be_able_to(:clone, owned_public_scenario)
     end
 
     it 'may clone an other-owned public scenario' do
-      expect(ability).to be_able_to(:clone, create(:scenario, owner: create(:user), private: false))
+      expect(ability).to be_able_to(:clone, other_public_scenario)
     end
 
     it 'may clone a self-owned private scenario' do
-      expect(ability).to be_able_to(:clone, create(:scenario, owner: user, private: true))
+      expect(ability).to be_able_to(:clone, owned_private_scenario)
     end
 
     it 'may not clone an other-owned private scenario' do
-      expect(ability).not_to be_able_to(:clone, create(:scenario, owner: create(:user), private: true))
+      expect(ability).not_to be_able_to(:clone, other_private_scenario)
     end
   end
 
@@ -99,79 +105,79 @@ RSpec.describe Api::TokenAbility do
     end
 
     it 'may not change an unowned public scenario' do
-      expect(ability).not_to be_able_to(:update, create(:scenario, owner: nil, private: false))
+      expect(ability).not_to be_able_to(:update, public_scenario)
     end
 
     it 'may not change a self-owned public scenario' do
-      expect(ability).not_to be_able_to(:update, create(:scenario, owner: user, private: false))
+      expect(ability).not_to be_able_to(:update, owned_public_scenario)
     end
 
     it 'may not change a self-owned private scenario' do
-      expect(ability).not_to be_able_to(:update, create(:scenario, owner: user, private: true))
+      expect(ability).not_to be_able_to(:update, owned_private_scenario)
     end
 
     it 'may not change an other-owned public scenario' do
-      expect(ability).not_to be_able_to(:update, create(:scenario, owner: create(:user), private: false))
+      expect(ability).not_to be_able_to(:update, other_public_scenario)
     end
 
     it 'may not change an other-owned private scenario' do
-      expect(ability).not_to be_able_to(:update, create(:scenario, owner: create(:user), private: true))
+      expect(ability).not_to be_able_to(:update, other_private_scenario)
     end
 
     it 'may not clone an unowned public scenario' do
-      expect(ability).not_to be_able_to(:clone, create(:scenario, owner: nil, private: false))
+      expect(ability).not_to be_able_to(:clone, public_scenario)
     end
 
     it 'may not clone an owned public scenario' do
-      expect(ability).not_to be_able_to(:clone, create(:scenario, owner: user, private: false))
+      expect(ability).not_to be_able_to(:clone, owned_public_scenario)
     end
 
     it 'may not clone an owned private scenario' do
-      expect(ability).not_to be_able_to(:clone, create(:scenario, owner: user, private: true))
+      expect(ability).not_to be_able_to(:clone, owned_private_scenario)
     end
   end
 
   shared_examples_for 'a token with the "scenarios:delete" scope' do
     it 'may not delete an unowned public scenario' do
-      expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: nil, private: false))
+      expect(ability).not_to be_able_to(:destroy, public_scenario)
     end
 
     it 'may delete a self-owned public scenario' do
-      expect(ability).to be_able_to(:destroy, create(:scenario, owner: user, private: false))
+      expect(ability).to be_able_to(:destroy, owned_public_scenario)
     end
 
     it 'may delete a self-owned private scenario' do
-      expect(ability).to be_able_to(:destroy, create(:scenario, owner: user, private: true))
+      expect(ability).to be_able_to(:destroy, owned_private_scenario)
     end
 
     it 'may not delete an other-owned public scenario' do
-      expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: create(:user), private: false))
+      expect(ability).not_to be_able_to(:destroy, other_public_scenario)
     end
 
     it 'may not delete an other-owned private scenario' do
-      expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: create(:user), private: true))
+      expect(ability).not_to be_able_to(:destroy, other_private_scenario)
     end
   end
 
   shared_examples_for 'a token without the "scenarios:delete" scope' do
     it 'may not delete an unowned public scenario' do
-      expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: nil, private: false))
+      expect(ability).not_to be_able_to(:destroy, public_scenario)
     end
 
     it 'may not delete a self-owned public scenario' do
-      expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: user, private: false))
+      expect(ability).not_to be_able_to(:destroy, owned_public_scenario)
     end
 
     it 'may not delete a self-owned private scenario' do
-      expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: user, private: true))
+      expect(ability).not_to be_able_to(:destroy, owned_private_scenario)
     end
 
     it 'may not delete an other-owned public scenario' do
-      expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: create(:user), private: false))
+      expect(ability).not_to be_able_to(:destroy, other_public_scenario)
     end
 
     it 'may not delete an other-owned private scenario' do
-      expect(ability).not_to be_able_to(:destroy, create(:scenario, owner: create(:user), private: true))
+      expect(ability).not_to be_able_to(:destroy, other_private_scenario)
     end
   end
 

--- a/spec/models/scenario_user_spec.rb
+++ b/spec/models/scenario_user_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe ScenarioUser do
+  let(:scenario) { create(:scenario) }
+
+  it { is_expected.to validate_inclusion_of(:role_id).in_array(User::ROLES.keys) }
+
+  it { is_expected.to belong_to(:scenario) }
+  it { is_expected.to belong_to(:user).optional }
+
+  it 'validates on_save with user_email and no user_id set' do
+    expect do
+      create(:scenario_user,
+        scenario: scenario,
+        user: nil,
+        user_email: 'test@test.com'
+      )
+    end.to_not raise_error
+  end
+
+  it 'validates on_save with user_id and no user_email set' do
+    expect do
+      create(:scenario_user,
+        scenario: scenario,
+        user: create(:user)
+      )
+    end.to_not raise_error
+  end
+
+  it 'allows updating the role if not the last scenario owner' do
+    # The first user added will automatically become the scenario owner
+    scenario.user = create(:user)
+    scenario_user = create(
+      :scenario_user,
+      scenario: scenario,
+      role_id: User::ROLES.key(:scenario_owner)
+    )
+
+    scenario_user.update(role_id: User::ROLES.key(:scenario_viewer))
+
+    expect(
+      scenario_user.reload.role_id
+    ).to be(User::ROLES.key(:scenario_viewer))
+  end
+
+  it 'allows destroying a record if not the last scenario owner' do
+    # The first user added will automatically become the scenario owner
+    scenario.user = create(:user)
+    scenario_user = create(
+      :scenario_user,
+      scenario: scenario,
+      role_id: User::ROLES.key(:scenario_owner)
+    )
+
+    scenario_user.destroy
+
+    expect(
+      scenario.scenario_users.count
+    ).to be(1)
+  end
+
+  it 'raises an error when validating an incorrect email address' do
+    expect do
+      create(:scenario_user,
+        scenario: scenario,
+        user: nil,
+        user_email: 'test'
+      )
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'raises an error when both user and email address are present' do
+    expect do
+      create(:scenario_user,
+        scenario: scenario,
+        user: create(:user),
+        user_email: 'test@test.com'
+      )
+    end.to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'cancels an update action for the last owner of a scenario' do
+    # The first user added will automatically become the scenario owner
+    scenario.user = create(:user)
+
+    scenario_user = scenario.scenario_users.first
+    scenario_user.update(role_id: User::ROLES.key(:scenario_viewer))
+
+    expect(
+      scenario_user.reload.role_id
+    ).to be(User::ROLES.key(:scenario_owner))
+  end
+
+  it 'cancels a destroy action for the last owner of a scenario if other users are present' do
+    owner = create(:scenario_user, scenario: scenario, role_id: User::ROLES.key(:scenario_owner))
+    viewer = create(:scenario_user, scenario: scenario, role_id: User::ROLES.key(:scenario_viewer))
+
+    owner.destroy
+
+    expect(owner.reload).to_not be(nil)
+  end
+
+  it 'does not cancel destroy action for the last owner of a scenario if its the last user' do
+    # The first user added will automatically become the scenario owner
+    owner = create(:scenario_user, scenario: scenario, role_id: User::ROLES.key(:scenario_owner))
+    owner.destroy
+
+    expect(
+      scenario.scenario_users.count
+    ).to be(0)
+  end
+end

--- a/spec/models/scenario_user_spec.rb
+++ b/spec/models/scenario_user_spec.rb
@@ -27,6 +27,22 @@ describe ScenarioUser do
     end.to_not raise_error
   end
 
+  context 'when creating a new scenario user with a known email adres' do
+    let(:user) { create(:user, email: email) }
+    let(:email) { 'hi@me.com' }
+    let(:scenario_user) { create(:scenario_user, user_email: email, user_id: nil) }
+
+    before { user }
+
+    it 'sets the user on the scenario user' do
+      expect(scenario_user.user_id).to eq(user.id)
+    end
+
+    it 'removes the email from the scenario_user' do
+      expect(scenario_user.user_email).to be_nil
+    end
+  end
+
   it 'allows updating the role if not the last scenario owner' do
     # The first user added will automatically become the scenario owner
     scenario.user = create(:user)

--- a/spec/requests/api/v3/create_scenario_spec.rb
+++ b/spec/requests/api/v3/create_scenario_spec.rb
@@ -87,7 +87,7 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       post '/api/v3/scenarios',
         params: { scenario: { user_values: { foo_demand: 10.0 } } }
 
-      expect(JSON.parse(response.body)['owner']).to be_nil
+      expect(JSON.parse(response.body)['users']).to eq([])
     end
   end
 
@@ -102,8 +102,8 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(response.status).to eq(200)
     end
 
-    it 'sets the scenario owner' do
-      expect(JSON.parse(response.body)['owner']).to include('id' => user.id)
+    it 'sets a scenario owner' do
+      expect(response.parsed_body['users'].first).to include('role' => 'scenario_owner')
     end
   end
 
@@ -211,8 +211,8 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(json['private']).to be(true)
     end
 
-    it 'sets the owner of the new scenario' do
-      expect(json.fetch('owner').fetch('id')).to eq(user.id)
+    it 'sets an owner of the new scenario' do
+      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
     end
   end
 
@@ -234,8 +234,8 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(json['private']).to be(true)
     end
 
-    it 'sets the owner of the new scenario' do
-      expect(json.fetch('owner').fetch('id')).to eq(user.id)
+    it 'sets an owner of the new scenario' do
+      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
     end
   end
 
@@ -257,8 +257,8 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(json['private']).to be(false)
     end
 
-    it 'sets the owner of the new scenario' do
-      expect(json.fetch('owner').fetch('id')).to eq(user.id)
+    it 'sets an owner of the new scenario' do
+      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
     end
   end
 
@@ -269,7 +269,7 @@ describe 'APIv3 Scenarios', :etsource_fixture do
         headers: access_token_header(user, :write)
     end
 
-    let(:parent) { create(:scenario, owner: user, private: true) }
+    let(:parent) { create(:scenario, user: user, private: true) }
     let(:user) { create(:user) }
     let(:json) { JSON.parse(response.body) }
 
@@ -277,8 +277,8 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(json['private']).to be(true)
     end
 
-    it 'sets the owner of the new scenario' do
-      expect(json.fetch('owner').fetch('id')).to eq(user.id)
+    it 'sets an owner of the new scenario' do
+      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
     end
   end
 
@@ -289,7 +289,7 @@ describe 'APIv3 Scenarios', :etsource_fixture do
         headers: access_token_header(user, :write)
     end
 
-    let(:parent) { create(:scenario, owner: user, private: true) }
+    let(:parent) { create(:scenario, user: user, private: true) }
     let(:user) { create(:user) }
     let(:json) { JSON.parse(response.body) }
 
@@ -301,8 +301,8 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(json['private']).to be(false)
     end
 
-    it 'sets the owner of the new scenario' do
-      expect(json.fetch('owner').fetch('id')).to eq(user.id)
+    it 'sets an owner of the new scenario' do
+      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
     end
   end
 
@@ -313,7 +313,7 @@ describe 'APIv3 Scenarios', :etsource_fixture do
         headers: access_token_header(user, :write)
     end
 
-    let(:parent) { create(:scenario, owner: create(:user), private: false) }
+    let(:parent) { create(:scenario, user: create(:user), private: false) }
     let(:user) { create(:user) }
     let(:json) { JSON.parse(response.body) }
 
@@ -325,8 +325,8 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(json['private']).to be(false)
     end
 
-    it 'sets the owner of the new scenario' do
-      expect(json.fetch('owner').fetch('id')).to eq(user.id)
+    it 'sets an owner of the new scenario' do
+      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
     end
   end
 
@@ -337,7 +337,7 @@ describe 'APIv3 Scenarios', :etsource_fixture do
         headers: access_token_header(user, :write)
     end
 
-    let(:parent) { create(:scenario, owner: user, private: false) }
+    let(:parent) { create(:scenario, user: user, private: false) }
     let(:user) { create(:user) }
     let(:json) { JSON.parse(response.body) }
 
@@ -349,8 +349,8 @@ describe 'APIv3 Scenarios', :etsource_fixture do
       expect(json['private']).to be(true)
     end
 
-    it 'sets the owner of the new scenario' do
-      expect(json.fetch('owner').fetch('id')).to eq(user.id)
+    it 'sets an owner of the new scenario' do
+      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
     end
   end
 
@@ -361,7 +361,7 @@ describe 'APIv3 Scenarios', :etsource_fixture do
         headers: access_token_header(user, :write)
     end
 
-    let(:parent) { create(:scenario, owner: create(:user), private: true) }
+    let(:parent) { create(:scenario, user: create(:user), private: true) }
     let(:user) { create(:user) }
     let(:json) { JSON.parse(response.body) }
 

--- a/spec/requests/api/v3/custom_curve_spec.rb
+++ b/spec/requests/api/v3/custom_curve_spec.rb
@@ -381,7 +381,8 @@ describe 'Custom curves', :etsource_fixture do
 
     context "when uploading a curve to someone else's public scenario" do
       before do
-        scenario.update!(owner: create(:user))
+        #scenario.update!(owner: create(:user))
+        scenario.user = create(:user)
       end
 
       let(:request) do
@@ -410,7 +411,8 @@ describe 'Custom curves', :etsource_fixture do
 
     context 'when uploading a curve to an owned private scenario' do
       before do
-        scenario.update!(owner: user)
+        scenario.scenario_users.destroy_all
+        scenario.user = user
       end
 
       let(:user) { create(:user) }
@@ -441,6 +443,8 @@ describe 'Custom curves', :etsource_fixture do
 
     context 'when removing an attached curve' do
       before do
+        scenario.scenario_users.destroy_all
+
         put url, params: {
           file: fixture_file_upload('price_curve.csv', 'text/csv')
         }
@@ -475,11 +479,14 @@ describe 'Custom curves', :etsource_fixture do
     context 'when removing an attached curve from an owned scenario' do
       before do
         put url, params: { file: fixture_file_upload('price_curve.csv', 'text/csv') }
-        scenario.update!(owner: user)
+
+        scenario.scenario_users.destroy_all
+        scenario.user = user
       end
 
       let(:user) { create(:user) }
-      let(:request) { delete url, headers: access_token_header(user, :write) }
+
+      let(:request) { delete url, headers: access_token_header(user, :delete) }
 
       it 'succeeds' do
         request
@@ -512,7 +519,7 @@ describe 'Custom curves', :etsource_fixture do
           file: fixture_file_upload('price_curve.csv', 'text/csv')
         }
 
-        scenario.update!(owner: create(:user))
+        scenario.user = create(:user)
       end
 
       let(:request) { delete url }

--- a/spec/requests/api/v3/delete_scenario_spec.rb
+++ b/spec/requests/api/v3/delete_scenario_spec.rb
@@ -23,7 +23,7 @@ describe 'Deleting a scenario with API v3' do
 
     context 'when the scenario is owned by someone' do
       before do
-        scenario.update!(owner: create(:user), private: false)
+        scenario.user = create(:user)
         delete "/api/v3/scenarios/#{scenario.id}"
       end
 
@@ -34,7 +34,9 @@ describe 'Deleting a scenario with API v3' do
 
     context 'when the scenario is private' do
       before do
-        scenario.update!(owner: create(:user), private: true)
+        scenario.scenario_users.destroy_all
+        scenario.user = create(:user)
+        scenario.reload.update!(private: true)
         delete "/api/v3/scenarios/#{scenario.id}"
       end
 
@@ -59,7 +61,8 @@ describe 'Deleting a scenario with API v3' do
 
     context 'when the scenario is public and owned by the user' do
       before do
-        scenario.update!(owner: user, private: false)
+        scenario.scenario_users.destroy_all
+        scenario.user = user
         delete "/api/v3/scenarios/#{scenario.id}", headers: access_token_header(user, :delete)
       end
 
@@ -70,7 +73,8 @@ describe 'Deleting a scenario with API v3' do
 
     context 'when the scenario is public and owned by the user but the token lacks scenarios:delete' do
       before do
-        scenario.update!(owner: user, private: false)
+        scenario.scenario_users.destroy_all
+        scenario.user = user
         delete "/api/v3/scenarios/#{scenario.id}", headers: access_token_header(user, :write)
       end
 
@@ -81,7 +85,8 @@ describe 'Deleting a scenario with API v3' do
 
     context 'when the scenario is owned by someone else' do
       before do
-        scenario.update!(owner: create(:user), private: false)
+        scenario.scenario_users.destroy_all
+        scenario.user = create(:user)
         delete "/api/v3/scenarios/#{scenario.id}", headers: access_token_header(user, :delete)
       end
 
@@ -92,7 +97,9 @@ describe 'Deleting a scenario with API v3' do
 
     context 'when the scenario is private and owned by the user' do
       before do
-        scenario.update!(owner: user, private: true)
+        scenario.scenario_users.destroy_all
+        scenario.user = user
+        scenario.reload.update!(private: true)
         delete "/api/v3/scenarios/#{scenario.id}", headers: access_token_header(user, :delete)
       end
 
@@ -103,7 +110,9 @@ describe 'Deleting a scenario with API v3' do
 
     context 'when the scenario is private and owned by someone else' do
       before do
-        scenario.update!(owner: create(:user), private: true)
+        scenario.scenario_users.destroy_all
+        scenario.user = create(:user)
+        scenario.reload.update!(private: true)
         delete "/api/v3/scenarios/#{scenario.id}", headers: access_token_header(user, :delete)
       end
 

--- a/spec/requests/api/v3/forecast_storage_order_spec.rb
+++ b/spec/requests/api/v3/forecast_storage_order_spec.rb
@@ -144,7 +144,8 @@ describe 'APIv3 forecast storage network orders' do
 
     context 'when the scenario is owned by someone else' do
       before do
-        scenario.update!(owner: create(:user))
+        scenario.scenario_users.destroy_all
+        scenario.user = create(:user)
         put url, params: { order: valid_options.reverse }
       end
 
@@ -156,7 +157,8 @@ describe 'APIv3 forecast storage network orders' do
     context 'when the scenario is owned by the current user' do
       before do
         user = create(:user)
-        scenario.update!(owner: user)
+        scenario.scenario_users.destroy_all
+        scenario.user = user
 
         put url,
           params: { order: valid_options.reverse },

--- a/spec/requests/api/v3/heat_network_orders_spec.rb
+++ b/spec/requests/api/v3/heat_network_orders_spec.rb
@@ -146,7 +146,8 @@ describe 'APIv3 heat network orders' do
 
     context 'when the scenario is owned by someone else' do
       before do
-        scenario.update!(owner: create(:user))
+        scenario.scenario_users.destroy_all
+        scenario.user = create(:user)
         put url, params: { order: valid_options.reverse }
       end
 
@@ -158,7 +159,8 @@ describe 'APIv3 heat network orders' do
     context 'when the scenario is owned by the current user' do
       before do
         user = create(:user)
-        scenario.update!(owner: user)
+        scenario.scenario_users.destroy_all
+        scenario.user = user
 
         put url,
           params: { order: valid_options.reverse },

--- a/spec/requests/api/v3/list_scenarios_spec.rb
+++ b/spec/requests/api/v3/list_scenarios_spec.rb
@@ -23,12 +23,12 @@ describe 'Deleting a scenario with API v3' do
   context 'when authenticated' do
     let(:user) { create(:user) }
 
-    let!(:scenario1) { create(:scenario, owner: user, private: false, created_at: 5.minutes.ago) }
-    let!(:scenario2) { create(:scenario, owner: user, private: true,  created_at: 4.minutes.ago) }
-    let!(:scenario3) { create(:scenario, owner: user, private: false, created_at: 3.minutes.ago) }
+    let!(:scenario1) { create(:scenario, user: user, private: false, created_at: 5.minutes.ago) }
+    let!(:scenario2) { create(:scenario, user: user, private: true, created_at: 4.minutes.ago) }
+    let!(:scenario3) { create(:scenario, user: user, private: false, created_at: 3.minutes.ago) }
 
     let!(:public_scenario) { create(:scenario) }
-    let!(:other_scenario) { create(:scenario, owner: create(:user)) }
+    let!(:other_scenario) { create(:scenario, user: create(:user)) }
 
     let(:json) { JSON.parse(response.body) }
 
@@ -41,8 +41,8 @@ describe 'Deleting a scenario with API v3' do
         expect(response.status).to eq(200)
       end
 
-      it 'returns only the public scenarios' do
-        expect(json['data'].map { |scenario| scenario['id'] }.sort)
+      it 'returns only the user-owned public scenarios' do
+        expect(json['data'].pluck('id').sort)
           .to eq([scenario1.id, scenario3.id].sort)
       end
     end
@@ -57,16 +57,16 @@ describe 'Deleting a scenario with API v3' do
       end
 
       it 'lists the scenarios' do
-        expect(json['data'].map { |scenario| scenario['id'] }.sort)
+        expect(json['data'].pluck('id').sort)
           .to eq([scenario3.id, scenario2.id, scenario1.id].sort)
       end
 
       it 'does not include unowned scenarios' do
-        expect(json['data'].map { |scenario| scenario['id'] }).not_to include(public_scenario.id)
+        expect(json['data'].pluck('id')).not_to include(public_scenario.id)
       end
 
       it 'does not include scenarios belonging to other users' do
-        expect(json['data'].map { |scenario| scenario['id'] }).not_to include(other_scenario.id)
+        expect(json['data'].pluck('id')).not_to include(other_scenario.id)
       end
 
       it 'does not include a link to the previous page' do

--- a/spec/requests/api/v3/merge_scenarios_spec.rb
+++ b/spec/requests/api/v3/merge_scenarios_spec.rb
@@ -95,7 +95,7 @@ describe 'APIv3 merging scenarios', :etsource_fixture do
       })
     end
 
-    before { scenario_one.update!(owner: create(:user), private: true) }
+    before { scenario_one.update!(user: create(:user), private: true) }
 
     it 'returns 404' do
       request

--- a/spec/requests/api/v3/saved_scenarios_spec.rb
+++ b/spec/requests/api/v3/saved_scenarios_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Saved scenarios API' do
 
   context 'when fetching a single saved scenario' do
     context 'when the saved scenario and scenario exist' do
-      let(:scenario) { create(:scenario, owner: user, area_code: 'nl') }
+      let(:scenario) { create(:scenario, user: user, area_code: 'nl') }
 
       before do
         stub_etmodel_request('/api/v1/saved_scenarios/1') do
@@ -110,7 +110,7 @@ RSpec.describe 'Saved scenarios API' do
     end
 
     context 'when the saved scenario exists but the scenario is not accessible' do
-      let(:scenario) { create(:scenario, owner: create(:user), private: true) }
+      let(:scenario) { create(:scenario, user: create(:user), private: true) }
 
       before do
         stub_etmodel_request('/api/v1/saved_scenarios/1') do
@@ -173,7 +173,7 @@ RSpec.describe 'Saved scenarios API' do
 
   context 'when creating a saved scenario' do
     context 'when the scenario exists' do
-      let(:scenario) { create(:scenario, owner: user) }
+      let(:scenario) { create(:scenario, user: user) }
       let(:params) do
         {
           title: 'My saved scenario',
@@ -214,7 +214,7 @@ RSpec.describe 'Saved scenarios API' do
     end
 
     context 'when missing the title' do
-      let(:scenario) { create(:scenario, owner: user) }
+      let(:scenario) { create(:scenario, user: user) }
 
       before do
         stub_etmodel_request('/api/v1/saved_scenarios', method: :post) do
@@ -240,7 +240,7 @@ RSpec.describe 'Saved scenarios API' do
     end
 
     context 'when the scenario is not accessible' do
-      let(:scenario) { create(:scenario, owner: create(:user), private: true) }
+      let(:scenario) { create(:scenario, user: create(:user), private: true) }
 
       before do
         post '/api/v3/saved_scenarios',
@@ -292,7 +292,7 @@ RSpec.describe 'Saved scenarios API' do
 
   context 'when updating a saved scenario' do
     context 'when the scenario exists' do
-      let(:scenario) { create(:scenario, owner: user) }
+      let(:scenario) { create(:scenario, user: user) }
 
       let(:params) do
         {
@@ -334,7 +334,7 @@ RSpec.describe 'Saved scenarios API' do
     end
 
     context 'when the saved scenario is not accessible' do
-      let(:scenario) { create(:scenario, owner: user) }
+      let(:scenario) { create(:scenario, user: user) }
 
       let(:params) do
         {

--- a/spec/requests/api/v3/scenario_users_controller_spec.rb
+++ b/spec/requests/api/v3/scenario_users_controller_spec.rb
@@ -32,10 +32,8 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
       end
 
       it 'returns a list of all users' do
-        expect(response.body).to eq(
-          [
-            { id: user.id, email: nil, role: 'scenario_owner' }
-          ].to_json
+        expect(JSON.parse(response.body)).to include(
+          a_hash_including('user_id' => user.id, 'user_email' => nil, 'role' => 'scenario_owner')
         )
       end
     end
@@ -48,9 +46,9 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
           headers: access_token_header(user, :delete),
           params: {
             scenario_users: [
-              { id: nil, email: 'viewer@test.com', role: 'scenario_viewer' },
-              { id: nil, email: 'collaborator@test.com', role: 'scenario_collaborator' },
-              { id: nil, email: 'owner@test.com', role: 'scenario_owner' }
+              { user_email: 'viewer@test.com', role: 'scenario_viewer' },
+              { user_email: 'collaborator@test.com', role: 'scenario_collaborator' },
+              { user_email: 'owner@test.com', role: 'scenario_owner' }
             ]
           }
       end
@@ -60,12 +58,10 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
       end
 
       it 'adds the given users to the scenario' do
-        expect(response.body).to eq(
-          [
-            { id: nil, email: 'viewer@test.com', role: 'scenario_viewer' },
-            { id: nil, email: 'collaborator@test.com', role: 'scenario_collaborator' },
-            { id: nil, email: 'owner@test.com', role: 'scenario_owner' }
-          ].to_json
+        expect(JSON.parse(response.body)).to include(
+          a_hash_including('user_id' => nil, 'user_email' => 'viewer@test.com', 'role' => 'scenario_viewer'),
+          a_hash_including('user_id' => nil, 'user_email' => 'collaborator@test.com', 'role' => 'scenario_collaborator'),
+          a_hash_including('user_id' => nil, 'user_email' => 'owner@test.com', 'role' => 'scenario_owner')
         )
       end
     end
@@ -75,9 +71,7 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
         post "/api/v3/scenarios/#{scenario.id}/users", as: :json,
           headers: access_token_header(user, :delete),
           params: {
-            scenario_users: [
-              { id: nil, email: 'viewer@test.com' }
-            ]
+            scenario_users: [{ user_email: 'viewer@test.com' }]
           }
       end
 
@@ -87,7 +81,7 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
 
       it 'returns an error' do
         expect(response.body).to eq(
-          { id: nil, email: 'viewer@test.com', error: 'role_id is invalid.' }.to_json
+          { user_email: 'viewer@test.com', error: 'role_id is invalid.' }.to_json
         )
       end
     end
@@ -98,8 +92,8 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
           headers: access_token_header(user, :delete),
           params: {
             scenario_users: [
-              { id: nil, email: 'viewer@test.com', role: 'scenario_viewer' },
-              { id: nil, email: 'viewer@test.com', role: 'scenario_collaborator' },
+              { user_email: 'viewer@test.com', role: 'scenario_viewer' },
+              { user_email: 'viewer@test.com', role: 'scenario_collaborator' },
             ]
           }
       end
@@ -111,7 +105,7 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
       it 'returns an error' do
         expect(response.body).to eq(
           {
-            id: nil, role: 'scenario_collaborator', email: 'viewer@test.com',
+            role: 'scenario_collaborator', user_email: 'viewer@test.com',
             error: 'A user with this ID or email already exists for this scenario'
           }.to_json
         )
@@ -138,8 +132,8 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
           headers: access_token_header(user, :delete),
           params: {
             scenario_users: [
-              { id: user_2.id, role: 'scenario_owner' },
-              { id: user_3.id, role: 'scenario_viewer' },
+              { user_id: user_2.id, role: 'scenario_owner' },
+              { user_id: user_3.id, role: 'scenario_viewer' },
             ]
           }
       end
@@ -149,43 +143,9 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
       end
 
       it 'updates the role for the given user' do
-        expect(response.body).to eq(
-          [
-            { id: user_2.id, email: nil, role: 'scenario_owner' },
-            { id: user_3.id, email: nil, role: 'scenario_viewer' },
-          ].to_json
-        )
-      end
-    end
-
-    context 'with a duplicate user id' do
-      let(:user_2) { create(:user) }
-
-      before do
-        create(:scenario_user,
-          scenario: scenario, user: user_2,
-          role_id: User::ROLES.key(:scenario_viewer)
-        )
-
-        put "/api/v3/scenarios/#{scenario.id}/users", as: :json,
-          headers: access_token_header(user, :delete),
-          params: {
-            scenario_users: [
-              { id: user_2.id, role: 'scenario_owner' },
-              { id: user_2.id, role: 'scenario_viewer' },
-            ]
-          }
-      end
-
-      it 'returns success' do
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'updates the user to the last stated role' do
-        expect(response.body).to eq(
-          [
-            { id: user_2.id, email: nil, role: 'scenario_viewer' }
-          ].to_json
+        expect(JSON.parse(response.body)).to include(
+          a_hash_including('user_id' => user_2.id, 'user_email' => nil, 'role' => 'scenario_owner'),
+          a_hash_including('user_id' => user_3.id, 'user_email' => nil, 'role' => 'scenario_viewer')
         )
       end
     end
@@ -196,7 +156,7 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
           headers: access_token_header(user, :delete),
           params: {
             scenario_users: [
-              { id: 999, role: 'scenario_collaborator' },
+              { user_id: 999, role: 'scenario_collaborator' },
             ]
           }
       end
@@ -207,7 +167,7 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
 
       it 'returns an error' do
         expect(response.body).to eq(
-          { id: 999, role: 'scenario_collaborator', error: 'Scenario user not found' }.to_json
+          { 'role' => 'scenario_collaborator', 'user_id' => 999, 'error' => 'Scenario user not found' }.to_json
         )
       end
     end
@@ -217,9 +177,7 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
         put "/api/v3/scenarios/#{scenario.id}/users", as: :json,
           headers: access_token_header(user, :delete),
           params: {
-            scenario_users: [
-              { id: 999 },
-            ]
+            scenario_users: [{ user_id: 999 }]
           }
       end
 
@@ -229,7 +187,7 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
 
       it 'returns an error' do
         expect(response.body).to eq(
-          { id: 999, error: 'No role given to update with.' }.to_json
+          { user_id: 999, error: 'Missing attribute(s) for scenario_user: role' }.to_json
         )
       end
     end
@@ -253,7 +211,7 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
         delete "/api/v3/scenarios/#{scenario.id}/users", as: :json,
           headers: access_token_header(user, :delete),
           params: {
-            scenario_users: [{ id: user_2.id }, { id: user_3.id }]
+            scenario_users: [{ user_id: user_2.id }, { user_id: user_3.id }]
           }
       end
 
@@ -272,55 +230,21 @@ RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
       end
     end
 
-    context 'with duplicate user ids' do
-      let(:user_2) { create(:user) }
-      let(:user_3) { create(:user) }
-
-      before do
-        create(:scenario_user,
-          scenario: scenario, user: user_2,
-          role_id: User::ROLES.key(:scenario_viewer)
-        )
-        create(:scenario_user,
-          scenario: scenario, user: user_3,
-          role_id: User::ROLES.key(:scenario_collaborator)
-        )
-
-        delete "/api/v3/scenarios/#{scenario.id}/users", as: :json,
-          headers: access_token_header(user, :delete),
-          params: {
-            scenario_users: [{ id: user_2.id }, { id: user_2.id }] # User 2, twice
-          }
-      end
-
-      it 'returns 422: unprocessable_entity' do
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
-      it 'returns an empty response body' do
-        expect(response.body).to eq(
-          {'error': 'Duplicate user ids found in request, please revise.'}.to_json
-        )
-      end
-    end
-
     context 'with a non-existing user id' do
       before do
         delete "/api/v3/scenarios/#{scenario.id}/users", as: :json,
           headers: access_token_header(user, :delete),
           params: {
-            scenario_users: [{ id: 999 }]
+            scenario_users: [{ user_id: 999 }]
           }
       end
 
-      it 'returns 404: not found' do
-        expect(response).to have_http_status(:not_found)
+      it 'returns OK' do
+        expect(response).to have_http_status(:ok)
       end
 
       it 'returns an empty response body' do
-        expect(response.body).to eq(
-          {'error': 'Could not find user(s) with id: 999'}.to_json
-        )
+        expect(response.body).to eq('')
       end
     end
   end

--- a/spec/requests/api/v3/scenario_users_controller_spec.rb
+++ b/spec/requests/api/v3/scenario_users_controller_spec.rb
@@ -1,0 +1,329 @@
+require 'spec_helper'
+
+RSpec.describe 'Api::V3::ScenarioUsers', type: :request, api: true do
+  let(:user) { create(:user) }
+  let!(:scenario) { create(:scenario, user: user) }
+
+  describe 'GET index' do
+    it 'returns invalid token without a proper access token' do
+      get "/api/v3/scenarios/#{scenario.id}/users", as: :json
+
+      expect(response.status).to be(401)
+    end
+
+    # A user should have a token with the scenario:delete scope before its allowed
+    # to do anything through this endpoint, because this is what equals to the 'owner' role.
+    it 'returns forbidden for a token without the proper access scope' do
+      get "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+        headers: access_token_header(user, :read)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context 'with a proper token and scope' do
+      before do
+        get "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete)
+
+      end
+
+      it 'returns success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a list of all users' do
+        expect(response.body).to eq(
+          [
+            { id: user.id, email: nil, role: 'scenario_owner' }
+          ].to_json
+        )
+      end
+    end
+  end
+
+  describe 'POST /api/v3/scenarios/:id/users' do
+    context 'with proper params' do
+      before do
+        post "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [
+              { id: nil, email: 'viewer@test.com', role: 'scenario_viewer' },
+              { id: nil, email: 'collaborator@test.com', role: 'scenario_collaborator' },
+              { id: nil, email: 'owner@test.com', role: 'scenario_owner' }
+            ]
+          }
+      end
+
+      it 'returns success' do
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'adds the given users to the scenario' do
+        expect(response.body).to eq(
+          [
+            { id: nil, email: 'viewer@test.com', role: 'scenario_viewer' },
+            { id: nil, email: 'collaborator@test.com', role: 'scenario_collaborator' },
+            { id: nil, email: 'owner@test.com', role: 'scenario_owner' }
+          ].to_json
+        )
+      end
+    end
+
+    context 'with malformed user params' do
+      before do
+        post "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [
+              { id: nil, email: 'viewer@test.com' }
+            ]
+          }
+      end
+
+      it 'returns 422: unprocessable entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns an error' do
+        expect(response.body).to eq(
+          { id: nil, email: 'viewer@test.com', error: 'role_id is invalid.' }.to_json
+        )
+      end
+    end
+
+    context 'with duplicate user params' do
+      before do
+        post "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [
+              { id: nil, email: 'viewer@test.com', role: 'scenario_viewer' },
+              { id: nil, email: 'viewer@test.com', role: 'scenario_collaborator' },
+            ]
+          }
+      end
+
+      it 'returns 422: unprocessable entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns an error' do
+        expect(response.body).to eq(
+          {
+            id: nil, role: 'scenario_collaborator', email: 'viewer@test.com',
+            error: 'A user with this ID or email already exists for this scenario'
+          }.to_json
+        )
+      end
+    end
+  end
+
+  describe 'PUT /api/v3/scenarios/:id/users' do
+    context 'with proper params' do
+      let(:user_2) { create(:user) }
+      let(:user_3) { create(:user) }
+
+      before do
+        create(:scenario_user,
+          scenario: scenario, user: user_2,
+          role_id: User::ROLES.key(:scenario_viewer)
+        )
+        create(:scenario_user,
+          scenario: scenario, user: user_3,
+          role_id: User::ROLES.key(:scenario_collaborator)
+        )
+
+        put "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [
+              { id: user_2.id, role: 'scenario_owner' },
+              { id: user_3.id, role: 'scenario_viewer' },
+            ]
+          }
+      end
+
+      it 'returns success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the role for the given user' do
+        expect(response.body).to eq(
+          [
+            { id: user_2.id, email: nil, role: 'scenario_owner' },
+            { id: user_3.id, email: nil, role: 'scenario_viewer' },
+          ].to_json
+        )
+      end
+    end
+
+    context 'with a duplicate user id' do
+      let(:user_2) { create(:user) }
+
+      before do
+        create(:scenario_user,
+          scenario: scenario, user: user_2,
+          role_id: User::ROLES.key(:scenario_viewer)
+        )
+
+        put "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [
+              { id: user_2.id, role: 'scenario_owner' },
+              { id: user_2.id, role: 'scenario_viewer' },
+            ]
+          }
+      end
+
+      it 'returns success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the user to the last stated role' do
+        expect(response.body).to eq(
+          [
+            { id: user_2.id, email: nil, role: 'scenario_viewer' }
+          ].to_json
+        )
+      end
+    end
+
+    context 'with a non-existing user id' do
+      before do
+        put "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [
+              { id: 999, role: 'scenario_collaborator' },
+            ]
+          }
+      end
+
+      it 'returns 404: not found' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns an error' do
+        expect(response.body).to eq(
+          { id: 999, role: 'scenario_collaborator', error: 'Scenario user not found' }.to_json
+        )
+      end
+    end
+
+    context 'with a missing role' do
+      before do
+        put "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [
+              { id: 999 },
+            ]
+          }
+      end
+
+      it 'returns 422: unprocessable entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns an error' do
+        expect(response.body).to eq(
+          { id: 999, error: 'No role given to update with.' }.to_json
+        )
+      end
+    end
+  end
+
+  describe 'DELETE /api/v3/scenarios/:id/users' do
+    context 'with proper params' do
+      let(:user_2) { create(:user) }
+      let(:user_3) { create(:user) }
+
+      before do
+        create(:scenario_user,
+          scenario: scenario, user: user_2,
+          role_id: User::ROLES.key(:scenario_viewer)
+        )
+        create(:scenario_user,
+          scenario: scenario, user: user_3,
+          role_id: User::ROLES.key(:scenario_collaborator)
+        )
+
+        delete "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [{ id: user_2.id }, { id: user_3.id }]
+          }
+      end
+
+      it 'returns OK' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns an empty response body' do
+        expect(response.body).to eq('')
+      end
+
+      it 'removes the given users' do
+        expect(
+          scenario.scenario_users.count
+        ).to be(1)
+      end
+    end
+
+    context 'with duplicate user ids' do
+      let(:user_2) { create(:user) }
+      let(:user_3) { create(:user) }
+
+      before do
+        create(:scenario_user,
+          scenario: scenario, user: user_2,
+          role_id: User::ROLES.key(:scenario_viewer)
+        )
+        create(:scenario_user,
+          scenario: scenario, user: user_3,
+          role_id: User::ROLES.key(:scenario_collaborator)
+        )
+
+        delete "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [{ id: user_2.id }, { id: user_2.id }] # User 2, twice
+          }
+      end
+
+      it 'returns 422: unprocessable_entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'returns an empty response body' do
+        expect(response.body).to eq(
+          {'error': 'Duplicate user ids found in request, please revise.'}.to_json
+        )
+      end
+    end
+
+    context 'with a non-existing user id' do
+      before do
+        delete "/api/v3/scenarios/#{scenario.id}/users", as: :json,
+          headers: access_token_header(user, :delete),
+          params: {
+            scenario_users: [{ id: 999 }]
+          }
+      end
+
+      it 'returns 404: not found' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns an empty response body' do
+        expect(response.body).to eq(
+          {'error': 'Could not find user(s) with id: 999'}.to_json
+        )
+      end
+    end
+  end
+end
+
+

--- a/spec/requests/api/v3/transition_paths_spec.rb
+++ b/spec/requests/api/v3/transition_paths_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'transition paths API' do
 
   context 'when creating a transition path' do
     context 'when the scenarios exist' do
-      let(:scenario) { create(:scenario, owner: user) }
+      let(:scenario) { create(:scenario, user: user) }
 
       let(:params) do
         {
@@ -116,7 +116,7 @@ RSpec.describe 'transition paths API' do
     end
 
     context 'when missing the title' do
-      let(:scenario) { create(:scenario, owner: user) }
+      let(:scenario) { create(:scenario, user: user) }
 
       before do
         stub_etmodel_request('/api/v1/transition_paths', method: :post) do
@@ -139,7 +139,7 @@ RSpec.describe 'transition paths API' do
     end
 
     context 'when a scenario is not accessible' do
-      let(:scenario) { create(:scenario, owner: create(:user), private: true) }
+      let(:scenario) { create(:scenario, user: create(:user), private: true) }
 
       before do
         post '/api/v3/transition_paths',
@@ -189,7 +189,7 @@ RSpec.describe 'transition paths API' do
 
   context 'when updating a transition path' do
     context 'when the scenarios exist' do
-      let(:scenario) { create(:scenario, owner: user) }
+      let(:scenario) { create(:scenario, user: user) }
 
       let(:params) do
         {
@@ -230,7 +230,7 @@ RSpec.describe 'transition paths API' do
     end
 
     context 'when the transition path is not accessible' do
-      let(:scenario) { create(:scenario, owner: user) }
+      let(:scenario) { create(:scenario, user: user) }
 
       let(:params) do
         {

--- a/spec/requests/api/v3/update_input_spec.rb
+++ b/spec/requests/api/v3/update_input_spec.rb
@@ -574,7 +574,8 @@ describe 'Updating inputs with API v3' do
 
   context 'when updating a public scenario owned by someone else' do
     before do
-      scenario.update!(owner: create(:user))
+      scenario.scenario_users.destroy_all
+      scenario.update!(user: create(:user))
     end
 
     it 'returns 403' do
@@ -590,7 +591,8 @@ describe 'Updating inputs with API v3' do
 
   context 'when updating their own public scenario' do
     before do
-      scenario.update!(owner: user)
+      scenario.scenario_users.destroy_all
+      scenario.update!(user: user)
 
       autobalance_scenario(
         values: { 'unrelated_one' => 25.0 },
@@ -609,7 +611,8 @@ describe 'Updating inputs with API v3' do
     before do
       user = create(:user)
 
-      scenario.update!(owner: user)
+      scenario.scenario_users.destroy_all
+      scenario.update!(user: user)
 
       autobalance_scenario(
         values: { 'unrelated_one' => 25.0 },
@@ -626,7 +629,8 @@ describe 'Updating inputs with API v3' do
     before do
       user = create(:user)
 
-      scenario.update!(owner: user, private: true)
+      scenario.scenario_users.destroy_all
+      scenario.update!(user: user)
 
       autobalance_scenario(
         values: { 'unrelated_one' => 25.0 },

--- a/spec/requests/api/v3/update_scenario_spec.rb
+++ b/spec/requests/api/v3/update_scenario_spec.rb
@@ -37,16 +37,17 @@ describe 'Updating a scenario with API v3' do
 
   context 'when setting an owned public scenario to be private' do
     before do
-      scenario.update!(owner:, private: false)
+      scenario.scenario_users.destroy_all
+      scenario.update!(user: user, private: false)
     end
 
-    let(:owner) { create(:user) }
+    let(:user) { create(:user) }
 
     it 'sets private to true' do
       expect do
         update_scenario(
           params: { scenario: { private: true } },
-          headers: access_token_header(owner, :write)
+          headers: access_token_header(user, :write)
         )
       end.to change(scenario, :private?).from(false).to(true)
     end
@@ -54,16 +55,18 @@ describe 'Updating a scenario with API v3' do
 
   context 'when setting an owned private scenario to be public' do
     before do
-      scenario.update!(owner:, private: true)
+      scenario.scenario_users.destroy_all
+      scenario.update(user: user)
+      scenario.reload.update(private: true)
     end
 
-    let(:owner) { create(:user) }
+    let(:user) { create(:user) }
 
     it 'sets private to false' do
       expect do
         update_scenario(
           params: { scenario: { private: false } },
-          headers: access_token_header(owner, :write)
+          headers: access_token_header(user, :write)
         )
       end.to change(scenario, :private?).from(true).to(false)
     end

--- a/spec/services/create_saved_scenario_spec.rb
+++ b/spec/services/create_saved_scenario_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe CreateSavedScenario do
   let!(:user)     { create(:user) }
-  let!(:scenario) { create(:scenario, owner: user) }
+  let!(:scenario) { create(:scenario, user: user) }
 
   let!(:token) do
     create(
@@ -89,7 +89,9 @@ RSpec.describe CreateSavedScenario do
 
   context 'when the scenario is not accessible' do
     before do
-      scenario.update(owner: create(:user), private: true)
+      scenario.scenario_users.destroy_all
+      scenario.reload.update(user: create(:user))
+      scenario.reload.update(private: true)
     end
 
     it 'returns a Failure' do

--- a/spec/services/update_saved_scenario_spec.rb
+++ b/spec/services/update_saved_scenario_spec.rb
@@ -3,7 +3,7 @@
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe UpdateSavedScenario do
   let!(:user)     { create(:user) }
-  let!(:scenario) { create(:scenario, owner: user) }
+  let!(:scenario) { create(:scenario, user: user) }
 
   let!(:token) do
     create(
@@ -89,7 +89,9 @@ RSpec.describe UpdateSavedScenario do
 
   context 'when the scenario is not accessible' do
     before do
-      scenario.update(owner: create(:user), private: true)
+      scenario.scenario_users.destroy_all
+      scenario.reload.update(user: create(:user))
+      scenario.reload.update(private: true)
     end
 
     it 'returns a Failure' do

--- a/spec/services/upsert_transition_path_spec.rb
+++ b/spec/services/upsert_transition_path_spec.rb
@@ -3,8 +3,8 @@
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe UpsertTransitionPath do
   let!(:user)      { create(:user) }
-  let!(:scenario1) { create(:scenario, end_year: 2040, owner: user) }
-  let!(:scenario2) { create(:scenario, end_year: 2050, owner: user) }
+  let!(:scenario1) { create(:scenario, end_year: 2040, user: user) }
+  let!(:scenario2) { create(:scenario, end_year: 2050, user: user) }
 
   let!(:token) do
     create(
@@ -40,7 +40,7 @@ RSpec.describe UpsertTransitionPath do
               'end_year'     => scenario2.end_year,
               'created_at'   => '2022-12-21T19:45:09Z',
               'updated_at'   => '2022-12-22T12:34:50Z',
-              'owner'        => { 'id' => user.id, 'name' => user.name }
+              'user'         => { 'id' => user.id, 'name' => user.name }
             }
           ]
         end
@@ -69,7 +69,7 @@ RSpec.describe UpsertTransitionPath do
         'end_year' => scenario2.end_year,
         'created_at' => '2022-12-21T19:45:09Z',
         'updated_at' => '2022-12-22T12:34:50Z',
-        'owner' => { 'id' => user.id, 'name' => user.name }
+        'user' => { 'id' => user.id, 'name' => user.name }
       })
     end
   end
@@ -92,7 +92,9 @@ RSpec.describe UpsertTransitionPath do
 
   context 'when a scenario is not accessible' do
     before do
-      scenario1.update!(owner: create(:user), private: true)
+      scenario1.scenario_users.destroy_all
+      scenario1.reload.update(user: create(:user))
+      scenario1.reload.update(private: true)
     end
 
     it 'returns a Failure' do

--- a/spec/system/delete_account_spec.rb
+++ b/spec/system/delete_account_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe 'Registrations', type: :system do
     sign_in(user)
 
     # Create some data for the user.
-    create(:scenario, owner: user)
-    create(:scenario, owner: user)
+    create(:scenario, user: user)
+    create(:scenario, user: user)
     create(:personal_access_token, user:)
 
     visit '/identity'


### PR DESCRIPTION
## What?
This PR adds multi-user scenario functionality to ETEngine.

## Why?
Some of our clients would like to be able to share scenarios and collaborate on them together with other users. A way to do so is by being able to link multiple users to one scenario and have the ability to give them different roles. This PR does just that.

## How?

### Backend
- Addition of a new model:
  - `ScenarioUser`: This model serves as the coupling link between `Scenarios` and `Users` and symbolizes the role that a user has in relation to a given scenario. For the model to work a `scenario_users` table was also added. This table contains all said information.
- Addition of 'roles' to the User model:
```
  ROLES = {
    1 => :scenario_viewer,
    2 => :scenario_collaborator,
    3 => :scenario_owner
  }
```
- Renaming `Scenario.owner` to `Scenario.users`, which is now Array of Users and no longer one User.
- `API::ScenarioUsersController`: This is the controller handling API requests towards `/api/v3/scenarios/:id/users/`. It handles requests for:
  - GET `/`: Returns all ScenarioUsers for a given Scenario
  - POST `/`: Handles adding multiple ScenarioUsers in one go. Expects an array in the form of: `[{user_id:, user_email:, role:}, {...}, ...]`. Additionally, an `invitation_args` object can be included in each user object to make ETEngine send out an invitation mail to the user that was just added to the scenario. For this, it uses the new `ScenarioInvitationMailer` described below.
  - PUT `/`: Handles updating multiple `ScenarioUsers` in one go. Expects an array in the form of: `[{id: / user_id: / user_email:, role:}, {...}, ...]`
  - DESTROY `/`: Handles destroying multiple `SavedScenarioUsers` in one go. Expects an array in the form of: `[{id: / user_id: / user_email:}, {...}, ...]`
- A new `ScenarioInvitationMailer` was added to send out invitation mails to both existing and new users (for which the email address was not found). The contents of the mails themselves can found in [app/views/scenario_invitation_mailer/](https://github.com/quintel/etengine/tree/d7a739df9dd8fbf4619ba135987263386aba6c8c/app/views/scenario_invitation_mailer),
- Changes to CanCan abilities to make sure a viewer can only read, a collaborator can only change the scenario but not manage its users, and an owner can do everything to a `Scenario`,
- Various changes all over the codebase, i.e. to the `ScenarioSerializer`, and `YearInterpolator` to keep working properly despite changes ownership (i.e. the change from `owner` to `users` described above).

Closes #1375 .