### PR TITLE
Tag scenario versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ GEM
     minitest (5.22.2)
     msgpack (1.4.5)
     multi_json (1.15.0)
-    mysql2 (0.5.3)
+    mysql2 (0.5.6)
     net-imap (0.4.10)
       date
       net-protocol

--- a/app/controllers/api/v3/scenario_version_tags_controller.rb
+++ b/app/controllers/api/v3/scenario_version_tags_controller.rb
@@ -2,6 +2,94 @@ module Api
   module V3
     class ScenarioVersionTagsController < BaseController
       include UsesScenario
+
+      skip_before_action :authorize_scenario!, :only => :index
+      respond_to :json
+
+      before_action :validate_scenario_version_tag, only: :update
+
+      before_action only: %i[batch] do
+        # Only check that the user can read. We restrict the search in the action.
+        authorize!(:read, Scenario)
+      end
+
+      # GET api/v3/scenarios/:id/version
+      def show
+        render json: ScenarioVersionSerializer.new(scenario)
+      end
+
+      # GET api/v3/scenarios/versions
+      #
+      # Lists all version tags of all the scenarios if they have one,
+      # indexed on the scenario_ids
+      def index
+        version_params = params.permit(scenarios: [])
+        ids = version_params[:scenarios].map(&:to_i)
+
+        scenarios = Scenario.accessible_by(current_ability)
+          .where(id: ids).includes(:users, :scenario_version_tag)
+
+        @serializers = scenarios.each_with_object({}) do |scenario, hash|
+          hash[scenario.id] = ScenarioVersionSerializer.new(scenario)
+
+          hash
+        end
+
+        render json: @serializers
+      end
+
+      # POST api/v3/scenarios/:id/version
+      def create
+        version = ScenarioVersionTag.new(
+          description: version_params[:description],
+          user: current_user,
+          scenario: scenario
+        )
+
+        version.save
+
+        render json: ScenarioVersionSerializer.new(scenario)
+      rescue ActiveRecord::RecordNotUnique
+        render(
+          status: :unprocessable_entity,
+          json: { errors: ['A version was already tagged'] }
+        )
+      end
+
+      # PUT api/v3/scenarios/:id/version
+      def update
+        if version_params[:description]
+          scenario_version_tag.description = version_params[:description]
+        end
+
+        if scenario_version_tag.save
+          render json: ScenarioVersionSerializer.new(scenario)
+        else
+          render(
+            status: :unprocessable_entity,
+            json: { errors: version.errors.messages }
+          )
+        end
+      end
+
+      private
+
+      def version_params
+        params.permit(:description)
+      end
+
+      def scenario_version_tag
+        @scenario_version_tag ||= scenario.scenario_version_tag
+      end
+
+      def validate_scenario_version_tag
+        return if scenario_version_tag.present?
+
+        render(
+          status: :not_found,
+          json: { errors: ['Scenario version tag not found'] }
+        )
+      end
     end
   end
 end

--- a/app/controllers/api/v3/scenario_version_tags_controller.rb
+++ b/app/controllers/api/v3/scenario_version_tags_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V3
+    class ScenarioVersionTagsController < BaseController
+      include UsesScenario
+    end
+  end
+end

--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -246,7 +246,7 @@ module Api
           authorize!(:update, @scenario)
         end
 
-        updater    = ScenarioUpdater.new(@scenario, final_params)
+        updater    = ScenarioUpdater.new(@scenario, final_params, current_user)
         serializer = nil
 
         Scenario.transaction do

--- a/app/models/api/v3/scenario_updater.rb
+++ b/app/models/api/v3/scenario_updater.rb
@@ -28,8 +28,9 @@ module Api
       # @param [#[]] params
       #   The HTTP parameters.
       #
-      def initialize(scenario, params)
+      def initialize(scenario, params, current_user)
         @scenario      = scenario
+        @current_user  = current_user
         @data          = (params.to_h || {}).with_indifferent_access
         @scenario_data = (@data[:scenario] || {}).with_indifferent_access
       end
