### PR TITLE
Hybrid Offshore Wind

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: '015f2fb', github: 'quintel/merit'
+gem 'quintel_merit', ref: '918bd4d', github: 'quintel/merit'
 gem 'atlas',         ref: 'd71240e', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: '5439199', github: 'quintel/refinery'

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: 'd75bce1', github: 'quintel/merit'
+gem 'quintel_merit', ref: '98faf34', github: 'quintel/merit'
 gem 'atlas',         ref: '83260d1', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: '5439199', github: 'quintel/refinery'

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: '421f3fb', github: 'quintel/merit'
+gem 'quintel_merit', ref: 'd75bce1', github: 'quintel/merit'
 gem 'atlas',         ref: '83260d1', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: '5439199', github: 'quintel/refinery'

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: '98faf34', github: 'quintel/merit'
+gem 'quintel_merit', ref: 'eaf7625', github: 'quintel/merit'
 gem 'atlas',         ref: '83260d1', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: '5439199', github: 'quintel/refinery'

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: 'eaf7625', github: 'quintel/merit'
+gem 'quintel_merit', ref: '015f2fb', github: 'quintel/merit'
 gem 'atlas',         ref: '83260d1', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: '5439199', github: 'quintel/refinery'

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ gem 'ruby-progressbar'
 
 # own gems
 gem 'quintel_merit', ref: '015f2fb', github: 'quintel/merit'
-gem 'atlas',         ref: '83260d1', github: 'quintel/atlas'
+gem 'atlas',         ref: 'd71240e', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: '5439199', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: 015f2fb9a6833f33ca47480c96da2ccdf11cbb2a
-  ref: 015f2fb
+  revision: 918bd4da31f115da990ea4a7162df9dac227c806
+  ref: 918bd4d
   specs:
     quintel_merit (0.1.0)
       numo-narray

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: 98faf34a4b59b5827d4951d927216938d33ed5f8
-  ref: 98faf34
+  revision: eaf76257f25614ff43fc9310d0d4a8384140793f
+  ref: eaf7625
   specs:
     quintel_merit (0.1.0)
       numo-narray

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 83260d193db153cf287770ed14ce94890f0fbb2d
-  ref: 83260d1
+  revision: d71240ed592198053bdea9d6b6be5fb0521dd7c0
+  ref: d71240e
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: 421f3fb1ca2895d6f10a458e7d897ecd527c4be6
-  ref: 421f3fb
+  revision: d75bce18a99cbd498ab6599a19a5de2dd668ca39
+  ref: d75bce1
   specs:
     quintel_merit (0.1.0)
       numo-narray

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: d75bce18a99cbd498ab6599a19a5de2dd668ca39
-  ref: d75bce1
+  revision: 98faf34a4b59b5827d4951d927216938d33ed5f8
+  ref: 98faf34
   specs:
     quintel_merit (0.1.0)
       numo-narray

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: eaf76257f25614ff43fc9310d0d4a8384140793f
-  ref: eaf7625
+  revision: 015f2fb9a6833f33ca47480c96da2ccdf11cbb2a
+  ref: 015f2fb
   specs:
     quintel_merit (0.1.0)
       numo-narray

--- a/app/models/qernel/causality/active_lazy_curve.rb
+++ b/app/models/qernel/causality/active_lazy_curve.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Qernel
+  module Causality
+    # A lazy curve that allows external factors to overwrite calculated values
+    class ActiveLazyCurve < LazyCurve
+      def []=(frame, value)
+        @values[frame] = value if @values[frame]
+      end
+    end
+  end
+end

--- a/app/models/qernel/merit_facade/flex_adapter.rb
+++ b/app/models/qernel/merit_facade/flex_adapter.rb
@@ -26,6 +26,8 @@ module Qernel
           OptimizingStorageAdapter
         when :load_shifting
           LoadShiftingAdapter
+        when :satisfied_demand
+          SatisfiedDemandAdapter
         else
           self
         end

--- a/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
+++ b/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
@@ -26,13 +26,9 @@ module Qernel
         super
 
         total_demand = participant.production
-        converter_demand = @clearing.sum
         curtailment_demand = @curtailed.sum
-        output_demand = total_demand - converter_demand - curtailment_demand
 
         find_edge(curtailment_node).dataset_set(:share, safe_div(curtailment_demand, total_demand))
