### PR TITLE
Introduce more fine-grained load-shifting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'ruby-progressbar'
 
 # own gems
 gem 'quintel_merit', ref: '421f3fb', github: 'quintel/merit'
-gem 'atlas',         ref: '5e85101', github: 'quintel/atlas'
+gem 'atlas',         ref: '2db914b', github: 'quintel/atlas'
 gem 'fever',         ref: 'bf092b2', github: 'quintel/fever'
 gem 'refinery',      ref: '72eacf8', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile
+++ b/Gemfile
@@ -77,8 +77,7 @@ gem 'ruby-progressbar'
 
 # own gems
 gem 'quintel_merit', ref: '421f3fb', github: 'quintel/merit'
-#gem 'atlas',         ref: 'f7aebb9', github: 'quintel/atlas'
-gem 'atlas',         path: '../atlas'
+gem 'atlas',         ref: 'f7aebb9', github: 'quintel/atlas'
 gem 'fever',         ref: 'bf092b2', github: 'quintel/fever'
 gem 'refinery',      ref: '72eacf8', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,8 @@ gem 'ruby-progressbar'
 
 # own gems
 gem 'quintel_merit', ref: '421f3fb', github: 'quintel/merit'
-gem 'atlas',         ref: 'f7aebb9', github: 'quintel/atlas'
+#gem 'atlas',         ref: 'f7aebb9', github: 'quintel/atlas'
+gem 'atlas',         path: '../atlas'
 gem 'fever',         ref: 'bf092b2', github: 'quintel/fever'
 gem 'refinery',      ref: '72eacf8', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'ruby-progressbar'
 
 # own gems
 gem 'quintel_merit', ref: '421f3fb', github: 'quintel/merit'
-gem 'atlas',         ref: 'f7aebb9', github: 'quintel/atlas'
+gem 'atlas',         ref: '5e85101', github: 'quintel/atlas'
 gem 'fever',         ref: 'bf092b2', github: 'quintel/fever'
 gem 'refinery',      ref: '72eacf8', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,19 @@ GIT
     git (1.2.5)
 
 GIT
+  remote: https://github.com/quintel/atlas.git
+  revision: f7aebb944182f7b92fecb5f4188c3354a64c93c6
+  ref: f7aebb9
+  specs:
+    atlas (1.0.0)
+      activemodel (>= 7)
+      activesupport (>= 7)
+      csv (>= 3)
+      gpgme (~> 2.0)
+      turbine-graph (>= 0.1)
+      virtus (~> 1.0)
+
+GIT
   remote: https://github.com/quintel/fever.git
   revision: bf092b2974efd3999e197907b5214362edd25e63
   ref: bf092b2
@@ -42,17 +55,6 @@ GIT
   ref: e36554a
   specs:
     rubel (0.1.1)
