### PR TITLE
Serialize active couplings with MessagePack

### DIFF
--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -15,7 +15,7 @@ class Scenario < ApplicationRecord
 
   serialize  :user_values, type: Hash, coder: MessagePack
   store      :balanced_values
-  serialize  :active_couplings, type: Array
+  serialize  :active_couplings, type: Array, coder: MessagePack
   store      :metadata, coder: JSON
 
   has_many   :scenario_users, dependent: :destroy

--- a/db/migrate/20250410084424_serialize_active_couplings.rb
+++ b/db/migrate/20250410084424_serialize_active_couplings.rb
@@ -1,0 +1,33 @@
+class SerializeActiveCouplings < ActiveRecord::Migration[7.1]
+  include ETEngine::ScenarioMigration
+
+  class ScenarioForMigration < ActiveRecord::Base
+    self.table_name = 'scenarios'
+  end
+
+  require 'msgpack'
+
+  def up
+    change_column :scenarios, :active_couplings, :text, size: :medium
+    add_column :scenarios, :active_couplings_binary, :binary, limit: 16.megabytes
+
+    migrate_scenarios(raise_if_no_changes: false) do |scenario|
+      original = ScenarioForMigration.find(scenario.id)
+      yaml_data = original.read_attribute_before_type_cast("active_couplings")
+      next if yaml_data.blank? || !yaml_data.is_a?(String)
+
+      begin
+        values = YAML.safe_load(yaml_data, permitted_classes: [Array, String, Symbol], aliases: true)
+        next unless values.is_a?(Array)
+        msgpack_blob = values.to_msgpack
+        ScenarioForMigration.find(scenario.id).update!(active_couplings_binary: msgpack_blob)
+      rescue => e
+        Rails.logger.warn("Skipping scenario ##{scenario.id}: #{e.message}")
+      end
+    end
+
+    rename_column :scenarios, :active_couplings, :active_couplings_old
+    rename_column :scenarios, :active_couplings_binary, :active_couplings
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_10_074412) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_10_084424) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -123,8 +123,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_10_074412) do
     t.string "source"
     t.text "balanced_values", size: :medium
     t.text "metadata"
-    t.text "active_couplings", size: :medium
+    t.text "active_couplings_old", size: :medium
     t.binary "user_values", size: :long
+    t.binary "active_couplings", size: :long
     t.index ["created_at"], name: "index_scenarios_on_created_at"
   end
 


### PR DESCRIPTION
I couldn't quite get this to work! When I run the debugger and investigate the `msgpack_blob` I get good MessagePack encoded data, but in the console it comes through as an empty array (see below). The spec failures are either from converting from a symbol to a string or from the empty array issue.

```
[2] pry(main)> s.active_couplings
=> []
[3] pry(main)> s.active_couplings_old
=> "---\n- :external_model_industry\n- :industry_chemical_other\n- :industry_metal_steel\n"
```