### PR TITLE
User curve model

### DIFF
--- a/app/models/gql/custom_curve_collection.rb
+++ b/app/models/gql/custom_curve_collection.rb
@@ -8,15 +8,15 @@ module Gql
 
     # Public: Creates a CustomCurveCollection from the attachments on a scenario.
     def self.from_scenario(scenario)
-      curve_attachments = scenario.attachments.select(&:loadable_curve?)
+      curve_attachments = scenario.user_curves.select(&:loadable_curve?)
 
       new(
-        curve_attachments.each_with_object({}) do |attachment, state|
-          config = CurveHandler::Config.find_by(db_key: attachment.key)
+        curve_attachments.each_with_object({}) do |user_curve, state|
+          config = CurveHandler::Config.find_by(db_key: user_curve.key)
 
-          state[config.key] = Merit::Curve.reader.read(
-            ActiveStorage::Blob.service.path_for(attachment.file.key)
-          ).freeze
+          next unless config
+
+          state[config.key] = user_curve.curve.to_a.freeze
         end
       )
     end

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -32,6 +32,8 @@ class Scenario < ApplicationRecord
   has_one    :hydrogen_demand_order, dependent: :destroy
   has_one    :households_space_heating_producer_order, dependent: :destroy
   has_many   :attachments, dependent: :destroy, class_name: 'ScenarioAttachment'
+  has_many :user_curves, dependent: :destroy
+
 
   has_many :source_attachments,
     dependent: :nullify,

--- a/app/models/scenario/inputs.rb
+++ b/app/models/scenario/inputs.rb
@@ -132,10 +132,9 @@ class Scenario < ApplicationRecord
 
     def inputs_disabled_by_curves
       @inputs_disabled_by_curves ||= Set.new(
-        @scenario.attachments
-          .select(&:curve?)
+        @scenario.user_curves
           .select(&:loadable_curve?)
-          .flat_map { |attachment| attachment.curve_config.internal_disabled_inputs }
+          .flat_map { |curve| curve.curve_config.internal_disabled_inputs }
       )
     end
   end

--- a/app/models/scenario_attachment.rb
+++ b/app/models/scenario_attachment.rb
@@ -43,11 +43,6 @@ class ScenarioAttachment < ApplicationRecord
     VALID_FILE_KEYS
   end
 
-  # TODO: Remove I think
-  def loadable_curve?
-    file&.attached? && CurveHandler::Config.db_key?(key)
-  end
-
   # Returns true for attachments which have all their 'source_scenario' metadata
   # set, indicating the attachment was imported from another scenario
   def source_scenario?

--- a/app/models/scenario_attachment.rb
+++ b/app/models/scenario_attachment.rb
@@ -43,16 +43,9 @@ class ScenarioAttachment < ApplicationRecord
     VALID_FILE_KEYS
   end
 
+  # TODO: Remove I think
   def loadable_curve?
     file&.attached? && CurveHandler::Config.db_key?(key)
-  end
-
-  def curve?
-    key.ends_with?('_curve')
-  end
-
-  def curve_config
-    Etsource::Config.user_curves[key.chomp('_curve')]
   end
 
   # Returns true for attachments which have all their 'source_scenario' metadata

--- a/app/models/user_curve.rb
+++ b/app/models/user_curve.rb
@@ -20,7 +20,7 @@ class UserCurve < ApplicationRecord
     curve.present? && CurveHandler::Config.db_key?(key)
   end
 
-  # TODO: Check if necessary
+  # TODO: Check if still necessary
   # Identify that this record is a curve based on the key suffix
   def curve?
     key.ends_with?('_curve')

--- a/app/models/user_curve.rb
+++ b/app/models/user_curve.rb
@@ -3,11 +3,17 @@
 class UserCurve < ApplicationRecord
   belongs_to :scenario
 
-  # Serialise the curve using MessagePack
-  serialize :curve, Array, coder: MessagePack
-
   # Ensure that each user curve has a unique key per scenario
   validates :key, presence: true, uniqueness: { scope: :scenario_id, case_sensitive: false }