-        find_edge(converter_node).dataset_set(:share, safe_div(converter_demand, total_demand))
-        find_edge(output_node).dataset_set(:share, safe_div(output_demand, total_demand))
       end
 
       private

--- a/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
+++ b/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
@@ -11,9 +11,16 @@ module Qernel
       def initialize(node, context)
         super
 
-        # input capacity of the output node
-        @output_input_capacity = output_node.node_api.input_capacity * output_node.node_api.number_of_units
-        @converter_input_capacity = converter_node.node_api.input_capacity * converter_node.node_api.number_of_units
+        # Input capacity of the output node
+        @output_input_capacity = (
+          output_node.node_api.input_capacity * output_node.node_api.number_of_units
+        )
+        # Input capacity of the converter node
+        @converter_input_capacity = (
+          converter_node.node_api.input_capacity *
+          converter_node.node_api.number_of_units *
+          converter_node.node_api.availability
+        )
 
         @clearing = Array.new(8760, 0.0)
         @curtailed = Array.new(8760, 0.0)

--- a/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
+++ b/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# require 'delegate'
+
+module Qernel
+  module MeritFacade
+    class HybridOffshoreAdapter < AlwaysOnAdapter
+      attr_reader :converter_curve
+
+      def initialize(node, context)
+        super
+
+        # input capacity of the output node
+        @output_input_capacity = output_node.node_api.input_capacity
+        @converter_input_capacity = converter_node.node_api.input_capacity
+        @clearing = Array.new(8760)
+
+        @converter_curve = Qernel::Causality::LazyCurve.new do |frame|
+          @clearing[frame] * -1
+        end
+      end
+
+      private
+
+      def producer_class
+        Merit::ConstrainedVolatileProducer
+      end
+
+      def producer_attributes
+        attrs = super
+
+        # lamba function that takes the frame and subracts the clearing, minimum with the cable in
+        # and that keeps track of the unfilled demand (that will become curtailment!)
+        attrs[:constraint] = ->(point, amount) { constrain(point, amount) }
+
+        attrs
+      end
+
+      # Calculates the energy that is constrained from going on the market. The constrained
+      # energy is located to other components
+      def constrain(point, amount)
+        converted = to_converter(amount)
+        @clearing[point] = converted
+
+        [amount - converted, @output_input_capacity].min
+      end
+
+      # The amount that flows to the converter in that hour
+      def to_converter(amount)
+        [amount - @output_input_capacity, @converter_input_capacity].min
+      end
+
+      # def curtailment_curve
+      #   # empty curve that will be filled
+      # end
+
+      # def output_curve
+      #   # can we also track this witinh the constarint method?
+      #   # this is what shoudl go into the cable -> so what goes into the market?
+      # end
+
+      def converter_node
+        @context.graph.node(@config.relations[:converter])
+      end
+
+      def output_node
+        @context.graph.node(@config.relations[:output])
+      end
+
+      def curtailment_node
+        @context.graph.node(@config.relations[:curtailment])
+      end
+
+      # something to set the clearing on the correct participant as satisfied demand
+    end
+  end
+end

--- a/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
+++ b/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
@@ -11,8 +11,8 @@ module Qernel
         super
 
         # input capacity of the output node
-        @output_input_capacity = output_node.node_api.input_capacity
-        @converter_input_capacity = converter_node.node_api.input_capacity
+        @output_input_capacity = output_node.node_api.input_capacity * output_node.node_api.number_of_units
+        @converter_input_capacity = converter_node.node_api.input_capacity * converter_node.node_api.number_of_units
         @clearing = Array.new(8760)
 
         @converter_curve = Qernel::Causality::LazyCurve.new do |frame|
@@ -70,8 +70,6 @@ module Qernel
       def curtailment_node
         @context.graph.node(@config.relations[:curtailment])
       end
-
-      # something to set the clearing on the correct participant as satisfied demand
     end
   end
 end

--- a/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
+++ b/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
@@ -6,7 +6,7 @@ module Qernel
     #
     # This adapter has to be attached to the main volatile producer.
     #
-    # A hybrid offshore park consist of two e-cables, one output towards land,
+    # A hybrid offshore park consist of two e-cables, one output from sea to land,
     # one input from land to sea; one volatile producer; a possible curtailment of the producer;
     # and a converter (e.g electrolyser) that can also bid on the main market through the input
     # cable. This converter should act as a Flex with SatifiedDemand, as the producer may set a load

