### PR TITLE
Attach / Detach user curves

### DIFF
--- a/app/models/curve_handler/detach_service.rb
+++ b/app/models/curve_handler/detach_service.rb
@@ -1,23 +1,21 @@
 # frozen_string_literal: true
 
 module CurveHandler
-  # Removes an attachment, unsetting any inputs which the may be been set when the attachmetn was
-  # originally added.
+  # Removes a UserCurve record, unsetting any inputs that may have been set when the curve was added.
   class DetachService
-    # Public: Calls the DetachService, removing the attachment. Looks up the config based on the
-    # attachment type.
-    def self.call(attachment)
-      new(Config.find_by(db_key: attachment.key, allow_nil: true)).call(attachment)
+    # Looks up the configuration by db_key and detaches the user curve.
+    def self.call(user_curve)
+      new(Config.find_by(db_key: user_curve.key, allow_nil: true)).call(user_curve)
     end
 
     def initialize(config)
       @config = config
     end
 
-    def call(attachment)
-      scenario = attachment.scenario
+    def call(user_curve)
+      scenario = user_curve.scenario
 
-      attachment.destroy
+      user_curve.destroy
 
       if @config&.sets_inputs?
         @config.input_keys.each do |key|

--- a/app/models/gql/custom_curve_collection.rb
+++ b/app/models/gql/custom_curve_collection.rb
@@ -8,15 +8,15 @@ module Gql
 
     # Public: Creates a CustomCurveCollection from the attachments on a scenario.
     def self.from_scenario(scenario)
-      curve_attachments = scenario.attachments.select(&:loadable_curve?)
+      scenario_user_curves = scenario.user_curves.select(&:loadable_curve?)
 
       new(
-        curve_attachments.each_with_object({}) do |attachment, state|
-          config = CurveHandler::Config.find_by(db_key: attachment.key)
+        scenario_user_curves.each_with_object({}) do |user_curve, state|
+          config = CurveHandler::Config.find_by(db_key: user_curve.key)
 
-          state[config.key] = Merit::Curve.reader.read(
-            ActiveStorage::Blob.service.path_for(attachment.file.key)
-          ).freeze
+          next unless config
+
+          state[config.key] = user_curve.curve.to_a.freeze
         end
       )
     end

--- a/app/models/gql/runtime/functions/curves.rb
+++ b/app/models/gql/runtime/functions/curves.rb
@@ -4,13 +4,12 @@ module Gql::Runtime
   module Functions
     # Contains GQL functions for retrieving and manipulating curves.
     module Curves
-      # Public: Looks up the attachment matching the `name`, and converts the
-      # contents into a curve. If no attachment is set, nil is returned.
+      # Public: Looks up the attachment matching the `name`, and returns a Merit::Curve.
+      # If no attachment is set, nil is returned.
       def ATTACHED_CURVE(name)
-        if (user_curve = scope.gql.scenario.user_curves.find_by(key: name.to_s))
-          return user_curve.curve.to_a
-        end
-        nil
+        return unless scope.gql.scenario.attached_curve?(name.to_s)
+
+        scope.gql.scenario.attached_curve(name.to_s).curve&.to_a
       end
 
       # Public: Restricts the values in a curve to be between the minimum and maximum. Raises an

--- a/app/models/gql/runtime/functions/curves.rb
+++ b/app/models/gql/runtime/functions/curves.rb
@@ -7,18 +7,10 @@ module Gql::Runtime
       # Public: Looks up the attachment matching the `name`, and converts the
       # contents into a curve. If no attachment is set, nil is returned.
       def ATTACHED_CURVE(name)
-        name = name.to_s
-        scenario = scope.gql.scenario
-
-        return nil unless scenario.attachment?(name)
-
-        path = ActiveStorage::Blob.service.path_for(scenario.attachment(name).file.key)
-
-        # The graph wants an array. Loading a curve and converting to an array
-        # is expensive since Merit::Curve has to deal with the possibility of
-        # missing/default values. Using the reader directly avoids this
-        # overhead.
-        Merit::Curve.reader.read(path)
+        if (user_curve = scope.gql.scenario.user_curves.find_by(key: name.to_s))
+          return user_curve.curve.to_a
+        end
+        nil
       end
 
       # Public: Restricts the values in a curve to be between the minimum and maximum. Raises an

