### PR TITLE
Use email from JWT to initialize and couple users

### DIFF
--- a/app/models/scenario_user.rb
+++ b/app/models/scenario_user.rb
@@ -67,6 +67,7 @@ class ScenarioUser < ApplicationRecord
   end
 
   def ensure_one_owner_left_before_save
+    return unless role_id_changed?
     # Don't check new records and ignore if the role is set to owner.
     return if new_record? || role_id == User::ROLES.key(:scenario_owner)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   attr_accessor :identity_user
 
-  delegate :email, :roles, :admin?, to: :identity_user, allow_nil: true
+  delegate :roles, :admin?, to: :identity_user, allow_nil: true
 
   has_many :scenario_users, dependent: :destroy
   has_many :scenarios, through: :scenario_users
@@ -22,18 +22,27 @@ class User < ApplicationRecord
 
   after_create :couple_scenario_users
 
+  # If users are initialized from JWT, then their email is not available
+  # from identity_user. In that case, a db field user_email is used. The email is
+  # needed on create to enter the couple_scenario_users hook.
+  def email
+    identity_user&.email || user_email
+  end
+
   # Links existing scenario users to the new User.
   #
   # It needs to be linked through the scenario user to ensure the scenario
   # user stops being marked as dirty.
   def couple_scenario_users
+    return unless email
+
     ScenarioUser.where(user_email: email).find_each do |su|
       su.couple_to(self)
       su.save
     end
   end
 
- # Performs sign-in steps for an Identity::User.
+  # Performs sign-in steps for an Identity::User.
   #
   # If a matching user exists in the database, it will be updated with the latest data from the
   # Identity::User. Otherwise, a new user will be created.
@@ -53,22 +62,24 @@ class User < ApplicationRecord
     id = token['sub']
     admin = token.dig('user', 'admin')
     name = token.dig('user', 'name')
+    email = token.dig('user', 'email')
 
-    raise 'Token does not contain user information' if id.blank? || name.blank?
+    raise 'Token does not contain user information' if id.blank? || name.blank? || email.blank?
 
     User.find_or_create_by!(id: token['sub']) do |u|
       u.admin = admin.presence || false
       u.name = name
+      u.user_email = email
     end
   # When a new user is introduced to the engine, this is usually through ETModels
-  # play interface. On entering play for the first time, two requests are sent to
+  # play interface. On entering play for the first time, multiple requests are sent to
   # the engine shortly after each other - one to create a scenario, one to initialise
-  # the inputs. In this case it may happen that the first request is still busy creating
+  # the inputs, etc. In this case it may happen that the first request is still busy creating
   # the user when the second request hits, resulting in a non-unique record on the users
   # id.
   # Also rescue from Deadlock: https://github.com/rails/rails/issues/54281
   rescue ActiveRecord::RecordNotUnique, ActiveRecord::Deadlocked, ActiveRecord::LockWaitTimeout
-    User.find(token['sub'])
+    User.find_by(id: token['sub'])
   end
 
   def self.from_session_user!(identity_user)

--- a/db/migrate/20250306093020_add_email_to_user.rb
+++ b/db/migrate/20250306093020_add_email_to_user.rb
@@ -1,0 +1,5 @@
+class AddEmailToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :user_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_01_13_141155) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_06_093020) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -187,6 +187,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_01_13_141155) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "include_in_qi_db", default: false
+    t.string "user_email"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/support/authorization_helper.rb
+++ b/spec/support/authorization_helper.rb
@@ -36,7 +36,8 @@ module AuthorizationHelper
       'sub' => user.id,
       'user' => {
         'id' => user.id,
-        'name' => user.name
+        'name' => user.name,
+        'email' => user.email
       },
       'scopes' => scopes
     }


### PR DESCRIPTION
Adds the email field back to the User in the db. We need the email to verify existing 'dirty' ScenarioUsers, and at this point `identity_user` is not yet available.

This transaction was failing before because it was matching on empty email fields when trying to couple users, rolling back the full user create each time.