### PR TITLE
Redesigned password reset mailer

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,19 @@
+class UserMailer < ActionMailer::Base
+  default from: "mailserver@quintel.com"
+
+  include Devise::Controllers::UrlHelpers
+
+  def password_reset_instructions(user)
+    @user = user
+    @token = @user.reset_token
+
+    I18n.with_locale do
+      mail(
+        to: user.email,
+        subject: I18n.t('user.forgot_password.mail.subject'),
+        template_path: 'devise/mailer',
+        template_name: 'reset_password_instructions'
+      )
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
     3 => :scenario_owner
   }.freeze
 
+  attr_accessor :reset_token
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable, :registerable
   devise :database_authenticatable, :registerable,
@@ -73,5 +75,15 @@ class User < ApplicationRecord
       su.couple_to(self)
       su.save
     end
+  end
+
+  def self.new_token
+    SecureRandom.urlsafe_base64
+  end
+
+  # Returns the hash digest of the given string
+  def self.digest(string)
+    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
+    BCrypt::Password.create(string, cost: cost)
   end
 end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,61 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
-
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= I18n.t('user.forgot_password.mail.subject') %></title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f4f4f4;
+      padding: 20px;
+    }
+    .container {
+      max-width: 700px;
+      margin: 0 auto;
+      background-color: #fff;
+      border-radius: 8px;
+      padding: 40px;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    }
+    .header {
+      text-align: center;
+      margin-bottom: 30px;
+    }
+    .btn {
+      display: inline-block;
+      padding: 10px 20px;
+      background-color: #4D99E4;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 5px;
+    }
+    .btn-container {
+      text-align: center;
+      margin-top: 30px;
+    }
+    .reset-url {
+      margin-top: 20px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <img src="<%= asset_path('inverted_logo.png') %>" alt="Logo" class="logo">
+      <h1><%= I18n.t('user.forgot_password.body.header') %></h1>
+      <p><%= I18n.t('user.forgot_password.body.message') %></p>
+    </div>
+    <div class="btn-container">
+      <a href="<%= edit_user_password_url(@resource, reset_password_token: @token) %>" class="btn"><%= I18n.t('user.forgot_password.body.button_text') %></a>
+    </div>
+    <div class="reset-url">
+      <p><%= I18n.t('user.forgot_password.body.link_message') %></p>
+      <p><%= edit_user_password_url(@resource, reset_password_token: @token) %></p>
+      <p><%= I18n.t('user.forgot_password.body.ignore_message') %></p>
+      <p><%= I18n.t('user.forgot_password.body.no_change_message') %></p>
+    </div>
+  </div>
+</body>
+</html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,17 @@ en:
         current_password: Current password
         unconfirmed_email: New e-mail address
         name: Your name
+  user:
+    forgot_password:
+      mail:
+        subject: "Reset password instructions"
+      body:
+        header: "Password Reset Instructions"
+        message: "You requested a password reset. Click the button below to reset your password."
+        button_text: "Reset My Password"
+        link_message: "If the button above does not work, you can copy and paste the following link into your browser:"
+        ignore_message: "If you didn't request this, please ignore this email."
+        no_change_message: "Your password won't change until you access the link above and create a new one."
   scenario_invitation_mailer:
     invite_user:
       subject: 'Invitation: ETM scenario'

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -35,9 +35,9 @@ nl:
   activemodel:
     attributes:
       'create_personal_access_token/params':
-        name: Token name
-        expires_in: Expiration
-        permissions: Permissions
+        name: Token naam
+        expires_in: Verloopt over
+        permissions: Rechten
   activerecord:
     attributes:
       user:
@@ -47,6 +47,17 @@ nl:
         current_password: Huidig wachtwoord
         unconfirmed_email: Nieuw e-mailadres
         name: Jouw naam
+  user:
+    forgot_password:
+      mail:
+        subject: "Instructies voor het opnieuw instellen van je wachtwoord"
+      body:
+        header: "Instructies voor het opnieuw instellen van je wachtwoord"
+        message: "Je hebt gevraagd om je wachtwoord opnieuw in te stellen. Klik op de onderstaande knop om je wachtwoord opnieuw in te stellen."
+        button_text: "Stel mijn wachtwoord opnieuw in"
+        link_message: "Als de bovenstaande knop niet werkt, kun je de volgende link kopiëren en plakken in je browser:"
+        ignore_message: "Als je dit niet hebt aangevraagd, kun je deze e-mail negeren."
+        no_change_message: "Je wachtwoord wordt niet gewijzigd totdat je de bovenstaande link opent en een nieuw wachtwoord aanmaakt."
   scenario_invitation_mailer:
     invite_user:
       subject: 'Uitnodiging: ETM scenario'
@@ -54,4 +65,3 @@ nl:
       scenario_viewer: gast
       scenario_collaborator: bewerker
       scenario_owner: eigenaar
-

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UserMailerPreview < ActionMailer::Preview
+  def password_reset_instructions
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset_instructions(user)
+  end
+end


### PR DESCRIPTION
I redesigned the password reset mailer and added a preview case and translations for it. I recycled the email confirmation template for the design. You can assess ChatGPT's translation abilities below (and the overall design of course).

![Screenshot 2024-07-24 at 16 23 09](https://github.com/user-attachments/assets/c68a459f-6d74-475f-812b-cf28424db71b)

Closes [#4301](https://github.com/quintel/my-etm/issues/32)