--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -32,6 +32,8 @@ class Scenario < ApplicationRecord
   has_one    :hydrogen_demand_order, dependent: :destroy
   has_one    :households_space_heating_producer_order, dependent: :destroy
   has_many   :attachments, dependent: :destroy, class_name: 'ScenarioAttachment'
+  has_many :user_curves, dependent: :destroy
+
 
   has_many :source_attachments,
     dependent: :nullify,

--- a/app/models/scenario/attachments.rb
+++ b/app/models/scenario/attachments.rb
@@ -3,6 +3,21 @@
 class Scenario < ApplicationRecord
   # Utility methods for accessing user-attached files on a scenario.
   module Attachments
+    # Public: Returns a list of keys of attachted curves
+    def attached_curve_keys
+      user_curves.pluck(:key)
+    end
+
+    # Public: Returns if a curve with this key is installed by the user
+    def attached_curve?(key)
+      attached_curve_keys.include?(key)
+    end
+
+    # Public: Returns the UserCurve with the given key
+    def attached_curve(key)
+      user_curves.find_by(key: key)
+    end
+
     # Public: Returns if an attachment has been added matching the key.
     def attachment?(key)
       attachment(key)&.file&.attached?

--- a/app/models/scenario/inputs.rb
+++ b/app/models/scenario/inputs.rb
@@ -132,10 +132,9 @@ class Scenario < ApplicationRecord
 
     def inputs_disabled_by_curves
       @inputs_disabled_by_curves ||= Set.new(
-        @scenario.attachments
-          .select(&:curve?)
+        @scenario.user_curves
           .select(&:loadable_curve?)
-          .flat_map { |attachment| attachment.curve_config.internal_disabled_inputs }
+          .flat_map { |curve| curve.curve_config.internal_disabled_inputs }
       )
     end
   end

--- a/app/models/scenario_attachment.rb
+++ b/app/models/scenario_attachment.rb
@@ -43,18 +43,6 @@ class ScenarioAttachment < ApplicationRecord
     VALID_FILE_KEYS
   end
 
-  def loadable_curve?
-    file&.attached? && CurveHandler::Config.db_key?(key)
-  end
-
-  def curve?
-    key.ends_with?('_curve')
-  end
-
-  def curve_config
-    Etsource::Config.user_curves[key.chomp('_curve')]
-  end
-
   # Returns true for attachments which have all their 'source_scenario' metadata
   # set, indicating the attachment was imported from another scenario
   def source_scenario?

--- a/app/models/scenario_attachment.rb
+++ b/app/models/scenario_attachment.rb
@@ -57,6 +57,15 @@ class ScenarioAttachment < ApplicationRecord
     SOURCE_SCENARIO_METADATA.to_h { |key| [key, public_send(key)] }
   end
 
+  # TODO: Remove these after migrating curves to UserCurve model
+  def curve?
+    key.ends_with?('_curve')
+  end
+
+  def curve_config
+    Etsource::Config.user_curves[key.chomp('_curve')]
+  end
+
   # Updates the source scenario metadata of the attachment. If no metadata is
   # supplied this can indicate the attachment has changed from a
   # scenario-imported curve to a user uploaded curve. Thus we remove all source

