### PR TITLE
Add constraint for hybrid offshore converter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: '918bd4d', github: 'quintel/merit'
+gem 'quintel_merit', ref: '76f2343', github: 'quintel/merit'
 gem 'atlas',         ref: 'd71240e', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: '5439199', github: 'quintel/refinery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,8 +26,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: 918bd4da31f115da990ea4a7162df9dac227c806
-  ref: 918bd4d
+  revision: 76f23430d584e27f023f4ab635c3a3691a291709
+  ref: 76f2343
   specs:
     quintel_merit (0.1.0)
       numo-narray


### PR DESCRIPTION
Make sure the converter (electrolyser) does not bid on the market when the cable is not big enough!