### PR TITLE
Add migration for renamed COP cutoff input

### DIFF
--- a/db/migrate/20240411112150_rename_cutoff_cop_input.rb
+++ b/db/migrate/20240411112150_rename_cutoff_cop_input.rb
@@ -1,0 +1,19 @@
+require 'etengine/scenario_migration'
+
+class RenameCutoffCopInput < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  KEYS = {
+    'flexibility_heat_pump_space_heating_cop_cutoff' => 'flexibility_heat_pump_space_heating_cop_cutoff_gas',
+  }.freeze
+
+  def up
+    migrate_scenarios do |scenario|
+      KEYS.each do |old_key, new_key|
+        if scenario.user_values.key?(old_key)
+          scenario.user_values[new_key] = scenario.user_values.delete(old_key)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_02_111604) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_11_112150) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
In quintel/etsource#3030 the input `flexibility_heat_pump_space_heating_cop_cutoff` was renamed to `flexibility_heat_pump_space_heating_cop_cutoff_gas`. This PR adds a migration that renames the input in existing scenarios.