### PR TITLE
Added a ctrl + enter shortcut for editing scenarios

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,16 +33,12 @@ $(document).on("turbo:load", function () {
       viewportMargin: Infinity,
     });
 
-    // Ctrl+Enter submit on the GQL editor.
-    if ($(this).attr("name") == "query") {
-      cm.on("keydown", function (el, event) {
-        if (event.ctrlKey && event.keyCode === 13) {
-          $(event.target).parents("form").submit();
-        }
-      });
-
-      cm.focus();
-    }
+    // Ctrl+Enter submit on any CodeMirror instance
+    cm.on("keydown", function (el, event) {
+      if (event.ctrlKey && event.keyCode === 13) {
+        $(event.target).closest("form").submit();
+      }
+    });
   });
 
   $("#area_code_selector select").change(function (e) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,6 +33,10 @@ $(document).on("turbo:load", function () {
       viewportMargin: Infinity,
     });
 
+    if ($(this).attr("name") == "query") {
+      cm.focus();
+    }
+
     // Ctrl+Enter submit on any CodeMirror instance
     cm.on("keydown", function (el, event) {
       if (event.ctrlKey && event.keyCode === 13) {

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -38,7 +38,12 @@
         = hno.input :order, as: :text, input_html: { value: user_sortable_list(@scenario.heat_network_order(:lt)) }, label: 'Heat network (LT) dispatchables order', hint: 'Delete all lines to revert to default'
       = f.simple_fields_for :households_space_heating_producer_order, @scenario.households_space_heating_producer_order do |hno|
         = hno.input :order, as: :text, input_html: { value: user_sortable_list(@scenario.households_space_heating_producer_order) }, label: 'Households space heating producer order', hint: 'Delete all lines to revert to default'
-      = f.button :submit, class: 'btn btn-primary btn-large'
+      = content_tag(:button, type: 'submit', class: 'btn btn-primary btn-large') do
+        Submit
+        %span.hotkey
+          %kbd Ctrl
+          %span.plus +
+          %kbd ↩
 
   :css
     #scenario_heat_network_order_ht_order, #scenario_heat_network_order_mt_order,#scenario_heat_network_order_lt_order,#scenario_forecast_storage_order_order,#scenario_households_space_heating_producer_order_order,#scenario_hydrogen_supply_order_order,#scenario_hydrogen_demand_order_order {


### PR DESCRIPTION
Generalised the CodeMirror function in application.js so any codemirror instances could use the ctrl+enter command to submit a form. Hence editing scenarios can be submitted with ctrl + enter now.

Should I write tests for this kind of change @noracato? 