### PR TITLE
Fix for tokens on beta

### DIFF
--- a/lib/etengine/token_decoder.rb
+++ b/lib/etengine/token_decoder.rb
@@ -45,7 +45,7 @@ module ETEngine
     end
 
     def strip_etm_prefix(token)
-      token.remove(/^(etm_|etm_beta_)/)
+      token.sub(/^etm_(beta_)?/, '')
     end
   end
 end


### PR DESCRIPTION
Adjust method to strip prefix for tokens as remove was greedily removing etm_ and leaving the beta behind.