--- a/app/models/user_curve.rb
+++ b/app/models/user_curve.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class UserCurve < ApplicationRecord
+  belongs_to :scenario
+  belongs_to :source_scenario, class_name: 'Scenario', optional: true
+
+  SOURCE_SCENARIO_METADATA = %i[
+    source_scenario_id
+    source_scenario_title
+    source_saved_scenario_id
+    source_dataset_key
+    source_end_year
+  ].freeze
+
+  # Ensure that each user curve has a unique key per scenario
+  validates :key, presence: true, uniqueness: { scope: :scenario_id, case_sensitive: false }
+  # Check the metadata for the curve
+  validate :validate_source_scenario_metadata
+
+  def curve
+    @curve ||= MeritCurveSerializer.load(read_attribute(:curve))
+  end
+
+  def curve=(val)
+    @curve = val
+    write_attribute(:curve, MeritCurveSerializer.dump(val))
+  end
+
+  # Returns true if a valid curve is stored
+  def loadable_curve?
+    curve.present? && CurveHandler::Config.db_key?(key)
+  end
+
+  # Returns the configuration for the curve using the key (without the suffix)
+  def curve_config
+    Etsource::Config.user_curves[key.chomp('_curve')]
+  end
+
+  def source_scenario?
+    SOURCE_SCENARIO_METADATA.all? { |key| public_send(key).present? }
+  end
+
+  def metadata_json
+    return {} unless source_scenario?
+
+    SOURCE_SCENARIO_METADATA.to_h { |key| [key, public_send(key)] }
+  end
+
+  def update_or_remove_metadata(metadata)
+    return update(metadata) if metadata.present?
+    return unless source_scenario?
+
+    update(SOURCE_SCENARIO_METADATA.index_with { nil })
+  end
+
+  def validate_source_scenario_metadata
+    if SOURCE_SCENARIO_METADATA.any? { |key| public_send(key).present? } && !source_scenario?
+      errors.add(:base, 'All metadata needs to be set for curves imported from another scenario')
+    end
+  end
+
+  def as_csv
+    curve.map{ |hour| [hour] }
+  end
+end

--- a/app/serializers/custom_curve_serializer.rb
+++ b/app/serializers/custom_curve_serializer.rb
@@ -2,23 +2,22 @@
 
 # Provides JSON information about a custom curve.
 class CustomCurveSerializer
-  # Creates a presenter for a ScenarioAttachment with an ActiveStorage
-  # attachment.
-  def initialize(attachment)
-    @attachment = attachment
-    @custom_curve = attachment.file
+  # @param user_curve [UserCurve] an object with a serialized curve and metadata.
+  def initialize(user_curve)
+    @user_curve = user_curve
+    @curve = user_curve.curve
   end
 
   def as_json(*)
-    return {} unless @custom_curve.attached?
+    return {} unless @user_curve.loadable_curve?
 
     data = UnattachedCustomCurveSerializer.new(config).as_json
 
     data.merge!(
       attached: true,
-      name: @custom_curve.filename.to_s,
-      size: @custom_curve.byte_size,
-      date: @custom_curve.created_at.utc,
+      name: @user_curve.name || @user_curve.key,
+      size: serialized_size,
+      date: @user_curve.created_at.utc,
       stats: stats
     )
 
@@ -28,33 +27,30 @@ class CustomCurveSerializer
   private
 
   def key
-    @attachment.key.chomp('_curve')
+    @user_curve.key.chomp('_curve')
   end
 
   def config
-    CurveHandler::Config.find(key)
+    @config ||= CurveHandler::Config.find(@user_curve.key.chomp('_curve'))
+  end
+
+  def serialized_size
+    @user_curve[:curve]&.bytesize || 0
   end
 
   def stats
     min_index = 0
     max_index = 0
 
-    curve.each_with_index do |value, index|
-      max_index = index if value > curve[max_index]
-      min_index = index if value < curve[min_index]
+    @curve.each_with_index do |value, index|
+      max_index = index if value > @curve[max_index]
+      min_index = index if value < @curve[min_index]
     end
 
     {
-      length: curve.length,
+      length: @curve.length,
       min_at: min_index,
       max_at: max_index
     }
-  end
-
-  def curve
-    @curve ||=
-      Merit::Curve.load_file(
-        ActiveStorage::Blob.service.path_for(@custom_curve.key)
-      ).to_a
   end
 end

--- a/app/serializers/custom_price_curve_serializer.rb
+++ b/app/serializers/custom_price_curve_serializer.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-# Provides JSON information about a custom price curve.
+# Provides JSON information about a custom price curve stored in a UserCurve.
 class CustomPriceCurveSerializer < CustomCurveSerializer
   def as_json(*)
     attrs = super
-    attrs[:source_scenario] = @attachment.metadata_json unless attrs.empty?
-
+    attrs[:source_scenario] = @user_curve.metadata_json unless attrs.empty?
     attrs
   end
 
@@ -14,9 +13,9 @@ class CustomPriceCurveSerializer < CustomCurveSerializer
   def stats
     attrs = super
 