--- a/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
+++ b/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
@@ -26,7 +26,7 @@ module Qernel
         super
 
         total_demand = participant.production
-        curtailment_demand = @curtailed.sum
+        curtailment_demand = @curtailed.sum * 3600
 
         # The curtailment egde is a share edge, so we calculate the share
         find_edge(curtailment_node).dataset_set(:share, safe_div(curtailment_demand, total_demand))

--- a/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
+++ b/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
@@ -17,7 +17,7 @@ module Qernel
         @clearing = Array.new(8760, 0.0)
         @curtailed = Array.new(8760, 0.0)
 
-        @converter_curve = Qernel::Causality::LazyCurve.new do |frame|
+        @converter_curve = Qernel::Causality::ActiveLazyCurve.new do |frame|
           @clearing[frame] * -1
         end
       end

--- a/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
+++ b/app/models/qernel/merit_facade/hybrid_offshore_adapter.rb
@@ -28,8 +28,6 @@ module Qernel
         total_demand = participant.production
         curtailment_demand = @curtailed.sum
 
-        puts total_demand_to_converter, @clearing.sum, converter_adapter.participant.production
-
         # The curtailment egde is a share edge, so we calculate the share
         find_edge(curtailment_node).dataset_set(:share, safe_div(curtailment_demand, total_demand))
         # The converter node is a constant edge, so we set the demend directly

--- a/app/models/qernel/merit_facade/producer_adapter.rb
+++ b/app/models/qernel/merit_facade/producer_adapter.rb
@@ -21,6 +21,8 @@ module Qernel
           BackupAdapter
         when :always_on_battery_park
           AlwaysOnBatteryParkAdapter
+        when :hybrid_offshore
+          HybridOffshoreAdapter
         else
           raise "Unknown #{context.attribute}.subtype " \
                 "#{config.subtype.to_s.inspect} for #{node.key}"

--- a/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
+++ b/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+
+module Qernel
+  module MeritFacade
+    # A flex consumer whos demand is partly satisfied directly by another
+    # participant
+    class SatisfiedDemandAdapter < FlexAdapter
+      private
+
+      def producer_attributes
+        attrs = super
+
+        attrs[:satisfied_demand_curve] = satisfied_demand_curve
+
+        attrs
+      end
+
+      def producer_class
+        Merit::Flex::WithSatisfiedDemand
+      end
+
+      #  what if node does not exist? what if curve does not exist -> also make
+      # curve name more generic as attribute and put it here with public_send
+      def satisfied_demand_curve
+        @context.plugin.adapters[@config.relations[:input].to_sym].converter_curve
+      end
+    end
+  end
+end

--- a/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
+++ b/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
@@ -3,7 +3,8 @@
 module Qernel
   module MeritFacade
     # A flex consumer whos demand is partly satisfied directly by another
-    # participant,
+    # participant. Currently, the adapter satisfying the demand has to be of type
+    # HybridOffshore.
     class SatisfiedDemandAdapter < FlexAdapter
       private
 
@@ -19,8 +20,6 @@ module Qernel
         Merit::Flex::WithSatisfiedDemand
       end
 
-      # TODO: add node validation
-      # TODO: make curve name a merit attribute and use public_send
       def satisfied_demand_curve
         @context.plugin.adapters[@config.relations[:input].to_sym].converter_curve
       end

--- a/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
+++ b/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
@@ -2,7 +2,7 @@
 
 module Qernel
   module MeritFacade
-    # A flex consumer whos demand is partly satisfied directly by another
+    # A flex consumer whose demand is partly satisfied directly by another
     # participant. Currently, the adapter satisfying the demand has to be of type
     # HybridOffshore.
     class SatisfiedDemandAdapter < FlexAdapter

--- a/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
+++ b/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
@@ -5,12 +5,6 @@ module Qernel
     # A flex consumer whos demand is partly satisfied directly by another
     # participant,
     class SatisfiedDemandAdapter < FlexAdapter
-      def inject!
-        super
-
-        input_edge.dataset_set(:share, participant.production)
-      end
-
       private
 
       def producer_attributes
