### PR TITLE
Make storage optimization available for the residential sector

### DIFF
--- a/app/models/qernel/merit_facade/context.rb
+++ b/app/models/qernel/merit_facade/context.rb
@@ -59,10 +59,10 @@ module Qernel
         :"#{@carrier}_#{direction}_curve"
       end
 
-      # Public: Returns the StorageOptimization which can generate load curves for optimizing
-      # batteries.
+      # Public: Returns the StorageOptimizationDistribution which can generate load curves for
+      # optimizing batteries.
       def storage_optimization
-        @storage_optimization ||= StorageOptimization.new(
+        @storage_optimization ||= StorageOptimizationDistribution.new(
           plugin.adapters.values,
           graph.forecast_storage_order
         )

--- a/app/models/qernel/merit_facade/flex_adapter.rb
+++ b/app/models/qernel/merit_facade/flex_adapter.rb
@@ -22,7 +22,7 @@ module Qernel
           CurtailmentAdapter
         when :heat_storage
           HeatStorageAdapter
-        when :optimizing_storage || :optimizing_storage_households
+        when :optimizing_storage, :optimizing_storage_households
           OptimizingStorageAdapter
         when :load_shifting
           LoadShiftingAdapter

--- a/app/models/qernel/merit_facade/flex_adapter.rb
+++ b/app/models/qernel/merit_facade/flex_adapter.rb
@@ -22,7 +22,7 @@ module Qernel
           CurtailmentAdapter
         when :heat_storage
           HeatStorageAdapter
-        when :optimizing_storage
+        when :optimizing_storage || :optimizing_storage_households
           OptimizingStorageAdapter
         when :load_shifting
           LoadShiftingAdapter

--- a/app/models/qernel/merit_facade/storage_optimization.rb
+++ b/app/models/qernel/merit_facade/storage_optimization.rb
@@ -18,9 +18,10 @@ module Qernel
       end
 
       # Public: Creates a new Optimization which receives all of the adapters from the Merit plugin.
-      def initialize(adapters, order = [])
+      def initialize(adapters, order = [], optimizing_type: :optimizing_storage)
         @adapters = adapters
         @order = order.map(&:to_s)
+        @optimizing_type = optimizing_type
       end
 
       # Public: Returns an array describing how much energy will be stored in the named battery in
@@ -40,6 +41,11 @@ module Qernel
 
       def residual_load
         Merit::CurveTools.add_curves([consumption_curve, production_curve])
+      end
+
+      # Public: Returns wether the given battery is being optimized
+      def optimizing?(key)
+        reserves.key?(key)
       end
 
       private
@@ -115,7 +121,7 @@ module Qernel
       def batteries
         @batteries ||= begin
           optimizing = @adapters.select do |adapter|
-            adapter.config.subtype == :optimizing_storage && adapter.config.type == :flex
+            adapter.config.subtype == @optimizing_type && adapter.config.type == :flex
           end
 
           optimizing.sort_by.with_index do |adapter, index|

--- a/app/models/qernel/merit_facade/storage_optimization_distribution.rb
+++ b/app/models/qernel/merit_facade/storage_optimization_distribution.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Qernel
+  module MeritFacade
+    # Distributes the batteries over the sectors that have been turned on for storage optimisation
+    class StorageOptimizationDistribution
+      OPTIMIZING_SECTORS = %i[households].freeze
+
+      def initialize(adapters, order = [])
+        @adapters = adapters
+        @order = order
+      end
+
+      # Delegate to correct optimizer
+      def load_for(key)
+        optimizers.each do |opt|
+          return opt.load_for(key) if opt.optimizing?(key)
+        end
+      end
+
+      # Delegate to correct optimizer
+      def reserve_for(key)
+        optimizers.each do |opt|
+          return opt.reserve_for(key) if opt.optimizing?(key)
+        end
+      end
+
+      private
+
+      def optimizers
+        @optimizers ||= optimizing_sectors.map do |sector|
+          StorageOptimization.new(
+            adapters_for(sector),
+            @order,
+            optimizing_type: subtype_key_for(sector)
+        )
+        end
+      end
+
+      def adapters_for(sector)
+        if sector == :system
+          @adapters
+        else
+          filter_adapters(sector)
+        end
+      end
+
+      # Private: filters the sector out of the main adapters, returns the sector adapters
+      def filter_adapters(sector)
+        sector_adapters = []
+        @adapters.reject! do |adapter|
+          part_of_sector = select_adapter?(sector, adapter)
+          sector_adapters << adapter if part_of_sector
+
+          part_of_sector
+        end
+
+        sector_adapters
+      end
+
+      def select_adapter?(sector, adapter)
+        return true if adapter.config.subtype == subtype_key_for(sector)
+        return false if adapter.config.type == :flex
+        return true if adapter.node.sector_key == sector
+
+        false
+      end
+
+      # Private: Check which optimizing storages need to be built
+      # Always add system as last sector
+      def optimizing_sectors
+        OPTIMIZING_SECTORS.select do |sector|
+          @adapters.any? { |adapter| adapter.config.subtype == subtype_key_for(sector) }
+        end << :system
+      end
+
+      def subtype_key_for(sector)
+        return :optimizing_storage if sector == :system
+
+        :"optimizing_storage_#{sector}"
+      end
+    end
+  end
+end

--- a/app/models/qernel/merit_facade/storage_optimization_distribution.rb
+++ b/app/models/qernel/merit_facade/storage_optimization_distribution.rb
@@ -61,7 +61,7 @@ module Qernel
       def select_adapter?(sector, adapter)
         return true if adapter.config.subtype == subtype_key_for(sector)
         return false if adapter.config.type == :flex
-        return true if adapter.node.sector_key == sector
+        return true if adapter.node.node.sector_key == sector
 
         false
       end

--- a/app/models/qernel/merit_facade/storage_optimization_distribution.rb
+++ b/app/models/qernel/merit_facade/storage_optimization_distribution.rb
@@ -33,7 +33,7 @@ module Qernel
             adapters_for(sector),
             @order,
             optimizing_type: subtype_key_for(sector)
-        )
+          )
         end
       end
 