-    attrs[:max]  = curve[attrs[:max_at]]
-    attrs[:min]  = curve[attrs[:min_at]]
-    attrs[:mean] = curve.sum / curve.length
+    attrs[:max]  = @curve[attrs[:max_at]]
+    attrs[:min]  = @curve[attrs[:min_at]]
+    attrs[:mean] = @curve.sum / @curve.length
 
     attrs
   end

--- a/app/serializers/custom_profile_curve_serializer.rb
+++ b/app/serializers/custom_profile_curve_serializer.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
-# Provides JSON information about a custom price curve.
 class CustomProfileCurveSerializer < CustomCurveSerializer
+  private
+
+  def stats
+    attrs = super
+
+    if config.reducer
+      reduced = config.reducer.call(@curve.to_a)
+      attrs[:full_load_hours] = reduced
+    end
+
+    attrs
+  end
 end

--- a/app/serializers/merit_curve_serializer.rb
+++ b/app/serializers/merit_curve_serializer.rb
@@ -1,0 +1,11 @@
+class MeritCurveSerializer
+  # Dump the Merit::Curve instance into a MessagePack binary string.
+  def self.dump(curve)
+    MessagePack.pack(curve.to_a)
+  end
+
+  # Load the MessagePack binary string and instantiate a new Merit::Curve.
+  def self.load(packed)
+    Merit::Curve.new(MessagePack.unpack(packed))
+  end
+end

--- a/db/migrate/20250326090732_create_user_curves.rb
+++ b/db/migrate/20250326090732_create_user_curves.rb
@@ -1,0 +1,24 @@
+class CreateUserCurves < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_curves, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+      t.integer :scenario_id, null: false
+      t.string  :key, null: false
+      t.string  :name
+
+      # MEDIUMBLOB - I tested a curve serialized with MessagePack and it was ~70 kb.
+      # A normal blob is 64 kb. So we need a medium blob
+      t.binary  :curve, null: false, limit: 16.megabytes - 1
+
+      # Metadata fields
+      t.integer :source_scenario_id
+      t.string  :source_scenario_title
+      t.integer :source_saved_scenario_id
+      t.string  :source_dataset_key
+      t.integer :source_end_year
+
+      t.timestamps
+    end
+
+    add_index :user_curves, [:scenario_id, :key], unique: true
+  end
+end

--- a/db/migrate/20250403101055_convert_user_curves_to_model.rb
+++ b/db/migrate/20250403101055_convert_user_curves_to_model.rb
@@ -1,0 +1,57 @@
+require 'etengine/scenario_migration'
+
+class ConvertUserCurvesToModel < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  def up
+    total_scenarios = Scenario.migratable.count
+
+    migrate_scenarios(raise_if_no_changes: false) do |scenario|
+      processed += 1
+      scenario_migrated = false
+
+      scenario.attachments.find_each do |attachment|
+        next unless attachment.curve?
+        next if scenario.user_curves.exists?(key: attachment.key)
+
+        begin
+          binary = attachment.file.download   # Download the binary file data stored via ActiveStorage.
+          tempfile = Tempfile.new(["curve", ".csv"])
+          tempfile.binmode                    # Switch the tempfile to binary mode so we can write raw binary data.
+          tempfile.write(binary)              # Write the downloaded binary data into the tempfile.
+          tempfile.rewind                     # Rewind the file pointer to the beginning of the file.
+
+          file_stub = ActionDispatch::Http::UploadedFile.new(
+            tempfile: tempfile,
+            filename: attachment.key
+          )
+
+          config = Etsource::Config.user_curves[attachment.key.chomp('_curve')]
+          next if config.nil?
+
+          service = CurveHandler::AttachService.new(config, file_stub, scenario, attachment.metadata_json)
+
+          if service.call
+            attachment.destroy!
+            scenario_migrated = true
+          end
+        rescue => e
+          Rails.logger.error "Attachment #{attachment.id} failed for scenario #{scenario.id}: #{e.message}"
+        ensure
+          tempfile.close                  # release any resources
+          tempfile.unlink                 # delete from disk
+        end
+      end
+
+      # Marks the scenario as changed so it's counted by ScenarioMigration.
+      scenario.touch if scenario_migrated? # TODO: Either keep this and remove "raise_if_no_changes: false" or remove this
+      end
+    end
+
+    raise ETEngine::ScenarioMigration::NoScenariosMigrated if migrated.zero?
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_21_121642) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_26_090732) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -134,6 +134,21 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_21_121642) do
     t.datetime "updated_at", null: false
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "user_curves", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "scenario_id", null: false
+    t.string "key", null: false
+    t.string "name"
+    t.binary "curve", size: :medium, null: false
+    t.integer "source_scenario_id"
+    t.string "source_scenario_title"
+    t.integer "source_saved_scenario_id"
+    t.string "source_dataset_key"
+    t.integer "source_end_year"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["scenario_id", "key"], name: "index_user_curves_on_scenario_id_and_key", unique: true
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_26_090732) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_03_101055) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/spec/factories/user_curve.rb
+++ b/spec/factories/user_curve.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user_curve do
+    association :scenario
+    key { "interconnector_1_price_curve" }
+    curve { Merit::Curve.new([1.0] * 8760) }
+  end
+end

