### PR TITLE
 Changing working of V() command

### DIFF
--- a/app/models/gql/runtime/functions/core.rb
+++ b/app/models/gql/runtime/functions/core.rb
@@ -148,7 +148,7 @@ module Gql::Runtime
         elements.tap(&:flatten!).map! do |element|
           GET(element, attr_name)
         end
-        elements.length <= 1 ? (elements.first || 0.0) : elements
+        elements.length <= 1 ? (elements.first ) : elements
       end
       alias MAP M
       # @deprecated


### PR DESCRIPTION
Changes the working of the V() command, when a number does not exist, a 'nil' is printed instead of '0'. 

Goes together with:
https://github.com/quintel/etengine/pull/1434 
https://github.com/quintel/etmodel/pull/4279