--- a/spec/models/qernel/merit_facade/storage_optimization_distribution_spec.rb
+++ b/spec/models/qernel/merit_facade/storage_optimization_distribution_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe Qernel::MeritFacade::StorageOptimizationDistribution do
 
     node = instance_double('Qernel::Node')
     allow(node).to receive(:sector_key).and_return(sector)
-    allow(adapter).to receive(:node).and_return(node)
+
+    node_api = instance_double('Qernel::NodeApi::EnergyApi')
+    allow(node_api).to receive(:node).and_return(node)
+    allow(adapter).to receive(:node).and_return(node_api)
 
     adapter
   end
@@ -41,7 +44,6 @@ RSpec.describe Qernel::MeritFacade::StorageOptimizationDistribution do
 
     node = instance_double('Qernel::Node')
     allow(node).to receive(:key).and_return(key)
-    allow(node).to receive(:sector_key).and_return(sector)
     allow(adapter).to receive(:node).and_return(node)
 
     params = Qernel::MeritFacade::OptimizingStorageAdapter::Params.new(

--- a/spec/models/qernel/merit_facade/storage_optimization_distribution_spec.rb
+++ b/spec/models/qernel/merit_facade/storage_optimization_distribution_spec.rb
@@ -135,5 +135,39 @@ RSpec.describe Qernel::MeritFacade::StorageOptimizationDistribution do
         ])
       end
     end