--- a/spec/models/scenario/inputs_spec.rb
+++ b/spec/models/scenario/inputs_spec.rb
@@ -3,21 +3,25 @@
 require 'spec_helper'
 
 RSpec.describe Scenario::Inputs do
-  let(:scenario) { Scenario.new }
+  let(:scenario) { create(:scenario) }
   let(:inputs) { described_class.new(scenario) }
 
   context 'when the scenario has an attached curve' do
-    before do
-      attachment = scenario.attachments.build(key: 'a_curve')
-      allow(attachment).to receive(:loadable_curve?).and_return(true)
+    let(:curve) do
+      create(:user_curve, key: 'a_curve', scenario: scenario).tap do |uc|
+        allow(uc).to receive(:curve_config).and_return(
+          CurveHandler::Config.from_etsource(
+            key: 'a',
+            type: 'generic',
+            disables: ['both_input']
+          )
+        )
+        allow(uc).to receive(:loadable_curve?).and_return(true)
+      end
+    end
 
-      allow(attachment).to receive(:curve_config).and_return(
-        CurveHandler::Config.from_etsource({
-          key: 'a',
-          type: 'generic',
-          disables: ['both_input']
-        })
-      )
+    before do
+      allow(scenario).to receive(:user_curves).and_return([curve])
 
       scenario.user_values = {
         both_input: 100,

--- a/spec/models/user_curve_spec.rb
+++ b/spec/models/user_curve_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe UserCurve do
+  let(:scenario) { create(:scenario) }
+
+  describe 'core functionality' do
+    let(:curve_data) { [0.0, 1.0, 2.0, 3.0] }
+
+    it 'serializes and deserializes to a Merit::Curve' do
+      user_curve = create(
+        :user_curve,
+        scenario:,
+        key: 'some_curve',
+        curve: Merit::Curve.new(curve_data, 8760, 0.0)
+      )
+
+      user_curve.reload
+      expect(user_curve.curve).to be_a(Merit::Curve)
+      expect(user_curve.curve.to_a).to eq(curve_data + [0.0] * (8760 - 4))
+    end
+
+    it 'validates uniqueness of key per scenario' do
+      create(:user_curve, scenario:, key: 'duplicate_curve')
+      duplicate = build(:user_curve, scenario:, key: 'duplicate_curve')
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:key]).to include('has already been taken')
+    end
+  end
+
+  describe 'metadata handling' do
+    let(:metadata) do
+      {
+        source_scenario_id: 1,
+        source_scenario_title: 'Imported Curve',
+        source_saved_scenario_id: 123,
+        source_dataset_key: 'nl',
+        source_end_year: 2050
+      }
+    end
+
+    it 'returns true when all source scenario metadata is set' do
+      user_curve = create(:user_curve, scenario:, **metadata)
+
+      expect(user_curve.source_scenario?).to be(true)
+    end
+
+    it 'returns false when only partial metadata is set' do
+      user_curve = build(:user_curve, scenario:, source_scenario_id: 1)
+
+      expect(user_curve).not_to be_valid
+      expect(user_curve.errors[:base])
+        .to include('All metadata needs to be set for curves imported from another scenario')
+    end
+
+    it 'returns false when no metadata is set' do
+      user_curve = build(:user_curve, scenario:)
+
+      expect(user_curve.source_scenario?).to be(false)
+    end
+
+    it 'clears metadata when passed nil to update_or_remove_metadata' do
+      user_curve = create(:user_curve, scenario:, **metadata)
+
+      user_curve.update_or_remove_metadata(nil)
+
+      expect(user_curve.source_scenario?).to be(false)
+      expect(user_curve.metadata_json).to eq({})
+    end
+
+    it 'updates metadata with update_or_remove_metadata' do
+      user_curve = create(:user_curve, scenario:)
+      new_meta = {
+        source_scenario_id: 42,
+        source_scenario_title: 'Wind import',
+        source_saved_scenario_id: 999,
+        source_dataset_key: 'de',
+        source_end_year: 2040
+      }
+
+      user_curve.update_or_remove_metadata(new_meta)
+
+      expect(user_curve.source_scenario?).to be(true)
+      expect(user_curve.metadata_json).to eq(new_meta)
+    end
+  end
+end

