### PR TITLE
Adding migration for the removal of industry P2H WTP inputs

### DIFF
--- a/db/migrate/20250113141155_remove_external_wtp.rb
+++ b/db/migrate/20250113141155_remove_external_wtp.rb
@@ -12,13 +12,13 @@ class RemoveExternalWtp < ActiveRecord::Migration[7.0]
     external_coupling_industry_other_paper_p2h_wtp
   ].freeze
 
-  REGULAR_WTP_KEYS = %w[
-    wtp_of_industry_chemicals_refineries_flexibility_p2h_electricity
-    wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity
-    wtp_of_industry_chemicals_other_flexibility_p2h_electricity
-    wtp_of_industry_other_food_flexibility_p2h_electricity
-    wtp_of_industry_other_paper_flexibility_p2h_electricity
-]
+  #REGULAR_WTP_KEYS = %w[
+   # wtp_of_industry_chemicals_refineries_flexibility_p2h_electricity
+    #wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity
+    #wtp_of_industry_chemicals_other_flexibility_p2h_electricity
+    #wtp_of_industry_other_food_flexibility_p2h_electricity
+    #wtp_of_industry_other_paper_flexibility_p2h_electricity
+#].freeze
 
   # Mapping of regular keys to external keys
   WTP_KEYS_MAPPING = {
@@ -53,14 +53,14 @@ class RemoveExternalWtp < ActiveRecord::Migration[7.0]
       # Set the corresponding regular key with the retrieved value
       scenario.user_values[regular_key] = value_to_transfer
 
-      end
     end
+  end
 
-    def remove_external_keys(scenario)
+  def remove_external_keys(scenario)
       EXTERNAL_WTP_KEYS.each do |external_key|
         # Remove the external key from user_values
         scenario.user_values.delete(external_key)
-      end
     end
   end
+end
 

--- a/db/migrate/20250113141155_remove_external_wtp.rb
+++ b/db/migrate/20250113141155_remove_external_wtp.rb
@@ -36,6 +36,7 @@ class RemoveExternalWtp < ActiveRecord::Migration[7.0]
       # Check if one of external wtip sliders is touched, then some correction should be done to set keys
       next unless EXTERNAL_WTP_KEYS.any? { |key| scenario.user_values.key?(key)}
       set_regular_keys(scenario)
+      remove_external_keys(scenario)
     end
   end
 
@@ -54,6 +55,12 @@ class RemoveExternalWtp < ActiveRecord::Migration[7.0]
 
       end
     end
-  end
 
+    def remove_external_keys(scenario)
+      EXTERNAL_WTP_KEYS.each do |external_key|
+        # Remove the external key from user_values
+        scenario.user_values.delete(external_key)
+      end
+    end
+  end
 

--- a/db/migrate/20250113141155_remove_external_wtp.rb
+++ b/db/migrate/20250113141155_remove_external_wtp.rb
@@ -1,0 +1,59 @@
+require 'etengine/scenario_migration'
+
+class RemoveExternalWtp < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  # All relevant building stock keys that could've been set
+  EXTERNAL_WTP_KEYS = %w[
+    external_coupling_industry_chemical_refineries_p2h_wtp
+    external_coupling_industry_chemical_fertilizers_p2h_wtp
+    external_coupling_industry_chemical_other_p2h_wtp
+    external_coupling_industry_other_food_p2h_wtp
+    external_coupling_industry_other_paper_p2h_wtp
+  ].freeze
+
+  REGULAR_WTP_KEYS = %w[
+    wtp_of_industry_chemicals_refineries_flexibility_p2h_electricity
+    wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity
+    wtp_of_industry_chemicals_other_flexibility_p2h_electricity
+    wtp_of_industry_other_food_flexibility_p2h_electricity
+    wtp_of_industry_other_paper_flexibility_p2h_electricity
+]
+
+  # Mapping of regular keys to external keys
+  WTP_KEYS_MAPPING = {
+    'wtp_of_industry_chemicals_refineries_flexibility_p2h_electricity' => 'external_coupling_industry_chemical_refineries_p2h_wtp',
+    'wtp_of_industry_chemicals_fertilizers_flexibility_p2h_electricity' => 'external_coupling_industry_chemical_fertilizers_p2h_wtp',
+    'wtp_of_industry_chemicals_other_flexibility_p2h_electricity' => 'external_coupling_industry_chemical_other_p2h_wtp',
+    'wtp_of_industry_other_food_flexibility_p2h_electricity' => 'external_coupling_industry_other_food_p2h_wtp',
+    'wtp_of_industry_other_paper_flexibility_p2h_electricity' => 'external_coupling_industry_other_paper_p2h_wtp'
+  }.freeze
+
+
+  def up
+
+    migrate_scenarios do |scenario|
+      # Check if one of external wtip sliders is touched, then some correction should be done to set keys
+      next unless EXTERNAL_WTP_KEYS.any? { |key| scenario.user_values.key?(key)}
+      set_regular_keys(scenario)
+    end
+  end
+
+  def set_regular_keys(scenario)
+    # Obtain old default area values
+
+    WTP_KEYS_MAPPING.each do |regular_key, external_key|
+      # Skip if key is not set in user_values
+      next unless scenario.user_values.key?(external_key)
+
+      # Retrieve the value from the external key
+      value_to_transfer = scenario.user_values[external_key]
+
+      # Set the corresponding regular key with the retrieved value
+      scenario.user_values[regular_key] = value_to_transfer
+
+      end
+    end
+  end
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_25_104913) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_13_141155) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
This PR adds the migration that is necessary for the removal of industry wtp p2h inputs.
It is written to check whether one of the removed inputs is set, if this is the case, the regular input is set to the external coupling input. 

Goes together with:
https://github.com/quintel/etsource/pull/3185
https://github.com/quintel/etmodel/pull/4391