+
+    context 'with one battery targeted towards the households sector, and one towards system, but only household demand' do
+      let(:adapters) do
+        [
+          consumer_double(:must_run, ([10_000.0] * 6 + [5000.0] * 6) * 365),
+          battery_double(key: :hh_battery, volume: 5000.0, capacity: 1000.0, subtype: :optimizing_storage_households),
+          battery_double(key: :system_battery, volume: 5000.0, capacity: 1000.0)
+        ]
+      end
+
+      it 'calculates the households battery reserve' do
+        expect(opt_dist.reserve_for(:hh_battery)[24...36]).to eq([
+          5000, 4000, 3000, 2000, 1000, 0, 0, 1000, 2000, 3000, 4000, 5000
+        ])
+      end
+
+      it 'calculates the households battery load' do
+        expect(opt_dist.load_for(:hh_battery)[24...36]).to eq([
+          0, 1000, 1000, 1000, 1000, 1000, 0, -1000, -1000, -1000, -1000, -1000
+        ])
+      end
+
+      it 'calculates the systems battery reserve' do
+        expect(opt_dist.reserve_for(:system_battery)[24...36]).to eq([
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        ])
+      end
+
+      it 'calculates the systems battery load' do
+        expect(opt_dist.load_for(:system_battery)[24...36]).to eq([
+          0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        ])
+      end
+    end
   end
 end

--- a/spec/models/qernel/merit_facade/storage_optimization_distribution_spec.rb
+++ b/spec/models/qernel/merit_facade/storage_optimization_distribution_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Qernel::MeritFacade::StorageOptimizationDistribution do
+  # Creates an adapter double with the given type, subtype, and load curve.
+  def adapter_double(klass_name, type, subtype, curve: nil, adapter_klass: 'Qernel::MeritFacade::Adapter', sector: :households)
+    adapter = instance_double(adapter_klass)
+    participant = instance_double(klass_name)
+
+    allow(participant).to receive(:load_curve).and_return(curve)
+
+    allow(adapter).to receive(:config).and_return(
+      Atlas::NodeAttributes::ElectricityMeritOrder.new(type: type, subtype: subtype)
+    )
+
+    allow(adapter).to receive(:participant).and_return(participant)
+
+    node = instance_double('Qernel::Node')
+    allow(node).to receive(:sector_key).and_return(sector)
+    allow(adapter).to receive(:node).and_return(node)
+
+    adapter
+  end
+
+  def producer_double(subtype, curve)
+    adapter_double('Merit::Producer', :producer, subtype, curve: curve)
+  end
+
+  def consumer_double(subtype, curve, sector: :households)
+    adapter_double('Merit::User', :consumer, subtype, curve: curve, sector: sector)
+  end
+
+  def battery_double(key: nil, subtype: :optimizing_storage, volume:, capacity:, efficiency: 1.0, sector: :households)
+    adapter = adapter_double(
+      'Merit::CurveProducer',
+      :flex,
+      subtype,
+      adapter_klass: 'Qernel::MeritFacade::OptimizingStorageAdapter'
+    )
+
+    node = instance_double('Qernel::Node')
+    allow(node).to receive(:key).and_return(key)
+    allow(node).to receive(:sector_key).and_return(sector)
+    allow(adapter).to receive(:node).and_return(node)
+
+    params = Qernel::MeritFacade::OptimizingStorageAdapter::Params.new(
+      input_capacity: capacity,
+      output_capacity: capacity,
+      volume: volume,
+      output_efficiency: efficiency
+    )
+
+    allow(adapter).to receive(:optimizing_storage_params).and_return(params)
+
+    adapter
+  end
+
+  let(:opt_dist) { described_class.new(adapters) }
+
+  describe '#reserve_for' do
+    context 'with a single battery targeted towards the full system' do
+      let(:adapters) do
+        [
+          consumer_double(:must_run, ([10_000.0] * 6 + [5000.0] * 6) * 365),
+          battery_double(key: :a_battery, volume: 5000.0, capacity: 1000.0)
+        ]
+      end
+
+      it 'calculates the battery reserve' do
+        expect(opt_dist.reserve_for(:a_battery)[24...36]).to eq([
+          5000, 4000, 3000, 2000, 1000, 0, 0, 1000, 2000, 3000, 4000, 5000
+        ])
+      end
+
+      it 'calculates the battery load' do
+        expect(opt_dist.load_for(:a_battery)[24...36]).to eq([
+          0, 1000, 1000, 1000, 1000, 1000, 0, -1000, -1000, -1000, -1000, -1000
+        ])
+      end
+    end
+
+    context 'with a single battery targeted towards the households sector' do
+      let(:adapters) do
+        [
+          consumer_double(:must_run, ([10_000.0] * 6 + [5000.0] * 6) * 365),
+          battery_double(key: :a_battery, volume: 5000.0, capacity: 1000.0, subtype: :optimizing_storage_households)
+        ]
+      end
+
+      it 'calculates the battery reserve' do
+        expect(opt_dist.reserve_for(:a_battery)[24...36]).to eq([
+          5000, 4000, 3000, 2000, 1000, 0, 0, 1000, 2000, 3000, 4000, 5000
+        ])
+      end
+
+      it 'calculates the battery load' do
+        expect(opt_dist.load_for(:a_battery)[24...36]).to eq([
+          0, 1000, 1000, 1000, 1000, 1000, 0, -1000, -1000, -1000, -1000, -1000
+        ])
+      end
+    end
+
+    context 'with one battery targeted towards the households sector, and one towards system' do
+      let(:adapters) do
+        [
+          consumer_double(:must_run, ([10_000.0] * 6 + [5000.0] * 6) * 365),
+          consumer_double(:must_run, ([10_000.0] * 6 + [5000.0] * 6) * 365, sector: :industry),
+          battery_double(key: :hh_battery, volume: 5000.0, capacity: 1000.0, subtype: :optimizing_storage_households),
+          battery_double(key: :system_battery, volume: 5000.0, capacity: 1000.0)
+        ]
+      end
+
+      it 'calculates the households battery reserve' do
+        expect(opt_dist.reserve_for(:hh_battery)[24...36]).to eq([
+          5000, 4000, 3000, 2000, 1000, 0, 0, 1000, 2000, 3000, 4000, 5000
+        ])
+      end
+
+      it 'calculates the households battery load' do
+        expect(opt_dist.load_for(:hh_battery)[24...36]).to eq([
+          0, 1000, 1000, 1000, 1000, 1000, 0, -1000, -1000, -1000, -1000, -1000
+        ])
+      end
+
+      it 'calculates the systems battery reserve' do
+        expect(opt_dist.reserve_for(:system_battery)[24...36]).to eq([
+          5000, 4000, 3000, 2000, 1000, 0, 0, 1000, 2000, 3000, 4000, 5000
+        ])
+      end
+
+      it 'calculates the systems battery load' do
+        expect(opt_dist.load_for(:system_battery)[24...36]).to eq([
+          0, 1000, 1000, 1000, 1000, 1000, 0, -1000, -1000, -1000, -1000, -1000
+        ])
+      end
+    end
+  end
+end

