### PR TITLE
Reconciliation transformation nodes are part of the supply demand balance

### DIFF
--- a/app/models/qernel/reconciliation/adapter.rb
+++ b/app/models/qernel/reconciliation/adapter.rb
@@ -40,7 +40,7 @@ module Qernel
       end
 
       def carrier_demand
-        @carrier_demand || raise("carrier_demand not yet calulated for #{@node.key}")
+        @carrier_demand.presence || raise("carrier_demand not yet calulated for #{@node.key}")
       end
 
       def demand_curve

--- a/app/models/qernel/reconciliation/transformation_adapter.rb
+++ b/app/models/qernel/reconciliation/transformation_adapter.rb
@@ -21,12 +21,16 @@ module Qernel
         end
       end
 
+      def carrier_demand
+        carrier_demand_input - carrier_demand_output
+      end
+
       def carrier_demand_input
-        @carrier_demand_input || raise("carrier_demand_input not yet calulated for #{@node.key}")
+        @carrier_demand_input.presence || raise("carrier_demand_input not yet calulated for #{@node.key}")
       end
 
       def carrier_demand_output
-        @carrier_demand_output || raise("carrier_demand_output not yet calulated for #{@node.key}")
+        @carrier_demand_output.presence || raise("carrier_demand_output not yet calulated for #{@node.key}")
       end
 
       def demand_curve

--- a/app/models/qernel/reconciliation/transformation_adapter.rb
+++ b/app/models/qernel/reconciliation/transformation_adapter.rb
@@ -21,8 +21,13 @@ module Qernel
         end
       end
 
+      # Unused for real demand calculations.
+      #
+      # Should be positive for plugin.installed_adapters_of_type to verify that
+      # this adapter is active. Taking the max will ensure a positive demand if
+      # either consuming or producing
       def carrier_demand
-        carrier_demand_input - carrier_demand_output
+        [carrier_demand_input, carrier_demand_output].max
       end
 
       def carrier_demand_input


### PR DESCRIPTION
Fixes an issue where the transformation nodes where not taken into account when calculating the supply and demand balance in reconciliation.

Closes #1484 