### PR TITLE
Add migration for active coupling groups

### DIFF
--- a/db/migrate/20240823072338_add_active_couplings.rb
+++ b/db/migrate/20240823072338_add_active_couplings.rb
@@ -1,0 +1,13 @@
+require 'etengine/scenario_migration'
+
+class AddActiveCouplings < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  def up
+    migrate_scenarios do |scenario|
+      scenario.inactive_couplings.each { |coupling| scenario.activate_coupling(coupling)}
+    end
+  end
+
+  def down;end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_22_120921) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_23_072338) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
Follows https://github.com/quintel/etengine/pull/1457.