### PR TITLE
Cherry pick fixes for natural gas transformation to stable

### DIFF
--- a/app/models/qernel/reconciliation/adapter.rb
+++ b/app/models/qernel/reconciliation/adapter.rb
@@ -40,7 +40,7 @@ module Qernel
       end
 
       def carrier_demand
-        @carrier_demand || raise("carrier_demand not yet calulated for #{@node.key}")
+        @carrier_demand.presence || raise("carrier_demand not yet calulated for #{@node.key}")
       end
 
       def demand_curve

--- a/app/models/qernel/reconciliation/helper.rb
+++ b/app/models/qernel/reconciliation/helper.rb
@@ -6,12 +6,12 @@ module Qernel
 
       # Internal: Array describing the hourly carrier demand.
       def total_demand_curve(plugin)
-        combined_curve(plugin, :consumer, :export)
+        combined_curve(plugin, :consumer, :export, :input)
       end
 
       # Internal: Array describing the hourly carrier supply.
       def total_supply_curve(plugin)
-        combined_curve(plugin, :producer, :import)
+        combined_curve(plugin, :producer, :import, :output)
       end
 
       # Public: Given the Reconciliation plugin, returns the balance of supply
@@ -29,11 +29,14 @@ module Qernel
       end
 
       # Internal: Creates the combined curves of two adapter groups.
-      private_class_method def combined_curve(plugin, group_one, group_two)
+      private_class_method def combined_curve(plugin, group_one, group_two, transformation)
         ::Merit::CurveTools.add_curves((
           plugin.installed_adapters_of_type(group_one) +
           plugin.installed_adapters_of_type(group_two)
-        ).map(&:demand_curve)).to_a
+        ).map(&:demand_curve) +
+        plugin.installed_adapters_of_type(:transformation)
+              .map(&:"demand_curve_#{transformation}")
+      ).to_a
       end
 
       # Internal: Sums the specified carrier demand attribute over all adapters of a given type.

--- a/app/models/qernel/reconciliation/transformation_adapter.rb
+++ b/app/models/qernel/reconciliation/transformation_adapter.rb
@@ -21,12 +21,21 @@ module Qernel
         end
       end
 
+      # Unused for real demand calculations.
+      #
+      # Should be positive for plugin.installed_adapters_of_type to verify that
+      # this adapter is active. Taking the max will ensure a positive demand if
+      # either consuming or producing
+      def carrier_demand
+        [carrier_demand_input, carrier_demand_output].max
+      end
+
       def carrier_demand_input
-        @carrier_demand_input || raise("carrier_demand_input not yet calulated for #{@node.key}")
+        @carrier_demand_input.presence || raise("carrier_demand_input not yet calulated for #{@node.key}")
       end
 
       def carrier_demand_output
-        @carrier_demand_output || raise("carrier_demand_output not yet calulated for #{@node.key}")
+        @carrier_demand_output.presence || raise("carrier_demand_output not yet calulated for #{@node.key}")
       end
 
       def demand_curve


### PR DESCRIPTION
This PR cherry-picks two commits to stable. The commits fixed https://github.com/quintel/etengine/issues/1484, see also https://github.com/quintel/etengine/pull/1552.

The commits are cherry-picked to stable on request of the client. The assumption is that hardly any scenarios have been made on stable, let alone scenarios with external coupling (which is where this issue arised).