### PR TITLE
Removed users from scenario serialisation

### DIFF
--- a/app/serializers/scenario_serializer.rb
+++ b/app/serializers/scenario_serializer.rb
@@ -26,7 +26,6 @@ class ScenarioSerializer
       methods: %i[start_year inactive_couplings]
     ).symbolize_keys
 
-    json[:users]    = @resource.scenario_users.map { |su| { id: su.user&.id, email: su.email, role: User::ROLES[su.role_id] } }
     json[:scaling]  = @resource.scaler&.as_json(except: %i[id scenario_id])
     json[:template] = @resource.preset_scenario_id
     json[:url]      = @controller.api_v3_scenario_url(@resource)

--- a/spec/requests/api/v3/create_scenario_spec.rb
+++ b/spec/requests/api/v3/create_scenario_spec.rb
@@ -107,7 +107,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets a scenario owner' do
-      expect(response.parsed_body['users'].first).to include('role' => 'scenario_owner')
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 
@@ -217,7 +219,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets an owner of the new scenario' do
-      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 
@@ -240,7 +244,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets an owner of the new scenario' do
-      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 
@@ -263,7 +269,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets an owner of the new scenario' do
-      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 
@@ -283,7 +291,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets an owner of the new scenario' do
-      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 
@@ -307,7 +317,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets an owner of the new scenario' do
-      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 
@@ -331,7 +343,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets an owner of the new scenario' do
-      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 
@@ -355,7 +369,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets an owner of the new scenario' do
-      expect(json.fetch('users').first).to include({ 'id' => user.id, 'role' => 'scenario_owner' })
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 

--- a/spec/requests/api/v3/interpolate_scenario_spec.rb
+++ b/spec/requests/api/v3/interpolate_scenario_spec.rb
@@ -113,7 +113,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets the scenario owner' do
-      expect(response_data['users'].first).to include('role' => 'scenario_owner')
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 
@@ -145,7 +147,9 @@ describe 'APIv3 Scenarios', :etsource_fixture do
     end
 
     it 'sets the scenario owner' do
-      expect(response_data['users'].first).to include('role' => 'scenario_owner')
+      scenario = Scenario.last
+      expect(scenario.users).to include(user)
+      expect(scenario.scenario_users.find_by(user: user).role_id).to eq(3)
     end
   end
 


### PR DESCRIPTION
Removed users from the scenarios serialisation and updated spec to check user scenario associations without relying on the response.