### PR TITLE
Add migration to remove retired household behaviour keys

### DIFF
--- a/db/migrate/20250512070901_remove_household_behaviour.rb
+++ b/db/migrate/20250512070901_remove_household_behaviour.rb
@@ -1,0 +1,25 @@
+require 'etengine/scenario_migration'
+
+class RemoveHouseholdBehaviour < ActiveRecord::Migration[7.1]
+  include ETEngine::ScenarioMigration
+
+  # Retired household behaviour keys
+  HOUSEHOLD_BEHAVIOUR_KEYS = %w[
+    households_behavior_low_temperature_washing
+    households_behavior_standby_killer_turn_off_appliances
+    households_behavior_turn_off_the_light
+    households_behavior_close_windows_turn_off_heating
+  ].freeze
+
+  def up
+    migrate_scenarios do |scenario|
+
+      # Check if one of household behaviour keys has been set, then remove them
+      next unless HOUSEHOLD_BEHAVIOUR_KEYS.any? { |key| scenario.user_values.key?(key)}
+
+      HOUSEHOLD_BEHAVIOUR_KEYS.each do |key|
+        scenario.user_values.delete(key)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_17_090853) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_12_070901) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
Household behaviour inputs/sliders were retired. See https://github.com/quintel/etsource/pull/3261. The migration in this PR makes sure that the keys are also removed from all scenarios.

Note: the `households_behavior_close_windows_turn_off_heating` input/slider had already been removed much earlier, during heat modelling changes. The key had never been removed from scenarios though.