@@ -55,6 +56,7 @@ module Api
           return false unless @scenario.save(validate: false)
 
           @scenario.copy_preset_roles if copy_preset_roles?
+          @scenario.scenario_version_tag&.update(user: @current_user)
           true
         else
           false

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -347,6 +347,10 @@ class Scenario < ApplicationRecord
     scenario_users.find_by(user: user, role_id: User::ROLES.key(:scenario_owner))
   end
 
+  def collaborator?(user)
+    scenario_users.find_by(user: user, role_id: User::ROLES.key(:scenario_collaborator)..)
+  end
+
   # Convenience method to quickly set the owner for a scenario, e.g. when creating it as
   # Scenario.create(user: User). Only works when no users are associated yet.
   def user=(user)

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -23,6 +23,7 @@ class Scenario < ApplicationRecord
 
   has_one    :preset_scenario, :foreign_key => 'preset_scenario_id', :class_name => 'Scenario'
   has_one    :scaler, class_name: 'ScenarioScaling', dependent: :delete
+  has_one    :scenario_version_tag, dependent: :destroy
   has_many   :heat_network_orders, dependent: :destroy
   has_one    :forecast_storage_order, dependent: :destroy
   has_one    :hydrogen_supply_order, dependent: :destroy

--- a/app/models/scenario_version_tag.rb
+++ b/app/models/scenario_version_tag.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Optional to add version tags to scenarios to display in saved scenario
+class ScenarioVersionTag < ApplicationRecord
+  # scenario          the scenario for the tag, cannot be updated
+  # user              the user that created the tag, cannot be updated
+  # text
+
+  belongs_to :scenario
+  belongs_to :user
+
+
+end

--- a/app/models/scenario_version_tag.rb
+++ b/app/models/scenario_version_tag.rb
@@ -3,13 +3,21 @@
 # Optional to add version tags to scenarios to display in saved scenario
 class ScenarioVersionTag < ApplicationRecord
   # scenario          the scenario for the tag, cannot be updated
-  # user              the user that created the tag, cannot be updated
+  # user              the user that created the tag
   # text
 
   belongs_to :scenario
   belongs_to :user
 
+  validate :validate_user_in_scenario_users
+
   def as_json(*)
     super(except: %i[id scenario_id])
+  end
+
+  def validate_user_in_scenario_users
+    return if scenario.users.exists?(user.id)
+
+    errors.add(:user, 'is not a user of the scenario')
   end
 end

--- a/app/models/scenario_version_tag.rb
+++ b/app/models/scenario_version_tag.rb
@@ -9,5 +9,7 @@ class ScenarioVersionTag < ApplicationRecord
   belongs_to :scenario
   belongs_to :user
 
-
+  def as_json(*)
+    super(except: %i[id scenario_id])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ApplicationRecord
 
   has_many :scenario_users, dependent: :destroy
   has_many :scenarios, through: :scenario_users
+  has_many :scenario_version_tags
   has_many :personal_access_tokens, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 191 }

--- a/app/serializers/scenario_version_serializer.rb
+++ b/app/serializers/scenario_version_serializer.rb
@@ -6,6 +6,7 @@ class ScenarioVersionSerializer
   #
   def initialize(scenario)
     @resource = scenario.scenario_version_tag
+    @last_updated_at = scenario.updated_at
   end
 
   # Creates a Hash suitable for conversion to JSON by Rails.
@@ -14,6 +15,9 @@ class ScenarioVersionSerializer
   #   The Hash containing the scenario version tag attributes.
   #
   def as_json(*)
-    @resource ? @resource.as_json : {}
+    hash = @resource ? @resource.as_json : {}
+    hash[:last_updated_at] = @last_updated_at
+
+    hash
   end
 end

