### PR TITLE
Allow admins to manage all resources

### DIFF
--- a/app/models/api/token_ability.rb
+++ b/app/models/api/token_ability.rb
@@ -6,6 +6,13 @@ module Api
     include CanCan::Ability
 
     def initialize(token, user)
+
+      # Ensure admins can fully manage all resources before any restrictions apply.
+      if user&.admin?
+        can :manage, :all  # Ensures access to everything else
+        return              # Skip further scope restrictions for admins
+      end
+
       can :read, Scenario, private: false
       scopes = token[:scopes]
 

--- a/app/models/api/token_ability.rb
+++ b/app/models/api/token_ability.rb
@@ -14,9 +14,12 @@ module Api
       @user   = user
 
       allow_public_read
-      allow_read if read_scope?
-      allow_write if write_scope?
-      allow_delete if delete_scope?
+      return unless read_scope?
+      allow_read
+      return unless write_scope?
+      allow_write
+      return unless delete_scope?
+      allow_delete
     end
 
     private

--- a/app/models/api/token_ability.rb
+++ b/app/models/api/token_ability.rb
@@ -1,60 +1,106 @@
 # frozen_string_literal: true
 
 module Api
-  # Describes the abilities of someone accessing the API with an access a token.
+  # Describes the abilities of someone accessing the API with an access token.
+  # Admins can read, write, and delete all scenarios, provided they have the correct scope in the token.
+  # Users can read public scenarios and scenarios where they are viewers.
+  # Users with write scope can create, update, and clone scenarios where they are collaborators.
+  # Users with delete scope can delete scenarios where they are owners.
   class TokenAbility
     include CanCan::Ability
 
     def initialize(token, user)
-      # Ensure admins can fully manage all resources before any restrictions apply.
-      if user&.admin?
-        can :manage, :all
-        return
-      end
+      @scopes = token[:scopes]
+      @user   = user
 
+      allow_public_read
+      allow_read if read_scope?
+      allow_write if write_scope?
+      allow_delete if delete_scope?
+    end
+
+    private
+
+    # Methods to allow access to scenarios based on the role.
+    # Everyone can read public scenarios.
+    def allow_public_read
       can :read, Scenario, private: false
-      scopes = token[:scopes]
+    end
 
-      # scenarios:read
-      # --------------
-      return unless scopes.include?('scenarios:read')
+    def allow_read
+      if admin?
+        can :read, Scenario
+      else
+        can :read, Scenario, id: viewer_scenario_ids
+      end
+    end
 
-      can :read, Scenario, id: ScenarioUser.where(
-        user_id: user.id,
-        role_id: User::ROLES.key(:scenario_viewer)..
-      ).pluck(:scenario_id)
-
-      # scenarios:write
-      # ---------------
-      return unless scopes.include?('scenarios:write')
-
+    def allow_write
       can :create, Scenario
 
-      # Unowned public scenario.
-      can :update, Scenario, private: false
-      cannot :update, Scenario, private: false, id: ScenarioUser.pluck(:scenario_id)
+      if admin?
+        # Admins with write scope can update and clone all scenarios.
+        can :update, Scenario
+        can :clone, Scenario
+      else
+        # Non-admins
+        # Allow updating unowned public scenarios except when any association exists.
+        can :update, Scenario, private: false
+        cannot :update, Scenario, private: false, id: ScenarioUser.pluck(:scenario_id)
+        # Allow updating scenarios where the user is a collaborator.
+        can :update, Scenario, id: collaborator_scenario_ids
 
-      # Self-owned scenario.
-      can :update, Scenario, id: ScenarioUser.where(
-        user_id: user.id,
+        # Allow cloning both unowned public scenarios and self-owned scenarios.
+        can :clone, Scenario, private: false
+        can :clone, Scenario, id: collaborator_scenario_ids
+      end
+    end
+
+    def allow_delete
+      if admin?
+        can :destroy, Scenario
+      else
+        can :destroy, Scenario, id: owner_scenario_ids
+      end
+    end
+
+    # Methods to get the scenario ids for the user based on the role.
+    def viewer_scenario_ids
+      ScenarioUser.where(
+        user_id: @user.id,
+        role_id: User::ROLES.key(:scenario_viewer)..
+      ).pluck(:scenario_id)
+    end
+
+    def collaborator_scenario_ids
+      ScenarioUser.where(
+        user_id: @user.id,
         role_id: User::ROLES.key(:scenario_collaborator)..
       ).pluck(:scenario_id)
+    end
 
-      # Actions that involve reading one scenario and writing to another.
-      can :clone, Scenario, private: false
-      can :clone, Scenario, id: ScenarioUser.where(
-        user_id: user.id,
-        role_id: User::ROLES.key(:scenario_collaborator)..
-      ).pluck(:scenario_id)
-
-      # scenarios:delete
-      # ----------------
-      return unless scopes.include?('scenarios:delete')
-
-      can :destroy, Scenario, id: ScenarioUser.where(
-        user_id: user.id,
+    def owner_scenario_ids
+      ScenarioUser.where(
+        user_id: @user.id,
         role_id: User::ROLES.key(:scenario_owner)
       ).pluck(:scenario_id)
+    end
+
+    # Methods to check the scopes of the token.
+    def read_scope?
+      @scopes.include?('scenarios:read')
+    end
+
+    def write_scope?
+      @scopes.include?('scenarios:write')
+    end
+
+    def delete_scope?
+      @scopes.include?('scenarios:delete')
+    end
+
+    def admin?
+      @user&.admin?
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   attr_accessor :identity_user
 
-  delegate :roles, :admin?, to: :identity_user, allow_nil: true
+  delegate :roles, to: :identity_user, allow_nil: true
 
   has_many :scenario_users, dependent: :destroy
   has_many :scenarios, through: :scenario_users
@@ -44,11 +44,7 @@ class User < ApplicationRecord
 
   # Override admin? to fall back to the attribute when identity_user is nil.
   def admin?
-    if identity_user.nil?
-      self.admin
-    else
-      identity_user.admin?
-    end
+    identity_user&.admin? || admin
   end
 
   # Performs sign-in steps for an Identity::User.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,15 @@ class User < ApplicationRecord
     end
   end
 
+  # Override admin? to fall back to the attribute when identity_user is nil.
+  def admin?
+    if identity_user.nil?
+      self.admin
+    else
+      identity_user.admin?
+    end
+  end
+
   # Performs sign-in steps for an Identity::User.
   #
   # If a matching user exists in the database, it will be updated with the latest data from the

--- a/spec/models/api/token_ability_spec.rb
+++ b/spec/models/api/token_ability_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::TokenAbility do
       ]
     }
   end