+
+  def curve
+    @curve ||= MeritCurveSerializer.load(read_attribute(:curve))
+  end
+
+  def curve=(val)
+    @curve = val
+    write_attribute(:curve, MeritCurveSerializer.dump(val))
+  end
 
   # Returns true if a valid curve is stored
   def loadable_curve?

--- a/app/models/user_curve.rb
+++ b/app/models/user_curve.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class UserCurve < ApplicationRecord
+  belongs_to :scenario
+
+  # Serialise the curve using MessagePack
+  serialize :curve, Array, coder: MessagePack
+
+  # Ensure that each user curve has a unique key per scenario
+  validates :key, presence: true, uniqueness: { scope: :scenario_id, case_sensitive: false }
+
+  # Returns true if a valid curve is stored
+  def loadable_curve?
+    curve.present? && CurveHandler::Config.db_key?(key)
+  end
+
+  # TODO: Check if necessary
+  # Identify that this record is a curve based on the key suffix
+  def curve?
+    key.ends_with?('_curve')
+  end
+
+  # Returns the configuration for the curve using the key (without the suffix)
+  def curve_config
+    Etsource::Config.user_curves[key.chomp('_curve')]
+  end
+end

--- a/app/models/user_curve.rb
+++ b/app/models/user_curve.rb
@@ -2,9 +2,20 @@
 
 class UserCurve < ApplicationRecord
   belongs_to :scenario
+  belongs_to :source_scenario, class_name: 'Scenario', optional: true
+
+  SOURCE_SCENARIO_METADATA = %i[
+    source_scenario_id
+    source_scenario_title
+    source_saved_scenario_id
+    source_dataset_key
+    source_end_year
+  ].freeze
 
   # Ensure that each user curve has a unique key per scenario
   validates :key, presence: true, uniqueness: { scope: :scenario_id, case_sensitive: false }
+  # Check the metadata for the curve
+  validate :validate_source_scenario_metadata
 
   def curve
     @curve ||= MeritCurveSerializer.load(read_attribute(:curve))
@@ -20,7 +31,7 @@ class UserCurve < ApplicationRecord
     curve.present? && CurveHandler::Config.db_key?(key)
   end
 
-  # TODO: Check if still necessary
+  # TODO: Check if this is still necessary
   # Identify that this record is a curve based on the key suffix
   def curve?
     key.ends_with?('_curve')
@@ -29,5 +40,28 @@ class UserCurve < ApplicationRecord
   # Returns the configuration for the curve using the key (without the suffix)
   def curve_config
     Etsource::Config.user_curves[key.chomp('_curve')]
+  end
+
+  def source_scenario?
+    SOURCE_SCENARIO_METADATA.all? { |key| public_send(key).present? }
+  end
+
+  def metadata_json
+    return {} unless source_scenario?
+
+    SOURCE_SCENARIO_METADATA.to_h { |key| [key, public_send(key)] }
+  end
+
+  def update_or_remove_metadata(metadata)
+    return update(metadata) if metadata.present?
+    return unless source_scenario?
+
+    update(SOURCE_SCENARIO_METADATA.index_with { nil })
+  end
+
+  def validate_source_scenario_metadata
+    if SOURCE_SCENARIO_METADATA.any? { |key| public_send(key).present? } && !source_scenario?
+      errors.add(:base, 'All metadata needs to be set for curves imported from another scenario')
+    end
   end
 end

--- a/app/serializers/merit_curve_serializer.rb
+++ b/app/serializers/merit_curve_serializer.rb
@@ -1,0 +1,18 @@
+class MeritCurveSerializer
+  # Dump the Merit::Curve instance into a MessagePack binary string.
+  # We capture the values array, the intended length, and the default value.
+  def self.dump(curve)
+    data = {
+      values: curve.to_a,
+      length: curve.length,
+      default: curve.instance_variable_get(:@default)
+    }
+    MessagePack.pack(data)
+  end
+
+  # Load the MessagePack binary string and instantiate a new Merit::Curve.
+  def self.load(packed)
+    data = MessagePack.unpack(packed, symbolize_keys: true)
+    Merit::Curve.new(data[:values], data[:length], data[:default])
+  end
+end