--- a/spec/serializers/custom_curve_serializer_spec.rb
+++ b/spec/serializers/custom_curve_serializer_spec.rb
@@ -5,6 +5,6 @@ require_relative './custom_curve_shared_examples'
 
 RSpec.describe CustomCurveSerializer do
   include_examples 'a custom curve Serializer' do
-    let(:attachment) { FactoryBot.create(:scenario_attachment) }
+    let(:curve) { create(:user_curve) }
   end
 end

--- a/spec/serializers/custom_curve_shared_examples.rb
+++ b/spec/serializers/custom_curve_shared_examples.rb
@@ -1,23 +1,42 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples_for 'a custom curve Serializer' do
-  let(:json) { described_class.new(attachment).as_json }
+  let(:json) { described_class.new(curve).as_json }
 
-  context 'with an attached curve' do
-    before do
-      attachment.file.attach(
-        io: File.open(Rails.root.join('spec/fixtures/files/price_curve.csv')),
-        filename: 'price_curve.csv',
-        content_type: 'text/csv'
-      )
+  context 'with a stored curve' do
+    let(:curve_data) { Array.new(8760) { rand(10.0..100.0) } }
+
+    let(:curve) do
+      FactoryBot.create(:user_curve).tap do |uc|
+        uc.curve = Merit::Curve.new(curve_data)
+        uc.save!
+      end
     end
 
-    it { expect(json).to include(name: 'price_curve.csv') }
-    it { expect(json).to include(size: 35_040) }
-    it { expect(json).to include(date: attachment.file.created_at) }
+    it 'includes the curve name' do
+      expect(json).to include(name: curve.key)
+    end
+
+    it 'includes the serialized size' do
+      expect(json).to include(size: curve[:curve].bytesize)
+    end
+
+    it 'includes the creation date' do
+      expect(json).to include(date: curve.created_at.utc)
+    end
+
+    it 'includes curve stats' do
+      expect(json[:stats][:length]).to eq(8760)
+      expect(json[:stats][:min_at]).to be_a(Integer)
+      expect(json[:stats][:max_at]).to be_a(Integer)
+    end
   end
 
-  context 'with no attached curve' do
+  context 'with no stored curve' do
+    let(:curve) do
+      FactoryBot.create(:user_curve, key: 'invalid_key')
+    end
+
     it { expect(json).to eq({}) }
   end
 end

--- a/spec/serializers/custom_profile_curve_serializer_spec.rb
+++ b/spec/serializers/custom_profile_curve_serializer_spec.rb
@@ -3,42 +3,47 @@
 require 'spec_helper'
 require_relative './custom_curve_shared_examples'
 
-describe CustomProfileCurveSerializer do
-  let(:attachment) do
-    FactoryBot.create(:scenario_attachment, key: 'some_profile_curve')
-  end
+RSpec.describe CustomProfileCurveSerializer do
+  let(:curve) { FactoryBot.create(:user_curve) }
 
   include_examples 'a custom curve Serializer'
 
-  context 'with an attached curve and a "reduce" config' do
-    let(:json) { described_class.new(attachment).as_json }
+  context 'with a curve that has a "reduce" config' do
+    let(:json) { described_class.new(curve).as_json }
 
     before do