@@ -29,19 +23,6 @@ module Qernel
       # TODO: make curve name a merit attribute and use public_send
       def satisfied_demand_curve
         @context.plugin.adapters[@config.relations[:input].to_sym].converter_curve
-      end
-
-      # Input edge should be a constant edge
-      def input_edge
-        input_node = @context.graph.node(@config.relations[:input])
-        edge = target_api.input_edges.find { |e| e.rgt_node == input_node }
-
-        unless edge
-          raise "Couldn't find a #{@context.carrier.inspect} edge between #{target_api.key} " \
-                "and #{input_node.key}"
-        end
-
-        edge
       end
     end
   end

--- a/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
+++ b/app/models/qernel/merit_facade/satisfied_demand_adapter.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 
-
 module Qernel
   module MeritFacade
     # A flex consumer whos demand is partly satisfied directly by another
-    # participant
+    # participant,
     class SatisfiedDemandAdapter < FlexAdapter
+      def inject!
+        super
+
+        input_edge.dataset_set(:share, participant.production)
+      end
+
       private
 
       def producer_attributes
@@ -20,10 +25,23 @@ module Qernel
         Merit::Flex::WithSatisfiedDemand
       end
 
-      #  what if node does not exist? what if curve does not exist -> also make
-      # curve name more generic as attribute and put it here with public_send
+      # TODO: add node validation
+      # TODO: make curve name a merit attribute and use public_send
       def satisfied_demand_curve
         @context.plugin.adapters[@config.relations[:input].to_sym].converter_curve
+      end
+
+      # Input edge should be a constant edge
+      def input_edge
+        input_node = @context.graph.node(@config.relations[:input])
+        edge = target_api.input_edges.find { |e| e.rgt_node == input_node }
+
+        unless edge
+          raise "Couldn't find a #{@context.carrier.inspect} edge between #{target_api.key} " \
+                "and #{input_node.key}"
+        end
+
+        edge
       end
     end
   end

--- a/app/serializers/merit_csv_serializer.rb
+++ b/app/serializers/merit_csv_serializer.rb
@@ -66,7 +66,7 @@ class MeritCSVSerializer < CausalityCurvesCSVSerializer
   end
 
   def exclude_producer_subtypes
-    %i[curtailment]
+    %i[curtailment satisfied_demand]
   end
 
   def consumer_types

--- a/app/serializers/node_serializer_data.rb
+++ b/app/serializers/node_serializer_data.rb
@@ -754,6 +754,24 @@ module NodeSerializerData
     }
   }.freeze
 
+  # If the node belongs to the electricity_distribution group then
+  # add these
+  ELECTRICITY_DISTRIBUTION_ATTRIBUTES_AND_METHODS = {
+    technical: {
+      'electricity_output_capacity' => {
+        label: 'Installed capacity',
+        key: :total_installed_electricity_capacity,
+        unit: 'MW'
+      },
+      'loss_output_conversion' => {
+        label: 'Distribution losses',
+        key: :distribution_losses,
+        unit: '%',
+        formatter: FORMAT_FAC_TO_PERCENT
+      }
+    }
+  }.freeze
+
   # some nodes use extra attributes. Rather than messing up the views I
   # add the method here. I hope this will be removed
   def uses_coal_and_wood_pellets?
@@ -806,6 +824,8 @@ module NodeSerializerData
         STEEL_ATTRIBUTES_AND_METHODS
       when :h2_storage
         H2_STORAGE_ATTRIBUTES_AND_METHODS
+      when :electricity_distribution
+        ELECTRICITY_DISTRIBUTION_ATTRIBUTES_AND_METHODS
       else
         {}
       end


### PR DESCRIPTION
With this PR the modelling of hybrid offshore wind is added to the ETM. This comes with, among others, the following features:

-   Hybrid offshore wind turbine that can generate electricity for HV network or directly for connected offshore electrolyser. 
-   Price-based offshore electrolyser that can receive electricity from hybrid wind turbine or from onshore HV network
-   New adapter classes `HybridOffshore` and `WithSatisfiedDemand` for MeritFacade


Goes with:

https://github.com/quintel/documentation/pull/195
https://github.com/quintel/etsource/pull/3067
https://github.com/quintel/etlocal/pull/524
https://github.com/quintel/etmodel/pull/4290
https://github.com/quintel/etdataset/pull/1001
quintel/merit#154