### PR TITLE
Migrate external coupling inputs for coal gas distribution

### DIFF
--- a/db/migrate/20240822120921_add_coal_gas_distribution.rb
+++ b/db/migrate/20240822120921_add_coal_gas_distribution.rb
@@ -1,17 +1,19 @@
-class CoalGasDist < ActiveRecord::Migration[7.0]
+class AddCoalGasDistribution < ActiveRecord::Migration[7.0]
   include ETEngine::ScenarioMigration
 
-  FINAL_DEMAND_SHARE_KEY = 'external_coupling_energy_distribution_coal_gas_energy_production_share'.freeze
+  FINAL_DEMAND_SHARE_KEY = 'external_coupling_energy_distribution_coal_gas_final_demand_share'.freeze
   ENERGY_PRODUCTION_SHARE_KEY = 'external_coupling_energy_distribution_coal_gas_energy_production_share'.freeze
   CHEMICAL_FEEDSTOCK_SHARE_KEY = 'external_coupling_energy_distribution_coal_gas_chemical_feedstock_share'.freeze
 
   def up
     migrate_scenarios do |scenario|
+      next unless scenario.user_values.key?(ENERGY_PRODUCTION_SHARE_KEY || CHEMICAL_FEEDSTOCK_SHARE_KEY)
+
       energy_production_share = scenario.user_values[ENERGY_PRODUCTION_SHARE_KEY] || 0.0
       chemical_feedstock_share = scenario.user_values[CHEMICAL_FEEDSTOCK_SHARE_KEY] || 0.0
       final_demand_share = 100.0 - chemical_feedstock_share - energy_production_share
 
-      if final_demand_share > 100.0 || final_demand_share < 0.01
+      if final_demand_share >= 100.0 || final_demand_share <= 0.01
         raise "Invalid final demand share: #{final_demand_share}. It must be between 0 and 100."
       else
         scenario.user_values[FINAL_DEMAND_SHARE_KEY] = final_demand_share

--- a/db/migrate/20240822120921_add_coal_gas_distribution.rb
+++ b/db/migrate/20240822120921_add_coal_gas_distribution.rb
@@ -7,17 +7,14 @@ class AddCoalGasDistribution < ActiveRecord::Migration[7.0]
 
   def up
     migrate_scenarios do |scenario|
-      next unless scenario.user_values.key?(ENERGY_PRODUCTION_SHARE_KEY || CHEMICAL_FEEDSTOCK_SHARE_KEY)
+      next unless scenario.user_values.key?(ENERGY_PRODUCTION_SHARE_KEY && CHEMICAL_FEEDSTOCK_SHARE_KEY)
 
-      energy_production_share = scenario.user_values[ENERGY_PRODUCTION_SHARE_KEY] || 0.0
-      chemical_feedstock_share = scenario.user_values[CHEMICAL_FEEDSTOCK_SHARE_KEY] || 0.0
-      final_demand_share = 100.0 - chemical_feedstock_share - energy_production_share
+      energy_production_share = scenario.user_values[ENERGY_PRODUCTION_SHARE_KEY]
+      chemical_feedstock_share = scenario.user_values[CHEMICAL_FEEDSTOCK_SHARE_KEY]
 
-      if final_demand_share >= 100.0 || final_demand_share <= 0.01
-        raise "Invalid final demand share: #{final_demand_share}. It must be between 0 and 100."
-      else
-        scenario.user_values[FINAL_DEMAND_SHARE_KEY] = final_demand_share
-      end
+      next unless energy_production_share + chemical_feedstock_share < 100.0
+
+      scenario.user_values[FINAL_DEMAND_SHARE_KEY] = 100.0 - chemical_feedstock_share - energy_production_share
     end
   end
 end

--- a/db/migrate/20240822120921_coal_gas_dist.rb
+++ b/db/migrate/20240822120921_coal_gas_dist.rb
@@ -1,0 +1,21 @@
+class CoalGasDist < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  FINAL_DEMAND_SHARE_KEY = 'external_coupling_energy_distribution_coal_gas_energy_production_share'.freeze
+  ENERGY_PRODUCTION_SHARE_KEY = 'external_coupling_energy_distribution_coal_gas_energy_production_share'.freeze
+  CHEMICAL_FEEDSTOCK_SHARE_KEY = 'external_coupling_energy_distribution_coal_gas_chemical_feedstock_share'.freeze
+
+  def up
+    migrate_scenarios do |scenario|
+      energy_production_share = scenario.user_values[ENERGY_PRODUCTION_SHARE_KEY] || 0.0
+      chemical_feedstock_share = scenario.user_values[CHEMICAL_FEEDSTOCK_SHARE_KEY] || 0.0
+      final_demand_share = 100.0 - chemical_feedstock_share - energy_production_share
+
+      if final_demand_share > 100.0 || final_demand_share < 0.01
+        raise "Invalid final demand share: #{final_demand_share}. It must be between 0 and 100."
+      else
+        scenario.user_values[FINAL_DEMAND_SHARE_KEY] = final_demand_share
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_16_114754) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_22_120921) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
In https://github.com/quintel/etsource/commit/3ae7109012b11fedd9e420111f1e2095f6bb7af2 the external coupling of coal gas distribution outputs has been updated. Most notably, a share group is added and the group is completed by the addition of an input for the output share going to final demand.

This migration sets the value for the new input for external coupling of coal gas distribution to final demand.