### PR TITLE
Migration to add the include_in_qi_db attribute on the Users table

### DIFF
--- a/db/migrate/20241125104913_add_qi_field_on_user.rb
+++ b/db/migrate/20241125104913_add_qi_field_on_user.rb
@@ -1,0 +1,30 @@
+class AddQiFieldOnUser < ActiveRecord::Migration[7.0]
+
+  DOMAINS = [
+    '@quintel.com',
+    '@energytransitionmodel.com',
+    '@tennet.eu',
+    '@netbeheernederland.nl',
+    '@gasunie.nl',
+    '@kalavasta.com',
+    '@entsog.eu',
+    '@sec.entsoe.eu',
+    '@economy-bi.gov.uk',
+    '@nijmegen.nl',
+    '@rotterdam.nl',
+    '@tudelft.nl',
+    '@alliander.com',
+    '@noord-holland.nl'
+  ].freeze
+
+  def up
+    add_column :users, :include_in_qi_db, :boolean, default: false
+
+    User.where(DOMAINS.map { |domain| "email LIKE ?" }.join(' OR '), *DOMAINS.map { |domain| "%#{domain}" })
+        .update_all(include_in_qi_db: true)
+  end
+
+  def down
+    remove_column :users, :include_in_qi_db
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_12_093940) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_25_104913) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -251,6 +251,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_12_093940) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.boolean "include_in_qi_db", default: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
The migration also sets the attribute on existing users who match the backup list.