--- a/spec/models/qernel/merit_facade/storage_optimization_spec.rb
+++ b/spec/models/qernel/merit_facade/storage_optimization_spec.rb
@@ -214,7 +214,6 @@ RSpec.describe Qernel::MeritFacade::StorageOptimization do
       end
 
       it 'calculates the battery reserve' do
-        puts opt.reserve_for(:a_battery)[24...36]
         expect(opt.reserve_for(:a_battery)[24...36]).to eq([
           5000.0, 4500.0, 3750.0, 3000.0, 2250.0, 1000.0, 1750.0, 2500.0, 3000.0, 3750.0, 4000.0, 5000.0
         ])
@@ -236,7 +235,6 @@ RSpec.describe Qernel::MeritFacade::StorageOptimization do
       end
 
       it 'calculates the battery reserve' do
-        puts opt.reserve_for(:a_battery)[24...36]
         expect(opt.reserve_for(:a_battery)[24...36].map(&:to_i)).to eq([
           4166, 3333, 2499, 1666, 833, 0, 833, 1666, 2499, 3333, 4166, 4999
         ])


### PR DESCRIPTION
Adds a distributor that checks how many instances of forecasting should be started, and which nodes will join which forecasting.

Goal is to allow for a separate forecasting for the residential sector. However, it's easy to add other sectors in the future.