### PR TITLE
Remove intelligent control input sliders from scenarios

### DIFF
--- a/db/migrate/20250514083809_remove_intelligent_control.rb
+++ b/db/migrate/20250514083809_remove_intelligent_control.rb
@@ -1,0 +1,23 @@
+require 'etengine/scenario_migration'
+
+class RemoveIntelligentControl < ActiveRecord::Migration[7.1]
+  include ETEngine::ScenarioMigration
+
+  # Retired household behaviour keys
+  HOUSEHOLD_BEHAVIOUR_KEYS = %w[
+    buildings_lighting_savings_from_motion_detection_light
+    buildings_lighting_savings_from_daylight_control_light
+  ].freeze
+
+  def up
+    migrate_scenarios do |scenario|
+
+      # Check if one of household behaviour keys has been set, then remove them
+      next unless HOUSEHOLD_BEHAVIOUR_KEYS.any? { |key| scenario.user_values.key?(key)}
+
+      HOUSEHOLD_BEHAVIOUR_KEYS.each do |key|
+        scenario.user_values.delete(key)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_12_070901) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_14_083809) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
This PR solves https://github.com/quintel/etmodel/issues/4490 by removing the intelligent control lighting inputs in the scenarios

Goes together with:
ETSource: https://github.com/quintel/etsource/pull/3264 
ETModel: https://github.com/quintel/etmodel/pull/4491
ETDataset: Removal of dataset keys; TBD