--- a/db/migrate/20250326090732_create_user_curves.rb
+++ b/db/migrate/20250326090732_create_user_curves.rb
@@ -2,9 +2,18 @@ class CreateUserCurves < ActiveRecord::Migration[7.0]
   def change
     create_table :user_curves, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
       t.integer :scenario_id, null: false
-      t.string :key, null: false
+      t.string  :key, null: false
+
       # MEDIUMBLOB - expect curves to be 68-72 kb. A normal blob is 64 kb. This is 16 mb.
-      t.binary :curve, null: false, limit: 16.megabytes - 1
+      t.binary  :curve, null: false, limit: 16.megabytes - 1
+
+      # Metadata fields for imported curves
+      t.integer :source_scenario_id
+      t.string  :source_scenario_title
+      t.integer :source_saved_scenario_id
+      t.string  :source_dataset_key
+      t.integer :source_end_year
+
       t.timestamps
     end
 

--- a/db/migrate/20250326090732_create_user_curves.rb
+++ b/db/migrate/20250326090732_create_user_curves.rb
@@ -3,7 +3,8 @@ class CreateUserCurves < ActiveRecord::Migration[7.0]
     create_table :user_curves, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
       t.integer :scenario_id, null: false
       t.string :key, null: false
-      t.binary :curve, null: false # I think binary should avoid Messagepack encoding issues
+      # MEDIUMBLOB - expect curves to be 68-72 kb. A normal blob is 64 kb. This is 16 mb.
+      t.binary :curve, null: false, limit: 16.megabytes - 1
       t.timestamps
     end
 

--- a/db/migrate/20250326090732_create_user_curves.rb
+++ b/db/migrate/20250326090732_create_user_curves.rb
@@ -4,7 +4,8 @@ class CreateUserCurves < ActiveRecord::Migration[7.0]
       t.integer :scenario_id, null: false
       t.string  :key, null: false
 
-      # MEDIUMBLOB - expect curves to be 68-72 kb. A normal blob is 64 kb. This is 16 mb.
+      # MEDIUMBLOB - I tested a curve serialized with MessagePack and it was ~70 kb.
+      # A normal blob is 64 kb. So we need a medium blob
       t.binary  :curve, null: false, limit: 16.megabytes - 1
 
       # Metadata fields for imported curves

--- a/db/migrate/20250326090732_create_user_curves.rb
+++ b/db/migrate/20250326090732_create_user_curves.rb
@@ -1,0 +1,12 @@
+class CreateUserCurves < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_curves, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+      t.integer :scenario_id, null: false
+      t.string :key, null: false
+      t.binary :curve, null: false # I think binary should avoid Messagepack encoding issues
+      t.timestamps
+    end
+
+    add_index :user_curves, [:scenario_id, :key], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_06_093020) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_26_090732) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -71,50 +71,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_06_093020) do
     t.index ["scenario_id"], name: "index_hydrogen_supply_orders_on_scenario_id", unique: true
   end
 
-  create_table "oauth_openid_requests", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "access_grant_id", null: false
-    t.string "nonce", null: false
-    t.index ["access_grant_id"], name: "index_oauth_openid_requests_on_access_grant_id"
-  end
-
-  create_table "old_users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "email", null: false
-    t.string "company_school"
-    t.boolean "allow_news", default: true
-    t.string "heared_first_at", default: ".."
-    t.string "password_salt"
-    t.integer "role_id"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.string "openid_identifier"
-    t.string "phone_number"
-    t.string "group"
-    t.string "trackable", limit: 191, default: "0"
-    t.boolean "send_score", default: false
-    t.boolean "new_round"
-    t.string "old_crypted_password"
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
-    t.datetime "remember_created_at", precision: nil
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at", precision: nil
-    t.datetime "last_sign_in_at", precision: nil
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.index ["trackable"], name: "index_old_users_on_trackable"
-  end
-
-  create_table "personal_access_tokens", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "oauth_access_token_id", null: false
-    t.string "name"
-    t.datetime "last_used_at"
-    t.index ["oauth_access_token_id"], name: "index_personal_access_tokens_on_oauth_access_token_id", unique: true
-    t.index ["user_id"], name: "index_personal_access_tokens_on_user_id"
-  end
-
   create_table "scenario_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "scenario_id", null: false
     t.string "key", null: false