--- a/app/serializers/scenario_version_serializer.rb
+++ b/app/serializers/scenario_version_serializer.rb
@@ -1,0 +1,19 @@
+class ScenarioVersionSerializer
+  # Creates a new Scenario Version Tag API serializer.
+  #
+  # @param [Scenario] scenario
+  #   The scenarios for which we want JSON.
+  #
+  def initialize(scenario)
+    @resource = scenario.scenario_version_tag
+  end
+
+  # Creates a Hash suitable for conversion to JSON by Rails.
+  #
+  # @return [Hash{Symbol=>Object}]
+  #   The Hash containing the scenario version tag attributes.
+  #
+  def as_json(*)
+    @resource ? @resource.as_json : {}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,8 @@ Rails.application.routes.draw do
         end
         collection do
           post :merge
+
+          get 'versions', to: 'scenario_version_tags#index'
         end
         get :templates, :on => :collection
 
@@ -77,6 +79,8 @@ Rails.application.routes.draw do
         get 'converters/:id', to: redirect('/api/v3/scenarios/%{scenario_id}/nodes/%{id}')
 
         resources :inputs, :only => [:index, :show]
+
+        resource :version, :only => [:create, :show, :update], controller: 'scenario_version_tags'
 
         # Flexibility orders have been removed. Endpoint returns a 404 with a useful message.
         get   '/flexibility_order', to: 'removed_features#flexibility_order'

--- a/db/migrate/20240402143242_create_scenario_version_tags.rb
+++ b/db/migrate/20240402143242_create_scenario_version_tags.rb
@@ -1,0 +1,10 @@
+class CreateScenarioVersionTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :scenario_version_tags do |t|
+      t.integer :scenario_id, null: false
+      t.integer :user_id, null: false
+      t.text :description
+      t.index ['scenario_id', 'user_id'], unique: true
+    end
+  end
+end

--- a/spec/factories/scenario_version_tag.rb
+++ b/spec/factories/scenario_version_tag.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :scenario_version_tag do
+    description { 'My scenario version' }
+    user
+    scenario
+  end
+end

--- a/spec/models/api/v3/scenario_updater_spec.rb
+++ b/spec/models/api/v3/scenario_updater_spec.rb
@@ -55,7 +55,7 @@ describe Api::V3::ScenarioUpdater, :etsource_fixture do
   end
 
   let(:scenario) { FactoryBot.create(:scenario) }
-  let(:updater)  { Api::V3::ScenarioUpdater.new(scenario, params) }
+  let(:updater)  { Api::V3::ScenarioUpdater.new(scenario, params, nil) }
 
   context 'with no user parameters' do
     let(:params) { {} }

--- a/spec/requests/api/v3/scenario_version_tag_spec.rb
+++ b/spec/requests/api/v3/scenario_version_tag_spec.rb
@@ -26,12 +26,26 @@ describe 'Scenario versions API' do
         expect(response.status).to eq(200)
       end
 
-      it 'includes the first scenarios version tag' do
-        expect(json).to include(scenario.id.to_s => { 'description' => message, 'user_id' => user.id })
+      it 'includes the first scenarios version tag description' do
+        expect(json[scenario.id.to_s]['description']).to eq(message)
       end
 
+      it 'includes the first scenarios version tag user' do
+        expect(json[scenario.id.to_s]['user_id']).to eq(user.id)
+      end
+
+      it 'includes the first scenarios version tag update time' do
+        expect(json[scenario.id.to_s].keys).to include('last_updated_at')
+      end
+
+
       it 'includes the second scenarios version tag' do
-        expect(json).to include(scenario2.id.to_s => { 'description' => message2, 'user_id' => user.id  })
+        expect(json[scenario2.id.to_s]).to include(
+           {
+            'description' => message2,
+            'user_id' => user.id
+          }
+        )
       end
     end
 
@@ -47,11 +61,16 @@ describe 'Scenario versions API' do
       end
 
       it 'includes the first scenarios version tag' do
-        expect(json).to include(scenario.id.to_s => { 'description' => message, 'user_id' => user.id })
+        expect(json[scenario.id.to_s]).to include(
+          {
+            'description' => message,
+            'user_id' => user.id
+          }
+        )
       end
 
       it 'does not include the second scenario' do
