### PR TITLE
Merge household appliances efficiency sliders into one

### DIFF
--- a/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
+++ b/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
@@ -39,7 +39,7 @@ class MergeHouseholdAppliancesEfficiency < ActiveRecord::Migration[7.0]
 
       # The slider values should be checked for their minimum and maximum values
       # TODO: check this! What should be minimum and mamximum?
-      scenario.user_values[NEW_INPUT] = new_input
+      scenario.user_values[NEW_INPUT] = [[new_input, 90.0].min, -90.0].max
     end
   end
 end

--- a/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
+++ b/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
@@ -27,7 +27,7 @@ class MergeHouseholdAppliancesEfficiency < ActiveRecord::Migration[7.0]
 
       # Calculate weighted avg. Start value for the old sliders was 0.0. If input is not set, it's treated as 0.0.
       weighted_avg = SHARE_MAP.sum(0.0) do |parent_share_key, input_key|
-        efficiency = scenario.user_values.fetch(input_key, 0.0)
+        efficiency = scenario.user_values.delete(input_key) || 0.0
         parent_shares.get(parent_share_key) * (1.0 - efficiency / 100.0)
       end
 

--- a/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
+++ b/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
@@ -32,7 +32,7 @@ class MergeHouseholdAppliancesEfficiency < ActiveRecord::Migration[7.0]
       end
 
       # The weighted average is reconverted into a percentage
-      new_input = (weighted_avg - 1) * 100.0
+      new_input = (1 - weighted_avg) * 100.0
 
       # The slider values should be checked for their minimum and maximum values
       scenario.user_values[NEW_INPUT] = [[new_input, 90.0].min, -90.0].max

--- a/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
+++ b/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
@@ -1,0 +1,83 @@
+require 'etengine/scenario_migration'
+
+class MergeHouseholdAppliancesEfficiency < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  NEW_INPUT = 'households_appliances_electricity_efficiency'.freeze
+
+  OLD_INPUTS = %w[
+    households_appliances_clothes_dryer_electricity_efficiency
+    households_appliances_computer_media_electricity_efficiency
+    households_appliances_dishwasher_electricity_efficiency
+    households_appliances_fridge_freezer_electricity_efficiency
+    households_appliances_other_electricity_efficiency
+    households_appliances_television_electricity_efficiency
+    households_appliances_vacuum_cleaner_electricity_efficiency
+    households_appliances_washing_machine_electricity_efficiency
+  ].freeze
+
+  PARENT_SHARES = %w[
+    households_final_demand_for_appliances_electricity__households_appliances_clothes_dryer_electricity__electricity_parent_share
+    households_final_demand_for_appliances_electricity__households_appliances_computer_media_electricity__electricity_parent_share
+    households_final_demand_for_appliances_electricity__households_appliances_dishwasher_electricity__electricity_parent_share
+    households_final_demand_for_appliances_electricity__households_appliances_fridge_freezer_electricity__electricity_parent_share
+    households_final_demand_for_appliances_electricity__households_appliances_other_electricity__electricity_parent_share
+    households_final_demand_for_appliances_electricity__households_appliances_television_electricity__electricity_parent_share
+    households_final_demand_for_appliances_electricity__households_appliances_vacuum_cleaner_electricity__electricity_parent_share
+    households_final_demand_for_appliances_electricity__households_appliances_washing_machine_electricity__electricity_parent_share
+  ].freeze
+
+  def up
+    migrate_scenarios do |scenario|
+      unless relevant_inputs_set?(scenario)
+        puts "Skipping scenario #{scenario.id}: no relevant old inputs set."
+        next
+      end
+  
+      puts "Migrating scenario #{scenario.id}: relevant old inputs found."
+  
+      new_efficiency = calculate_new_efficiency(scenario)
+  
+      puts "Calculated new efficiency for scenario #{scenario.id}: #{new_efficiency.inspect}"
+  
+      if new_efficiency
+        scenario.user_values[NEW_INPUT] = new_efficiency
+        true
+      else
+        FileUtils.mkdir_p("tmp") # Make sure tmp/ exists
+        File.open("tmp/dataset_dump_#{scenario.id}.txt", "w") do |file|
+          file.puts "Dataset values for scenario #{scenario.id}:"
+          scenario.area.dataset.each do |key, value|
+            file.puts "#{key}: #{value.inspect}"
+          end
+        end
+        nil
+      end
+    end
+  end
+  private
+
+  def relevant_inputs_set?(scenario)
+    OLD_INPUTS.any? { |key| scenario.user_values[key].present? }
+  end
+
+  def calculate_new_efficiency(scenario)
+    weighted_sum = 0.0
+    total_share = 0.0
+
+    OLD_INPUTS.each_with_index do |input_key, index|
+      input_value = scenario.user_values[input_key]
+      parent_share_value = scenario.area[PARENT_SHARES[index]] || 0.0
+      puts "Checking input_key: #{input_key} with parent_share_key: #{PARENT_SHARES[index]}"
+      puts "  => input_value: #{input_value.inspect}, parent_share_value: #{parent_share_value.inspect}"
+      next unless input_value && parent_share_value
+
+      weighted_sum += parent_share_value * (1.0 - (input_value / 100.0))
+      total_share += parent_share_value
+    end
+
+    return nil unless total_share.positive?
+
+    (1.0 - (weighted_sum / total_share)) * 100.0
+  end
+end