@@ -171,13 +127,22 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_06_093020) do
     t.index ["created_at"], name: "index_scenarios_on_created_at"
   end
 
-  create_table "sessions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "sessions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "user_curves", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "scenario_id", null: false
+    t.string "key", null: false
+    t.binary "curve", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["scenario_id", "key"], name: "index_user_curves_on_scenario_id_and_key", unique: true
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,7 +139,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_26_090732) do
   create_table "user_curves", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "scenario_id", null: false
     t.string "key", null: false
-    t.binary "curve", null: false
+    t.binary "curve", limit: 16.megabytes - 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["scenario_id", "key"], name: "index_user_curves_on_scenario_id_and_key", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,7 +139,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_26_090732) do
   create_table "user_curves", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "scenario_id", null: false
     t.string "key", null: false
-    t.binary "curve", limit: 16.megabytes - 1, null: false
+    t.binary "curve", size: :medium, null: false
+    t.integer "source_scenario_id"
+    t.string "source_scenario_title"
+    t.integer "source_saved_scenario_id"
+    t.string "source_dataset_key"
+    t.integer "source_end_year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["scenario_id", "key"], name: "index_user_curves_on_scenario_id_and_key", unique: true

--- a/spec/factories/user_curve.rb
+++ b/spec/factories/user_curve.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user_curve do
+    association :scenario
+    key { "custom_curve" }
+    curve { Merit::Curve.new([1.0] * 8760) }
+  end
+end

--- a/spec/models/scenario/inputs_spec.rb
+++ b/spec/models/scenario/inputs_spec.rb
@@ -6,39 +6,6 @@ RSpec.describe Scenario::Inputs do
   let(:scenario) { Scenario.new }
   let(:inputs) { described_class.new(scenario) }
 
-  context 'when the scenario has an attached curve' do
-    before do
-      attachment = scenario.attachments.build(key: 'a_curve')
-      allow(attachment).to receive(:loadable_curve?).and_return(true)
-
-      allow(attachment).to receive(:curve_config).and_return(
-        CurveHandler::Config.from_etsource({
-          key: 'a',
-          type: 'generic',
-          disables: ['both_input']
-        })
-      )
-
-      scenario.user_values = {
-        both_input: 100,
-        present_input: 50,
-        future_input: 25
-      }
-    end
-
-    it 'removes the disabled input from the "present" list' do
-      expect(inputs.present).to eq({
-        Input.get(:present_input) => 50
-      })
-    end
-
-    it 'removes the disabled input from the "future" list' do
-      expect(inputs.future).to eq({
-        Input.get(:future_input) => 25
-      })
-    end
-  end
-
   context 'when a scenario has no inputs' do
     it 'has no before inputs' do
       expect(inputs.before).to be_empty

--- a/spec/models/user_curve_spec.rb
+++ b/spec/models/user_curve_spec.rb
@@ -2,24 +2,88 @@
 
 require 'spec_helper'
 
-describe UserCurve do
+RSpec.describe UserCurve do
   let(:scenario) { create(:scenario) }
-  let(:curve_data) { [0.0, 1.0, 2.0, 3.0] }
 
-  it 'serializes and deserializes to a Merit::Curve' do
-    curve = Merit::Curve.new(curve_data, 8760, 0.0)
-    user_curve = UserCurve.create!(scenario:, key: 'some_curve', curve:)
+  describe 'core functionality' do
+    let(:curve_data) { [0.0, 1.0, 2.0, 3.0] }
 
