### PR TITLE
GQL function percentage change per year

### DIFF
--- a/app/models/gql/runtime/functions/legacy.rb
+++ b/app/models/gql/runtime/functions/legacy.rb
@@ -137,6 +137,13 @@ module Gql::Runtime
         values.first
       end
 
+      # Calculates the result of first value multiplied with
+      # the second value to the power of nr of years between
+      # the scenario's start and end year
+      def RELATIVE_CHANGE_PER_YEAR(*values)
+        values[0] * ((1.0 + values[1]) ** scope.scenario.years)
+      end
+
       # Converts a value to another format. Know what you do!
       # Especially useful to write more readable Queries:
       #

--- a/app/models/gql/runtime/functions/update.rb
+++ b/app/models/gql/runtime/functions/update.rb
@@ -103,6 +103,20 @@ module Gql::Runtime
         end
       end
 
+      # Same as UPDATE with update_type relative_per_year. INPUT_VALUE() is expected 
+      # to be a percentage change per year that will be applied each year
+      # between the end year and start year. 
+
+      # @example when fo has a preset_demand of 100.0, start year 2019, en year 2050
+      #    UPDATE_RELATIVE_PER_YEAR(V(foo)), preset_demand, 0.01)
+      #    # => foo gets a demand of 136.13
+      #
+      def UPDATE_RELATIVE_PER_YEAR(*value_terms)
+        update_something_by(*value_terms) do |original_value, input_value|
+          original_value * ((1.0 + input_value) ** scope.scenario.years)
+        end
+      end
+
       # Same as UPDATE, but forcefully behaving as the :absolute strategy.
       def UPDATE_ABSOLUTE(*value_terms)
         update_something_by(*value_terms) { |_, input_value| input_value }


### PR DESCRIPTION
This new function is introduced for solving the issue as specified in this [PR](https://github.com/quintel/etsource/pull/2970). 

Related to the function UPDATE() with update_type = %y (relative_per_year). Now, the same result can be obtained using a GQL function rather than specifying the update_type of an input. 

Goes with:
- https://github.com/quintel/etsource/pull/2970
- https://github.com/quintel/etengine/pull/1427

Next step (when PR is approved):
- [ ] Include new functions in GQL documentation