--- a/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
+++ b/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
@@ -35,13 +35,6 @@ class MergeHouseholdAppliancesEfficiency < ActiveRecord::Migration[7.0]
         next
       end
 
-      # Skip if any individual parent‐share key is missing/nil
-      missing = SHARE_MAP.keys.reject do |parent_key|
-        value = parent_shares.get(parent_key) rescue nil
-        !value.nil?
-      end
-      next unless missing.empty?
-
       # Calculate weighted avg. Start value for the old sliders was 0.0. If input is not set, it's treated as 0.0.
       weighted_avg = SHARE_MAP.sum(0.0) do |parent_share_key, input_key|
         efficiency = scenario.user_values.fetch(input_key, 0.0)

--- a/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
+++ b/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
@@ -28,12 +28,7 @@ class MergeHouseholdAppliancesEfficiency < ActiveRecord::Migration[7.0]
         next
       end
 
-      # Skip if the share series can't be loaded
-      parent_shares = begin
-        dataset.shares("energy/residences_final_demand_for_appliances_electricity_parent_share")
-      rescue Atlas::ResourceNotFound, Atlas::DatasetError
-        next
-      end
+      parent_shares = dataset.shares("energy/residences_final_demand_for_appliances_electricity_parent_share")
 
       # Calculate weighted avg. Start value for the old sliders was 0.0. If input is not set, it's treated as 0.0.
       weighted_avg = SHARE_MAP.sum(0.0) do |parent_share_key, input_key|

--- a/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
+++ b/db/migrate/20250429122439_merge_household_appliances_efficiency.rb
@@ -19,25 +19,20 @@ class MergeHouseholdAppliancesEfficiency < ActiveRecord::Migration[7.0]
 
   def up
     migrate_scenarios do |scenario|
+      next unless Atlas::Dataset.exists?(scenario.area_code)
       next unless SHARE_MAP.values.any? { |key| scenario.user_values.key?(key) }
 
-      # Skip if the dataset itself can't be found
-      dataset = begin
-        Atlas::Dataset.find(scenario.area_code)
-      rescue Atlas::DocumentNotFoundError, Atlas::DatasetError
-        next
-      end
-
+      dataset = Atlas::Dataset.find(scenario.area_code)
       parent_shares = dataset.shares("energy/residences_final_demand_for_appliances_electricity_parent_share")
 
       # Calculate weighted avg. Start value for the old sliders was 0.0. If input is not set, it's treated as 0.0.
       weighted_avg = SHARE_MAP.sum(0.0) do |parent_share_key, input_key|
         efficiency = scenario.user_values.fetch(input_key, 0.0)
-        parent_shares.get(parent_share_key) * (1 - efficiency / 100.0)
+        parent_shares.get(parent_share_key) * (1.0 - efficiency / 100.0)
       end
 
       # The weighted average is reconverted into a percentage
-      new_input = (1 - weighted_avg) * 100.0
+      new_input = (1.0 - weighted_avg) * 100.0
 
       # The slider values should be checked for their minimum and maximum values
       scenario.user_values[NEW_INPUT] = [[new_input, 90.0].min, -90.0].max

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_12_070901) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_12_155230) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_12_155230) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_12_070901) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
This PR adresses https://github.com/quintel/etmodel/issues/4479. There are currently 8 household appliances efficiency sliders. This seems excessive. They are merged into one.

Should not be merged before the Deploy. The migration in ETEngine still has to be finished. @noracato / @louispt1 it's propsed for next sprint to pick this up. If either of you has time this week, feel free to pick this up. A modeller should review the outcomes.

Goes with: 
- https://github.com/quintel/etsource/pull/3255
- https://github.com/quintel/etmodel/pull/4481