-    user_curve.reload
-    expect(user_curve.curve).to be_a(Merit::Curve)
-    expect(user_curve.curve.to_a).to eq(curve_data + [0.0] * (8760 - 4))
+    it 'serializes and deserializes to a Merit::Curve' do
+      user_curve = create(
+        :user_curve,
+        scenario:,
+        key: 'some_curve',
+        curve: Merit::Curve.new(curve_data, 8760, 0.0)
+      )
+
+      user_curve.reload
+      expect(user_curve.curve).to be_a(Merit::Curve)
+      expect(user_curve.curve.to_a).to eq(curve_data + [0.0] * (8760 - 4))
+    end
+
+    it 'validates uniqueness of key per scenario' do
+      create(:user_curve, scenario:, key: 'duplicate_curve')
+      duplicate = build(:user_curve, scenario:, key: 'duplicate_curve')
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:key]).to include('has already been taken')
+    end
   end
 
-  it 'validates uniqueness of key per scenario' do
-    UserCurve.create!(scenario:, key: 'some_curve', curve: Merit::Curve.new)
-    duplicate = UserCurve.new(scenario:, key: 'some_curve', curve: Merit::Curve.new)
+  describe 'metadata handling' do
+    let(:metadata) do
+      {
+        source_scenario_id: 1,
+        source_scenario_title: 'Imported Curve',
+        source_saved_scenario_id: 123,
+        source_dataset_key: 'nl',
+        source_end_year: 2050
+      }
+    end
 
-    expect(duplicate).not_to be_valid
-    expect(duplicate.errors[:key]).to include('has already been taken')
+    it 'returns true when all source scenario metadata is set' do
+      user_curve = create(:user_curve, scenario:, **metadata)
+
+      expect(user_curve.source_scenario?).to be(true)
+    end
+
+    it 'returns false when only partial metadata is set' do
+      user_curve = build(:user_curve, scenario:, source_scenario_id: 1)
+
+      expect(user_curve).not_to be_valid
+      expect(user_curve.errors[:base])
+        .to include('All metadata needs to be set for curves imported from another scenario')
+    end
+
+    it 'returns false when no metadata is set' do
+      user_curve = build(:user_curve, scenario:)
+
+      expect(user_curve.source_scenario?).to be(false)
+    end
+
+    it 'clears metadata when passed nil to update_or_remove_metadata' do
+      user_curve = create(:user_curve, scenario:, **metadata)
+
+      user_curve.update_or_remove_metadata(nil)
+
+      expect(user_curve.source_scenario?).to be(false)
+      expect(user_curve.metadata_json).to eq({})
+    end
+
+    it 'updates metadata with update_or_remove_metadata' do
+      user_curve = create(:user_curve, scenario:)
+      new_meta = {
+        source_scenario_id: 42,
+        source_scenario_title: 'Wind import',
+        source_saved_scenario_id: 999,
+        source_dataset_key: 'de',
+        source_end_year: 2040
+      }
+
+      user_curve.update_or_remove_metadata(new_meta)
+
+      expect(user_curve.source_scenario?).to be(true)
+      expect(user_curve.metadata_json).to eq(new_meta)
+    end
   end
 end

--- a/spec/models/user_curve_spec.rb
+++ b/spec/models/user_curve_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe UserCurve do
+  let(:scenario) { create(:scenario) }
+  let(:curve_data) { [0.0, 1.0, 2.0, 3.0] }
+
+  it 'serializes and deserializes to a Merit::Curve' do
+    curve = Merit::Curve.new(curve_data, 8760, 0.0)
+    user_curve = UserCurve.create!(scenario:, key: 'some_curve', curve:)
+
+    user_curve.reload
+    expect(user_curve.curve).to be_a(Merit::Curve)
+    expect(user_curve.curve.to_a).to eq(curve_data + [0.0] * (8760 - 4))
+  end
+
+  it 'validates uniqueness of key per scenario' do
+    UserCurve.create!(scenario:, key: 'some_curve', curve: Merit::Curve.new)
+    duplicate = UserCurve.new(scenario:, key: 'some_curve', curve: Merit::Curve.new)
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:key]).to include('has already been taken')
+  end
+end