-  let(:scopes) { 'scenarios:read' }
+  let(:scopes) { '' }
 
   let(:mock_decoded_token) do
     {

--- a/spec/models/api/token_ability_spec.rb
+++ b/spec/models/api/token_ability_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Api::TokenAbility do
 
   # ------------------------------------------------------------------------------------------------
 
-  shared_examples_for "a token without the 'scenarios:read' scope" do
+  shared_examples_for 'a token without the "scenarios:read" scope' do
     it 'may view an unowned public scenario' do
       expect(ability).to be_able_to(:read, public_scenario)
     end
@@ -73,6 +73,14 @@ RSpec.describe Api::TokenAbility do
 
     it 'may not view an owned private scenario' do
       expect(ability).not_to be_able_to(:read, other_private_scenario)
+    end
+
+    context 'when admin' do
+      let(:user) { create(:user, admin: true, roles:) }
+
+      it 'may not view an owned private scenario' do
+        expect(ability).not_to be_able_to(:read, other_private_scenario)
+      end
     end
   end
 
@@ -91,6 +99,14 @@ RSpec.describe Api::TokenAbility do
 
     it 'may view an owned private scenario' do
       expect(ability).to be_able_to(:read, owned_private_scenario)
+    end
+
+    context 'when admin' do
+      let(:user) { create(:user, admin: true, roles:) }
+
+      it 'may view an owned private scenario' do
+        expect(ability).to be_able_to(:read, other_private_scenario)
+      end
     end
   end
 
@@ -138,6 +154,22 @@ RSpec.describe Api::TokenAbility do
     it 'may not clone an other-owned private scenario' do
       expect(ability).not_to be_able_to(:clone, other_private_scenario)
     end
+
+    context 'when admin' do
+      let(:user) { create(:user, admin: true, roles:) }
+
+      it 'may change an other-owned public scenario' do
+        expect(ability).to be_able_to(:update, other_public_scenario)
+      end
+
+      it 'may change an other-owned private scenario' do
+        expect(ability).to be_able_to(:update, other_private_scenario)
+      end
+
+      it 'may clone an other-owned private scenario' do
+        expect(ability).to be_able_to(:clone, other_private_scenario)
+      end
+    end
   end
 
   shared_examples_for 'a token without the "scenarios:write" scope' do
@@ -176,6 +208,22 @@ RSpec.describe Api::TokenAbility do
     it 'may not clone an owned private scenario' do
       expect(ability).not_to be_able_to(:clone, owned_private_scenario)
     end
+
+    context 'when admin' do
+      let(:user) { create(:user, admin: true, roles:) }
+
+      it 'may not change an other-owned public scenario' do
+        expect(ability).not_to be_able_to(:update, other_public_scenario)
+      end
+
+      it 'may not change an other-owned private scenario' do
+        expect(ability).not_to be_able_to(:update, other_private_scenario)
+      end
+
+      it 'may not clone an other-owned private scenario' do
+        expect(ability).not_to be_able_to(:clone, other_private_scenario)
+      end
+    end
   end
 
   shared_examples_for 'a token with the "scenarios:delete" scope' do
@@ -197,6 +245,18 @@ RSpec.describe Api::TokenAbility do
 
     it 'may not delete an other-owned private scenario' do
       expect(ability).not_to be_able_to(:destroy, other_private_scenario)
+    end
+
+    context 'when admin' do
+      let(:user) { create(:user, admin: true, roles:) }
+
+      it 'may delete an other-owned public scenario' do
+        expect(ability).to be_able_to(:destroy, other_public_scenario)
+      end
+
+      it 'may delete an other-owned private scenario' do
+        expect(ability).to be_able_to(:destroy, other_private_scenario)
+      end
     end
   end
 
@@ -220,11 +280,25 @@ RSpec.describe Api::TokenAbility do
     it 'may not delete an other-owned private scenario' do
       expect(ability).not_to be_able_to(:destroy, other_private_scenario)
     end
+
+    context 'when admin' do
+      let(:user) { create(:user, admin: true, roles:) }
+
+      it 'may not delete an other-owned public scenario' do
+        expect(ability).not_to be_able_to(:destroy, other_public_scenario)
+      end
+
+      it 'may not delete an other-owned private scenario' do
+        expect(ability).not_to be_able_to(:destroy, other_private_scenario)
+      end
+    end
   end
 
   # ------------------------------------------------------------------------------------------------
 
   context 'when the token scope is "public"' do
+    # Read
+    include_examples 'a token without the "scenarios:read" scope'
 
     # Update
     include_examples 'a token without the "scenarios:write" scope'


### PR DESCRIPTION
With these changes, also with [this PR for MyETM](https://github.com/quintel/my-etm/pull/104), admins can now access all resources.

Closes #1527 
