### PR TITLE
Rescue JSON::JWT exceptions as well as decode errors

### DIFF
--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -25,7 +25,7 @@ module Api
         end
       end
 
-      rescue_from ETEngine::TokenDecoder::DecodeError do
+      rescue_from ETEngine::TokenDecoder::DecodeError, JSON::JWT::Exception do
         render json: { errors: ['Invalid or expired token'] }, status: :unauthorized
       end
 


### PR DESCRIPTION
This way users should receive some output when they use an old or malformed token alerting them to the fact that the token is the issue.