-      attachment.file.attach(
-        io: File.open(Rails.root.join('spec/fixtures/files/capacity_curve.csv')),
-        filename: 'price_curve.csv',
-        content_type: 'text/csv'
+      allow(CurveHandler::Config).to receive(:find).and_return(
+        CurveHandler::Config.new(
+          :interconnector_1_price,
+          :capacity_profile,
+          :full_load_hours,
+          %w[input_one]
+        )
       )
     end
 
-    pending { expect(json[:stats]).to include(full_load_hours: 6570.0, length: 8760) }
+    it 'includes full_load_hours in the stats' do
+      expect(json[:stats]).to include(:full_load_hours)
+      expect(json[:stats][:length]).to eq(8760)
+    end
   end
 
-  context 'with an attached curve and no "reduce" config' do
-    let(:attachment) do
-      FactoryBot.create(:scenario_attachment, key: 'some_profile_without_reduce_curve')
-    end
-
-    let(:json) { described_class.new(attachment).as_json }
+  context 'with a curve that does not have a "reduce" config' do
+    let(:json) { described_class.new(curve).as_json }
 
     before do
-      attachment.file.attach(
-        io: File.open(Rails.root.join('spec/fixtures/files/price_curve.csv')),
-        filename: 'price_curve.csv',
-        content_type: 'text/csv'
+      allow(CurveHandler::Config).to receive(:find).and_return(
+        CurveHandler::Config.new(
+          :interconnector_1_price,
+          :profile,
+          nil,
+          []
+        )
       )
     end
 
-    it { expect(json[:stats]).not_to have_key(:full_load_hours) }
+    it 'does not include full_load_hours in the stats' do
+      expect(json[:stats]).not_to have_key(:full_load_hours)
+    end
   end
 end

--- a/spec/serializers/merit_curve_serializer_spec.rb
+++ b/spec/serializers/merit_curve_serializer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe MeritCurveSerializer do
+  let(:raw_values) { [1.0, 2.0, 3.0] }
+  let(:length)     { 5 }
+  let(:default)    { 0.0 }
+
+  let(:curve) { Merit::Curve.new(raw_values, length, default) }
+
+  describe '.dump and .load' do
+    it 'serializes and deserializes a Merit::Curve with correct values' do
+      packed = described_class.dump(curve)
+      unpacked = described_class.load(packed)
+
+      expect(unpacked).to be_a(Merit::Curve)
+      expect(unpacked.to_a).to eq([1.0, 2.0, 3.0, 0.0, 0.0])
+    end
+
+    it 'preserves length and default values' do
+      unpacked = described_class.load(described_class.dump(curve))
+
+      expect(unpacked.length).to eq(length)
+      expect(unpacked.instance_variable_get(:@default)).to eq(default)
+    end
+
+    it 'handles an empty curve' do
+      empty = Merit::Curve.new([], 4, 0.5)
+      unpacked = described_class.load(described_class.dump(empty))
+
+      expect(unpacked.to_a).to eq([0.5, 0.5, 0.5, 0.5])
+    end
+
+    it 'handles a curve with no specified length' do
+      curve = Merit::Curve.new([1.0, 2.0])
+      unpacked = described_class.load(described_class.dump(curve))
+
+      expect(unpacked.to_a).to eq([1.0, 2.0])
+    end
+  end
+
+  describe 'integration with UserCurve factory' do
+    let(:user_curve) { create(:user_curve, key: 'custom_curve') }
+
+    it 'stores and retrieves a Merit::Curve via the model' do
+      reloaded = UserCurve.find(user_curve.id)
+
+      expect(reloaded.curve).to be_a(Merit::Curve)
+      expect(reloaded.curve.to_a).to eq(user_curve.curve.to_a)
+    end
+  end
+end


### PR DESCRIPTION
This PR builds upon #1529 to refactor the attach and detach services and their spec to be able work with the new UserCurve model. Notably - adjusting attach and detach causes the custom curves endpoint to break, which is reflected in the spec (currently failing for that endpoint).

Closes #1521, #1522, #1519, #1518, #1520, #1523, #1524

Edit: This PR supersedes #1529.