-
-PATH
-  remote: ../atlas
-  specs:
-    atlas (1.0.0)
-      activemodel (>= 7)
-      activesupport (>= 7)
-      csv (>= 3)
-      gpgme (~> 2.0)
-      turbine-graph (>= 0.1)
-      virtus (~> 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: f7aebb944182f7b92fecb5f4188c3354a64c93c6
-  ref: f7aebb9
+  revision: 5e8510134d3e09793e608ad0b7601c88b5c757f9
+  ref: 5e85101
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 5e8510134d3e09793e608ad0b7601c88b5c757f9
-  ref: 5e85101
+  revision: 2db914bf62c4b95d5896d2d844f3da9abf7aef3e
+  ref: 2db914b
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,19 +5,6 @@ GIT
     git (1.2.5)
 
 GIT
-  remote: https://github.com/quintel/atlas.git
-  revision: f7aebb944182f7b92fecb5f4188c3354a64c93c6
-  ref: f7aebb9
-  specs:
-    atlas (1.0.0)
-      activemodel (>= 7)
-      activesupport (>= 7)
-      csv (>= 3)
-      gpgme (~> 2.0)
-      turbine-graph (>= 0.1)
-      virtus (~> 1.0)
-
-GIT
   remote: https://github.com/quintel/fever.git
   revision: bf092b2974efd3999e197907b5214362edd25e63
   ref: bf092b2
@@ -55,6 +42,17 @@ GIT
   ref: e36554a
   specs:
     rubel (0.1.1)
+
+PATH
+  remote: ../atlas
+  specs:
+    atlas (1.0.0)
+      activemodel (>= 7)
+      activesupport (>= 7)
+      csv (>= 3)
+      gpgme (~> 2.0)
+      turbine-graph (>= 0.1)
+      virtus (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -170,7 +168,7 @@ GEM
       dry-validation (~> 1.0, >= 1.0.0)
     connection_pool (2.4.1)
     crass (1.0.6)
-    csv (3.2.7)
+    csv (3.2.8)
     dalli (3.2.3)
     debug_inspector (1.1.0)
     deep_merge (1.2.2)

--- a/app/models/qernel/merit_facade/load_shifting_adapter.rb
+++ b/app/models/qernel/merit_facade/load_shifting_adapter.rb
@@ -79,11 +79,12 @@ module Qernel
       end
 
       def input_capacity
+        # The input capacity will be further affected in Merit by the availability of the node.
         @input_capacity = (@config.input_capacity_from_share || 0.0) * output_capacity
       end
 
       def output_capacity
-        # The input capacity will be further affected in Merit by the availability of the node.
+        # The output capacity will be further affected in Merit by the availability of the node.
         @output_capacity ||= limiting_curve.max
       end
 

--- a/app/models/qernel/merit_facade/load_shifting_adapter.rb
+++ b/app/models/qernel/merit_facade/load_shifting_adapter.rb
@@ -24,7 +24,7 @@ module Qernel
 
         # TODO: Set input and output capacities.
         target_api.typical_input_capacity = input_capacity
-        target_api.electricity_output_capacity = input_capacity
+        target_api.electricity_output_capacity = output_capacity
 
         inject_curve!(:input) do
           main_participant.load_curve.map { |v| v.negative? ? v.abs : 0.0 }
@@ -79,12 +79,12 @@ module Qernel
       end
 
       def input_capacity
-        # The input capacity will be further affected in Merit by the availability of the node.
-        @input_capacity ||= limiting_curve.max
+        @input_capacity = (@config.input_capacity_from_share || 0.0) * output_capacity
       end
 
       def output_capacity
-        input_capacity
+        # The input capacity will be further affected in Merit by the availability of the node.
+        @output_capacity ||= limiting_curve.max
       end
 
       # Finds all the participants for the nodes named in the `demand_sources` config attribute.

--- a/app/models/qernel/node.rb
+++ b/app/models/qernel/node.rb
@@ -403,7 +403,7 @@ public
     output_edges.select(&:inversed_flexible?).each(&:calculate)
   end
 
-  protected
+protected
 
   # The highest internal_value of in/output slots is the demand of
   # this node. If there are slots with different internal_values
@@ -415,7 +415,7 @@ public
   # @return [Float] The demand of this node
   #
   def update_demand
-    if output_edges.any?(&:inversed_flexible?) || output_edges.any?(&:reversed?)
+    if output_edges.any?(&:inversed_flexible?) or output_edges.any?(&:reversed?)
       @calculation_state = :update_demand_if_inversed_flexible_or_reversed
       slots.map(&:internal_value).compact.max
     elsif output_edges.empty?
@@ -433,7 +433,7 @@ public
 
   # --------- Carriers --------------------------------------------------------
 
-  public
+public
 
   # @return [Array<Carrier>] Carriers of input
   #

--- a/app/models/qernel/node.rb
+++ b/app/models/qernel/node.rb
@@ -417,17 +417,17 @@ public
   def update_demand
     if output_edges.any?(&:inversed_flexible?) || output_edges.any?(&:reversed?)
       @calculation_state = :update_demand_if_inversed_flexible_or_reversed
-      slots.map{ |s| s.internal_value.try(:nan?) ? 0.0 : s.internal_value }.compact.max
+      slots.map(&:internal_value).compact.max
     elsif output_edges.empty?
       @calculation_state = :update_demand_if_no_output_edges
       # 2010-06-23: If there is no output edges we take the highest value from input.
       # otherwise left dead end nodes don't get values
-      inputs.map{ |s| s.internal_value.try(:nan?) ? 0.0 : s.internal_value }.compact.max
+      inputs.map(&:internal_value).compact.max
     else
       @calculation_state = :update_demand
       # 2010-06-23: The normal case. Just take the highest value from outputs.
       # We did this to make the gas_extraction gas_import_export thing work
-      outputs.map{ |s| s.internal_value.try(:nan?) ? 0.0 : s.internal_value }.compact.max
+      outputs.map(&:internal_value).compact.max
     end
   end
 

--- a/app/models/qernel/node.rb
+++ b/app/models/qernel/node.rb
@@ -403,7 +403,7 @@ public
     output_edges.select(&:inversed_flexible?).each(&:calculate)
   end
 
-protected
+  protected
 
   # The highest internal_value of in/output slots is the demand of
   # this node. If there are slots with different internal_values
@@ -415,25 +415,25 @@ protected
   # @return [Float] The demand of this node
   #
   def update_demand
-    if output_edges.any?(&:inversed_flexible?) or output_edges.any?(&:reversed?)
+    if output_edges.any?(&:inversed_flexible?) || output_edges.any?(&:reversed?)
       @calculation_state = :update_demand_if_inversed_flexible_or_reversed
-      slots.map(&:internal_value).compact.max
+      slots.map{ |s| s.internal_value.try(:nan?) ? 0.0 : s.internal_value }.compact.max
     elsif output_edges.empty?
       @calculation_state = :update_demand_if_no_output_edges
       # 2010-06-23: If there is no output edges we take the highest value from input.
       # otherwise left dead end nodes don't get values
-      inputs.map(&:internal_value).compact.max
+      inputs.map{ |s| s.internal_value.try(:nan?) ? 0.0 : s.internal_value }.compact.max
     else
       @calculation_state = :update_demand
       # 2010-06-23: The normal case. Just take the highest value from outputs.
       # We did this to make the gas_extraction gas_import_export thing work
-      outputs.map(&:internal_value).compact.max
+      outputs.map{ |s| s.internal_value.try(:nan?) ? 0.0 : s.internal_value }.compact.max
     end
   end
 
   # --------- Carriers --------------------------------------------------------
 
-public
+  public
 
   # @return [Array<Carrier>] Carriers of input
   #


### PR DESCRIPTION
## What?
This PR adds support for setting up more fine-grained load-shifting by our users.

## Why?
The currently existing load-shifting functionality caused too much of a peak in the demand for the electricity system. The user needed a way to spread out this demand more evenly over time.

## How?
By adding support to set and influence `output_capacity` in etengine.