--- a/spec/serializers/merit_curve_serializer_spec.rb
+++ b/spec/serializers/merit_curve_serializer_spec.rb
@@ -1,11 +1,53 @@
-describe MeritCurveSerializer do
-  let(:curve) { Merit::Curve.new([1.0, 2.0, 3.0], 5, 0.0) }
+# frozen_string_literal: true
 
-  it 'serializes and deserializes a Merit::Curve' do
-    packed = described_class.dump(curve)
-    unpacked = described_class.load(packed)
+require 'spec_helper'
 
-    expect(unpacked).to be_a(Merit::Curve)
-    expect(unpacked.to_a).to eq([1.0, 2.0, 3.0, 0.0, 0.0])
+RSpec.describe MeritCurveSerializer do
+  let(:raw_values) { [1.0, 2.0, 3.0] }
+  let(:length)     { 5 }
+  let(:default)    { 0.0 }
+
+  let(:curve) { Merit::Curve.new(raw_values, length, default) }
+
+  describe '.dump and .load' do
+    it 'serializes and deserializes a Merit::Curve with correct values' do
+      packed = described_class.dump(curve)
+      unpacked = described_class.load(packed)
+
+      expect(unpacked).to be_a(Merit::Curve)
+      expect(unpacked.to_a).to eq([1.0, 2.0, 3.0, 0.0, 0.0])
+    end
+
+    it 'preserves length and default values' do
+      unpacked = described_class.load(described_class.dump(curve))
+
+      expect(unpacked.length).to eq(length)
+      expect(unpacked.instance_variable_get(:@default)).to eq(default)
+    end
+
+    it 'handles an empty curve' do
+      empty = Merit::Curve.new([], 4, 0.5)
+      unpacked = described_class.load(described_class.dump(empty))
+
+      expect(unpacked.to_a).to eq([0.5, 0.5, 0.5, 0.5])
+    end
+
+    it 'handles a curve with no specified length' do
+      curve = Merit::Curve.new([1.0, 2.0])
+      unpacked = described_class.load(described_class.dump(curve))
+
+      expect(unpacked.to_a).to eq([1.0, 2.0])
+    end
+  end
+
+  describe 'integration with UserCurve factory' do
+    let(:user_curve) { create(:user_curve, key: 'custom_curve') }
+
+    it 'stores and retrieves a Merit::Curve via the model' do
+      reloaded = UserCurve.find(user_curve.id)
+
+      expect(reloaded.curve).to be_a(Merit::Curve)
+      expect(reloaded.curve.to_a).to eq(user_curve.curve.to_a)
+    end
   end
 end

--- a/spec/serializers/merit_curve_serializer_spec.rb
+++ b/spec/serializers/merit_curve_serializer_spec.rb
@@ -1,0 +1,11 @@
+describe MeritCurveSerializer do
+  let(:curve) { Merit::Curve.new([1.0, 2.0, 3.0], 5, 0.0) }
+
+  it 'serializes and deserializes a Merit::Curve' do
+    packed = described_class.dump(curve)
+    unpacked = described_class.load(packed)
+
+    expect(unpacked).to be_a(Merit::Curve)
+    expect(unpacked.to_a).to eq([1.0, 2.0, 3.0, 0.0, 0.0])
+  end
+end


### PR DESCRIPTION
This PR:
- Adds a migration to introduce the user curve schema
- Introduces the user curve model and associates it with a scenario
- Ports curve and metadata methods from the ScenarioAttachment model to the UserCurve model
- Introduces MeritCurveSerializer to serialize/deserialize curves directly into and out of Merit::Curve objects
- Introduces spec for the model and serializer
- Adjusts attachment.curve method calls to refer instead to the UserCurves model
- Refactors spec related to custom curves on scenario, inputs, custom curve collection
 
**Note**: I compared the size of user curves serialized this way vs the csv files and the MessagePacked versions are larger. Depending on the data, the CSV blobs tend to be around 50kb and the MessagePack blobs tend to be 70kb. Obviously there are other advantages such as speed of read/write and dealing with floating points more effectively, but I thought it would be worth noting that finding here!

Closes: #1519 and #1520 