### PR TITLE
Prep migrations for deploy

### DIFF
--- a/db/migrate/20250410122627_attachments_to_user_curves.rb
+++ b/db/migrate/20250410122627_attachments_to_user_curves.rb
@@ -29,7 +29,7 @@ class AttachmentsToUserCurves < ActiveRecord::Migration[7.0]
           service = CurveHandler::AttachService.new(config, file_stub, scenario, attachment.metadata_json)
 
           if service.call(false)
-            attachment.destroy!
+            # attachment.destroy!
             scenario_migrated = true
           end
         rescue => e

--- a/db/migrate/20250415093227_remove_user_values_old_from_scenarios.rb
+++ b/db/migrate/20250415093227_remove_user_values_old_from_scenarios.rb
@@ -1,5 +1,0 @@
-class RemoveUserValuesOldFromScenarios < ActiveRecord::Migration[7.1]
-  def change
-    remove_column :scenarios, :user_values_old, :text
-  end
-end

--- a/spec/models/curve_handler/attach_service_spec.rb
+++ b/spec/models/curve_handler/attach_service_spec.rb
@@ -81,5 +81,12 @@ RSpec.describe CurveHandler::AttachService do
         .from({ 'orig' => 1.0 })
         .to({ 'i1' => 6570.0, 'i2' => 6570.0, 'orig' => 1.0 })
     end
+
+    context 'when providing false to the call' do
+      it 'will not set the scenario input value with the reduced value' do
+        expect { service.call(false) }
+          .not_to change { scenario.reload.user_values }
+      end
+    end
   end
 end


### PR DESCRIPTION
Don't remove old attachments
Ensure FLH will not be touched by adding spec for call(false) for attach service Remove migration that drops the old user values
When all went well we can remove the old stuff!