### PR TITLE
Migrate captured biogenic CO2 price to be 0 in existing scenarios

### DIFF
--- a/db/migrate/20240402111604_reset_biogenic_co2_price.rb
+++ b/db/migrate/20240402111604_reset_biogenic_co2_price.rb
@@ -11,7 +11,7 @@ class ResetBiogenicCo2Price < ActiveRecord::Migration[7.0]
 
   def up
     migrate_scenarios do |scenario|
-      next if scenario.user_values[BIOGENIC_CO2_PRICE]
+      next if scenario.user_values.key?(BIOGENIC_CO2_PRICE)
 
       scenario.user_values[BIOGENIC_CO2_PRICE] = 0.0
     end

--- a/db/migrate/20240402111604_reset_biogenic_co2_price.rb
+++ b/db/migrate/20240402111604_reset_biogenic_co2_price.rb
@@ -1,0 +1,19 @@
+require 'etengine/scenario_migration'
+
+class ResetBiogenicCo2Price < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  BIOGENIC_CO2_PRICE = 'costs_captured_biogenic_co2'.freeze
+
+  # The default for the new captured biogenic CO2 price is equal to CO2 emissions
+  # price. However to retain the outcomes of older scenarios, the biogenic CO2 price 
+  # is set to 0.
+
+  def up
+    migrate_scenarios do |scenario|
+      next if scenario.user_values[BIOGENIC_CO2_PRICE]
+
+      scenario.user_values[BIOGENIC_CO2_PRICE] = 0.0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_21_134650) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_02_111604) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
The default value for the `captured_biogenic_co2_price` is updated to be set at the `co2_price` value in https://github.com/quintel/etsource/pull/3027. To prevent any existing scenario outcomes to change, all existing scenarios are assigned `captured_biogenic_co2_price = 0.0`.