-        expect(json[scenario2.id.to_s]).to be_empty
+        expect(json[scenario2.id.to_s].keys).to eq(['last_updated_at'])
       end
     end
 
@@ -69,7 +88,12 @@ describe 'Scenario versions API' do
       end
 
       it 'includes the first scenarios version tag' do
-        expect(json).to include(scenario.id.to_s => { 'description' => message, 'user_id' => user.id })
+        expect(json[scenario.id.to_s]).to include(
+          {
+            'description' => message,
+            'user_id' => user.id
+          }
+        )
       end
 
       it 'does not include the second scenario' do

--- a/spec/requests/api/v3/scenario_version_tag_spec.rb
+++ b/spec/requests/api/v3/scenario_version_tag_spec.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Scenario versions API' do
+
+  let(:scenario) { create(:scenario, user: user) }
+  let(:scenario2) { create(:scenario, user: user, preset_scenario: scenario) }
+
+  let(:message) { 'First version!' }
+  let(:message2) { 'Second version!' }
+
+  let(:user) { create(:user) }
+  let(:json) { JSON.parse(response.body) }
+
+  describe 'index' do
+    context 'when all scenarios have a version tag' do
+      before do
+        create(:scenario_version_tag, scenario: scenario, user: user, description: message)
+        create(:scenario_version_tag, scenario: scenario2, user: user, description: message2)
+
+        get("/api/v3/scenarios/versions", params: { scenarios: [scenario.id, scenario2.id] })
+      end
+
+      it 'is successful' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'includes the first scenarios version tag' do
+        expect(json).to include(scenario.id.to_s => { 'description' => message, 'user_id' => user.id })
+      end
+
+      it 'includes the second scenarios version tag' do
+        expect(json).to include(scenario2.id.to_s => { 'description' => message2, 'user_id' => user.id  })
+      end
+    end
+
+    context 'when one scenario does not have a version tag' do
+      before do
+        create(:scenario_version_tag, scenario: scenario, user: user, description: message)
+
+        get("/api/v3/scenarios/versions", params: { scenarios: [scenario.id, scenario2.id] })
+      end
+
+      it 'is successful' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'includes the first scenarios version tag' do
+        expect(json).to include(scenario.id.to_s => { 'description' => message, 'user_id' => user.id })
+      end
+
+      it 'does not include the second scenario' do
+        expect(json[scenario2.id.to_s]).to be_empty
+      end
+    end
+
+    context 'when one scenario is not owned by the user' do
+      before do
+        create(:scenario_version_tag, scenario: scenario, user: user, description: message)
+
+        get("/api/v3/scenarios/versions", params: { scenarios: [scenario.id, private_scenario.id] })
+      end
+
+      let(:private_scenario) { create(:scenario, user: create(:user), private: true) }
+
+      it 'is successful' do
+        expect(response.status).to eq(200)
+      end
+
+      it 'includes the first scenarios version tag' do
+        expect(json).to include(scenario.id.to_s => { 'description' => message, 'user_id' => user.id })
+      end
+
+      it 'does not include the second scenario' do
+        expect(json.keys).not_to include(private_scenario.id.to_s)
+      end
+    end
+  end
+
+  describe 'show' do
+    before do
+      create(:scenario_version_tag, scenario: scenario, user: user, description: message)
+
+      get("/api/v3/scenarios/#{scenario.id}/version")
+    end
+
+    it 'is successful' do
+      expect(response.status).to eq(200)
+    end
+
+    it 'includes the description' do
+      expect(json).to include({ 'description' => message, 'user_id' => user.id })
+    end
+  end
+
+  describe 'create' do
+    context 'when there was no previous record' do
+      before do
+        post(
+          "/api/v3/scenarios/#{scenario.id}/version",
+          params: params,
+          headers: access_token_header(user, :write)
+        )
+      end
+
+      context 'when not providing a description' do
+        let(:params) { {} }
+
+        it 'is successful' do
+          expect(response.status).to eq(200)
+        end
+
+        it 'creates a version for the scenario' do
+          expect(scenario.scenario_version_tag).to be_present
+        end
+
+        it 'sets the user as version tag user' do
+          expect(scenario.scenario_version_tag.user).to eq(user)
+        end
+      end
+
+      context 'when providing a description' do
+        let(:params) { { description: message } }
+
+        it 'is successful' do
+          expect(response.status).to eq(200)
+        end
+
+        it 'creates a version for the scenario' do
+          expect(scenario.scenario_version_tag).to be_present
+        end
+
+        it 'sets the user as version tag user' do
+          expect(scenario.scenario_version_tag.user).to eq(user)
+        end
+
+        it 'sets a message' do
+          expect(scenario.scenario_version_tag.description).to eq(message)
+        end
+      end
+    end
+
+    context 'when there was a version already there' do
+      before do
+        create(:scenario_version_tag, scenario: scenario, user: user, description: message)
+        post(
+          "/api/v3/scenarios/#{scenario.id}/version",
+          params: params,
+          headers: access_token_header(user, :write)
+        )
+      end
+
+      let(:params) { { description: message2 } }
+
+      it 'is not successful' do
+        expect(response.status).to eq(422)
+      end
+
+      it 'does not change message' do
+        expect(scenario.scenario_version_tag.description).to eq(message)
+      end
+
+      it 'returns an error' do
+        expect(json['errors']).to include('A version was already tagged')
+      end
+    end
+  end
+
+  describe 'update' do
+    context 'with an existing version tag' do
+      before do
+        create(:scenario_version_tag, scenario: scenario, user: user, description: message)
+
+        put(
+          "/api/v3/scenarios/#{scenario.id}/version",
+          params: params,
+          headers: access_token_header(user, :write)
+        )
+
+        scenario.reload
+      end
+
+      context 'when updating the message' do
+        let(:params) { { description: message2 } }
+
+        it 'is successful' do
+          expect(response.status).to eq(200)
+        end
+
+        it 'creates a version for the scenario' do
+          expect(scenario.scenario_version_tag).to be_present
+        end
+
+        it 'sets the user as version tag user' do
+          expect(scenario.scenario_version_tag.user).to eq(user)
+        end
+
+        it 'sets a message' do
+          expect(scenario.scenario_version_tag.description).to eq(message2)
+        end
+      end
+
+      context 'when trying to update the user' do
+        let(:params) { { user_id: create(:user).id } }
+
+        it 'is successful' do
+          expect(response.status).to eq(200)
+        end
+
+        it 'does not change the user as version tag user' do
+          expect(scenario.scenario_version_tag.user).to eq(user)
+        end
+
+        it 'does not clear the message' do
+          expect(scenario.scenario_version_tag.description).to eq(message)
+        end
+      end
+
+      context 'when trying to update the user and the message' do
+        let(:params) { { user_id: create(:user).id, description: message2 } }
+
+        it 'is successful' do
+          expect(response.status).to eq(200)
+        end
+
+        it 'does not change the user as version tag user' do
+          expect(scenario.scenario_version_tag.user).to eq(user)
+        end
+
+        it 'updates the description' do
+          expect(scenario.scenario_version_tag.description).to eq(message2)
+        end
+      end
+    end
+
+    context 'with no pre existing version tag' do
+      before do
+        put(
+          "/api/v3/scenarios/#{scenario.id}/version",
+          params: params,
+          headers: access_token_header(user, :write)
+        )
+      end
+
+      let(:params) { { description: message2 } }
+
+      it 'is not successful' do
+        expect(response.status).to eq(404)
+      end
+
+      it 'returns an error' do
+        expect(json['errors']).to include('Scenario version tag not found')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows for scenarios to be tagged as a version. The version keeps track of the person who last changed the scenario, and allows for a description for the specific version. Each scenario is only allowed one tag.

This PR goes together with quintel/etmodel#4251.

Still todo:
- [ ] when scenario is updated, check if it was tagged and update the user with the current user