### PR TITLE
MVP for dumping and loading scenarios

### DIFF
--- a/app/controllers/inspect/scenarios_controller.rb
+++ b/app/controllers/inspect/scenarios_controller.rb
@@ -67,6 +67,17 @@ class Inspect::ScenariosController < Inspect::BaseController
     render :edit
   end
 
+  def load_dump
+    unless current_user.admin?
+      redirect_to root_path
+      return
+    end
+
+    json_data = JSON.parse(File.read(params.permit(:dump)[:dump].path)).with_indifferent_access
+    scenario = ScenarioPacker::Load.new(json_data).scenario
+    redirect_to inspect_scenario_path(id: scenario.id), notice: 'Scenario created'
+  end
+
   private
 
   def find_scenario

--- a/app/models/scenario_packer/dump.rb
+++ b/app/models/scenario_packer/dump.rb
@@ -1,0 +1,43 @@
+module ScenarioPacker
+  class Dump
+    # Creates a new Scenario API dumper.
+    #
+    # @param [Scenario] scenario
+    #   The scenarios for which we want JSON.
+    #
+    def initialize(scenario)
+      @resource   = scenario
+    end
+
+    # Creates a Hash suitable for conversion to JSON by Rails.
+    #
+    # @return [Hash{Symbol=>Object}]
+    #   The Hash containing the scenario attributes.
+    #
+    def as_json(*)
+      json = @resource.as_json(
+        only: %i[
+          area_code end_year private keep_compatible
+          user_values balanced_values active_couplings
+          user_curves
+        ]
+      )
+      json[:user_sortables] = @resource.user_sortables.each_with_object({}) do |sortable, hash|
+        next unless sortable.persisted?
+
+        if sortable.is_a?(HeatNetworkOrder)
+          hash[sortable.class] = [] unless hash.key?(sortable.class)
+          hash[sortable.class] << sortable.as_json.merge(temperature: sortable.temperature)
+        else
+          hash[sortable.class] = sortable.as_json
+        end
+      end
+
+      json[:user_curves] = @resource.user_curves.each_with_object({}) do |curve, hash|
+        hash[curve.key] = curve.curve
+      end
+
+      json
+    end
+  end
+end

--- a/app/models/scenario_packer/dump.rb
+++ b/app/models/scenario_packer/dump.rb
@@ -34,7 +34,7 @@ module ScenarioPacker
       end
 
       json[:user_curves] = @resource.user_curves.each_with_object({}) do |curve, hash|
-        hash[curve.key] = curve.curve
+        hash[curve.key] = curve.curve.to_a
       end
 
       json

--- a/app/models/scenario_packer/load.rb
+++ b/app/models/scenario_packer/load.rb
@@ -1,0 +1,46 @@
+module ScenarioPacker
+  class Load
+    # Creates a new Scenario API loader.
+    #
+    # Loading through here will skip a lot of validations
+    def initialize(json_data)
+      @data = json_data
+      @scenario = Scenario.new(
+        @data.slice(*scenario_attributes)
+      )
+      @scenario.active_couplings = @data[:active_couplings].map(&:to_sym)
+    end
+
+    def scenario
+      create_sortables
+      create_curves
+
+      @scenario.save!
+
+      @scenario
+    end
+
+    def scenario_attributes
+      %i[
+        area_code end_year private keep_compatible
+        user_values balanced_values
+      ]
+    end
+
+    def create_sortables
+      @data['user_sortables'].each do |class_name, order|
+        if class_name == "HeatNetworkOrder"
+          order.each { |attrs| @scenario.heat_network_orders << HeatNetworkOrder.new(attrs)}
+        else
+          @scenario.public_send(:"#{class_name.underscore}=", class_name.constantize.new(order))
+        end
+      end
+    end
+
+    def create_curves
+      @data['user_curves'].each do |key, curve|
+        @scenario.user_curves << UserCurve.new(key: key, curve: curve)
+      end
+    end
+  end
+end

--- a/app/services/scenario_set_fetcher.rb
+++ b/app/services/scenario_set_fetcher.rb
@@ -1,0 +1,34 @@
+
+
+class ScenarioSetFetcher
+  def self.fetch(type:, params:)
+    case type.to_s
+    when 'featured'
+      fetch_featured(params)
+    when 'user_input'
+      fetch_user_input(params)
+    # TODO: add fetching scenarios belonging to a certain user (by email), quintel scenarios, key client scenarios and last 100 scenarios
+    else
+      []
+    end
+  end
+
+  def self.fetch_featured(params)
+    year  = params[:end_year].to_i
+    group = params[:group]
+    groups = MyEtm::FeaturedScenario.in_groups_per_end_year[year] || []
+    data   = groups.find { |g| g[:name] == group }
+    data ? data[:scenarios].map(&:scenario_id) : []
+  end
+
+  def self.fetch_user_input(params)
+    raw = params[:scenario_ids]
+    ids = if raw.is_a?(String)
+      raw.split(/\s*,\s*/)
+    else
+      Array(raw)
+    end
+
+    ids.map(&:to_i).reject(&:zero?).uniq
+  end
+end

--- a/app/services/scenario_set_fetcher.rb
+++ b/app/services/scenario_set_fetcher.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 
-
+# Fetches sets of scenario ids to quickly filter for preset queries when dumping scenarios for testing
 class ScenarioSetFetcher
   def self.fetch(type:, params:)
     case type.to_s

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -4,6 +4,13 @@
 
 .row
   .span12
+    Import a dump
+    = form_with url: load_dump_inspect_scenarios_path do |f_load|
+      = f_load.file_field 'dump', accept: 'application/json'
+      = f_load.submit 'Create'
+
+.row
+  .span12
     = simple_form_for [:data, @scenario],
         :url => @scenario.new_record? ? inspect_scenarios_path : inspect_scenario_path(:id => @scenario) do |f|
       = f.input :end_year

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -4,13 +4,6 @@
 
 .row
   .span12
-    Import a dump
-    = form_with url: load_dump_inspect_scenarios_path do |f_load|
-      = f_load.file_field 'dump', accept: 'application/json'
-      = f_load.submit 'Create'
-
-.row
-  .span12
     = simple_form_for [:data, @scenario],
         :url => @scenario.new_record? ? inspect_scenarios_path : inspect_scenario_path(:id => @scenario) do |f|
       = f.input :end_year

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -1,30 +1,44 @@
 - content_for(:title, 'Scenarios')
-
 = render "inspect/shared/inspect_subnav"
 
-%section#search_box
-  = form_tag inspect_scenarios_path, method: :get do
-    = search_field_tag :q, params[:q], placeholder: 'Scenario ID'
+%section#search_box.mb-4
+  = form_tag inspect_scenarios_path, method: :get, class: 'd-flex align-items-center gap-2' do
+    = search_field_tag :q, params[:q], placeholder: 'Scenario ID', class: 'form-control'
     = submit_tag 'Search', class: 'btn'
 
-%p
-  = link_to "Create a new scenario", new_inspect_scenario_path, class: 'btn btn-primary'
-  - if params[:api_scenario_id]
-    = link_to 'View current scenario', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn'
+%div.d-flex.flex-wrap.align-items-center.mb-4.gap-4
+  / ─────────────── Actions ───────────────
+  %div
+    %h5.text-muted.mb-2 Actions
+    .btn-group
+      = link_to 'New scenario', new_inspect_scenario_path, class: 'btn btn-primary'
+      - if params[:api_scenario_id]
+        = link_to 'View current', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn btn-secondary'
 
-.row
-  .span12
-    %h3 Download scenarios by ID
-    = text_field_tag :scenario_ids,
-                     '',
-                     placeholder: 'e.g. 123,456,789',
-                     class: 'form-control w-auto d-inline-block',
-                     id: 'scenario_ids_input'
-    = link_to 'Download Dump',
-              '#',
-              class: 'btn btn-primary ms-2 disabled',
-              id: 'download_link',
-              download: ''
+  / ─────────────── Download ───────────────
+  %div
+    %h5.text-muted.mb-2 Download by ID
+    .input-group
+      = text_field_tag :scenario_ids,
+                       '',
+                       placeholder: 'e.g. 123,456,789',
+                       class: 'form-control w-auto',
+                       id: 'scenario_ids_input'
+      = link_to 'Download Dump',
+                '#',
+                id: 'download_link',
+                class: 'btn btn-secondary disabled',
+                download: ''
+
+  / ─────────────── Import ───────────────
+  %div
+    %h5.text-muted.mb-2 Import dump
+    = form_with url: load_dump_inspect_scenarios_path,
+                method: :post,
+                local: true,
+                html: { multipart: true, class: 'd-flex align-items-center gap-2', data: { turbo: false } } do |f|
+      = f.file_field :dump, accept: 'application/json', class: 'form-control'
+      = f.submit 'Create scenarios', class: 'btn btn-secondary'
 
 :javascript
   document.addEventListener('DOMContentLoaded', function() {
@@ -42,18 +56,11 @@
         return;
       }
 
-      link.href = baseUrl + '?type=user_input&scenario_ids=' + encodeURIComponent(ids);
+      link.href     = baseUrl + '?type=user_input&scenario_ids=' + encodeURIComponent(ids);
       link.download = 'scenarios-' + ids.split(',').join('-') + '-dump.json';
       link.classList.remove('disabled');
     });
   });
-
-.row
-  .span12
-    Import a dump
-    = form_with url: load_dump_inspect_scenarios_path do |f_load|
-      = f_load.file_field 'dump', accept: 'application/json'
-      = f_load.submit 'Create scenarios', class: 'btn btn-primary'
 
 %table.table.table-condensed.scenario-list
   %thead

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -12,6 +12,49 @@
   - if params[:api_scenario_id]
     = link_to 'View current scenario', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn'
 
+.row
+  .span12
+    %h3 Download scenarios by ID
+    = text_field_tag :scenario_ids,
+                     '',
+                     placeholder: 'e.g. 123,456,789',
+                     class: 'form-control w-auto d-inline-block',
+                     id: 'scenario_ids_input'
+    = link_to 'Download Dump',
+              '#',
+              class: 'btn btn-primary ms-2 disabled',
+              id: 'download_link',
+              download: ''
+
+:javascript
+  document.addEventListener('DOMContentLoaded', function() {
+    var input = document.getElementById('scenario_ids_input');
+    var link  = document.getElementById('download_link');
+    var baseUrl = "#{download_dump_inspect_scenarios_path}";
+
+    input.addEventListener('input', function() {
+      var ids = input.value.replace(/[^\d,]/g, '').trim();
+
+      if (!ids) {
+        link.classList.add('disabled');
+        link.removeAttribute('href');
+        link.removeAttribute('download');
+        return;
+      }
+
+      link.href = baseUrl + '?type=user_input&scenario_ids=' + encodeURIComponent(ids);
+      link.download = 'scenarios-' + ids.split(',').join('-') + '-dump.json';
+      link.classList.remove('disabled');
+    });
+  });
+
+.row
+  .span12
+    Import a dump
+    = form_with url: load_dump_inspect_scenarios_path do |f_load|
+      = f_load.file_field 'dump', accept: 'application/json'
+      = f_load.submit 'Create scenarios', class: 'btn btn-primary'
+
 %table.table.table-condensed.scenario-list
   %thead
     %tr

--- a/app/views/inspect/scenarios/load_results.html.haml
+++ b/app/views/inspect/scenarios/load_results.html.haml
@@ -1,0 +1,20 @@
+- content_for(:title, 'Imported Scenarios')
+
+= render "inspect/shared/inspect_subnav"
+
+.row
+  .span12
+    %h3 Scenarios Created Successfully
+
+    %p The scenarios are now available at the following URLs:
+
+    %ul
+      - @scenarios.each do |scenario|
+        - url = "#{Settings.etmodel}/scenarios/#{scenario.id}"
+        %li
+          = link_to url, url, target: '_blank', rel: 'noopener'
+
+    %p
+    = link_to 'Back to scenarios list',
+                inspect_scenarios_path,
+                class: 'btn btn-secondary mt-3'

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -5,13 +5,13 @@
 %div{ style: 'float: right' }
   = link_to 'Edit scenario', edit_inspect_scenario_path(@scenario), class: 'btn btn-primary'
 
-.row
-  .span12
-    Export current scenario as dump
+.row{ style: 'margin-bottom: 0.8rem;' }
+  .span12{ style: 'display: flex; align-items: center;' }
+    %span{ style: 'margin-right: 0.8rem; white-space: nowrap;' }
+      Export current scenario
     = link_to 'Download Dump',
         download_dump_inspect_scenarios_path(@scenario.id, scenario_ids: [ @scenario.id ]),
-        class:    'btn btn-secondary',
-        download: "scenario-#{@scenario.id}-dump.json"
+        class: 'btn btn-secondary'
 
 .row
   .span8

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -6,6 +6,14 @@
   = link_to 'Edit scenario', edit_inspect_scenario_path(@scenario), class: 'btn btn-primary'
 
 .row
+  .span12
+    Export current scenario as dump
+    = link_to 'Download Dump',
+        download_dump_inspect_scenarios_path(@scenario.id, scenario_ids: [ @scenario.id ]),
+        class:    'btn btn-secondary',
+        download: "scenario-#{@scenario.id}-dump.json"
+
+.row
   .span8
     %table.table
       %tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
           get :sankey,                 to: 'export#sankey'
           get :storage_parameters,     to: 'export#storage_parameters'
           get :merit
+          get :dump
           put :dashboard
           post :interpolate
           post :uncouple
@@ -35,6 +36,7 @@ Rails.application.routes.draw do
 
         collection do
           post :merge
+          post :load_dump
           get  :templates
           get  'versions', to: 'scenario_version_tags#index'
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,7 @@ Rails.application.routes.draw do
 
       resources :scenarios, only: %i[index show edit update new create] do
         put :fix, on: :member
+        post :load_dump, on: :collection
       end
 
       # Checks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,8 @@ Rails.application.routes.draw do
 
     resources :scenarios, only: [] do
       collection do
-        get 'download_dump', to: 'scenarios#download_dump'
+        get :download_dump
+        post :load_dump
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,12 @@ Rails.application.routes.draw do
 
     get 'search.js' => 'search#index', as: :search_autocomplete
 
+    resources :scenarios, only: [] do
+      collection do
+        get 'download_dump', to: 'scenarios#download_dump'
+      end
+    end
+
     scope '/:api_scenario_id' do
       root to: 'pages#index'
       post '/clear_cache' => 'pages#clear_cache', as: 'clear_cache'
@@ -163,7 +169,6 @@ Rails.application.routes.draw do
       resources :scenarios, only: %i[index show edit update new create] do
         put :fix, on: :member
         post :load_dump, on: :collection
-        get :download_dump, on: :collection
       end
 
       # Checks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,7 @@ Rails.application.routes.draw do
       resources :scenarios, only: %i[index show edit update new create] do
         put :fix, on: :member
         post :load_dump, on: :collection
+        get :download_dump, on: :collection
       end
 
       # Checks

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,1 @@
+etmodel: http://localhost:3001

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,6 +2,8 @@ etsource_lazy_load_dataset: false
 etsource_export: tmp/etsource
 etsource_working_copy: <%= ENV.fetch('ETSOURCE_PATH', '/app/etsource') %>
 
+etmodel: https://energytransitionmodel.com
+
 identity:
   issuer: https://my.energytransitionmodel.com
   client_uri: https://engine.energytransitionmodel.com

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -2,6 +2,8 @@ etsource_lazy_load_dataset: false
 etsource_export: tmp/etsource
 etsource_working_copy: <%= ENV.fetch('ETSOURCE_PATH', '/app/etsource') %>
 
+etmodel: https://beta.energytransitionmodel.com
+
 identity:
   issuer: <%= ENV.fetch('OPENID_ISSUER', 'https://beta.my.energytransitionmodel.com') %>
   client_uri: <%= ENV.fetch('IDENTITY_CLIENT_URI', 'https://beta.engine.energytransitionmodel.com') %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,8 +130,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_12_070901) do
     t.text "active_couplings_old", size: :medium
     t.binary "user_values", size: :long
     t.binary "balanced_values", size: :medium
-    t.binary "metadata", size: :medium
     t.binary "active_couplings", size: :medium
+    t.binary "metadata", size: :medium
     t.index ["created_at"], name: "index_scenarios_on_created_at"
   end
 

--- a/spec/models/scenario_packer/dump_spec.rb
+++ b/spec/models/scenario_packer/dump_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ScenarioPacker::Dump, type: :model do
+  let!(:scenario) do
+    scenario = create(
+      :scenario,
+      area_code:       'nl',
+      end_year:        2040,
+      private:         false,
+      keep_compatible: true
+    )
+
+    scenario.update!(
+      user_values:      { 'foo' => 9.87 },
+      balanced_values:  { 'bar' => 6.54 },
+      active_couplings: []
+    )
+
+    create(
+      :heat_network_order,
+      scenario:    scenario,
+      temperature: 'ht',
+      order:       HeatNetworkOrder.default_order
+    )
+
+    scenario.create_forecast_storage_order!(order: ForecastStorageOrder.default_order)
+
+    create(:user_curve, scenario: scenario, key: 'c1', curve: [1, 2, 3])
+    create(:user_curve, scenario: scenario, key: 'c2', curve: [4, 5, 6])
+
+    scenario
+  end
+
+  subject(:dumper) { described_class.new(scenario) }
+  let(:json_data)  { dumper.as_json }
+  let(:data)       { json_data.with_indifferent_access }
+
+  it 'exposes the basic scenario attributes' do
+    expected_attributes = {
+      'area_code'        => 'nl',
+      'end_year'         => 2040,
+      'private'          => false,
+      'keep_compatible'  => true,
+      'user_values'      => { 'foo' => 9.87 },
+      'balanced_values'  => { 'bar' => 6.54 },
+      'active_couplings' => []
+    }
+
+    actual_attributes = json_data.slice(*expected_attributes.keys)
+
+    expect(actual_attributes).to eq(expected_attributes)
+  end
+
+  it 'serializes heat_network_orders under user_sortables as an Array' do
+    serialized_heat_orders = data[:user_sortables][HeatNetworkOrder]
+
+    expect(serialized_heat_orders).to be_an(Array)
+    expect(serialized_heat_orders.first['temperature']).to eq 'ht'
+    expect(serialized_heat_orders.first['order']).to eq HeatNetworkOrder.default_order
+  end
+
+  it 'serializes forecast_storage_order under user_sortables as a Hash' do
+    serialized_forecast_order = data[:user_sortables][ForecastStorageOrder]
+
+    expect(serialized_forecast_order).to be_a(Hash)
+    expect(serialized_forecast_order['order']).to eq ForecastStorageOrder.default_order
+  end
+
+  it 'renders user_curves as plain arrays' do
+    expect(data[:user_curves]).to eq({
+      'c1' => [1, 2, 3],
+      'c2' => [4, 5, 6]
+    })
+  end
+
+  it 'does not include unsaved sortables' do
+    scenario.heat_network_orders.build(
+      temperature: 'mt',
+      order: HeatNetworkOrder.default_order
+    )
+
+    serialized_orders = described_class
+      .new(scenario)
+      .as_json
+      .with_indifferent_access
+      .dig(:user_sortables, HeatNetworkOrder) || []
+
+    temperatures = serialized_orders.map { |order| order['temperature'] }
+
+    expect(temperatures).not_to include('mt')
+  end
+end

--- a/spec/models/scenario_packer/load_spec.rb
+++ b/spec/models/scenario_packer/load_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ScenarioPacker::Load, type: :model do
+  let(:scenario_data) do
+    {
+      area_code:        'nl',
+      end_year:         2050,
+      private:          false,
+      keep_compatible:  true,
+      user_values:      { foo: 1.23 },
+      balanced_values:  { bar: 4.56 },
+      active_couplings: [],
+      'user_sortables' => {
+        'HeatNetworkOrder' => [
+          { 'temperature' => 'ht', 'order' => HeatNetworkOrder.default_order }
+        ],
+        'ForecastStorageOrder' => { 'order' => ForecastStorageOrder.default_order }
+      },
+      'user_curves' => {
+        'curve_one' => [0, 1, 2, 3],
+        'curve_two' => [4, 5, 6, 7]
+      }
+    }.with_indifferent_access
+  end
+
+  subject(:loader) { described_class.new(scenario_data) }
+  let(:scenario_instance) { loader.instance_variable_get(:@scenario) }
+
+  describe '#initialize' do
+    it 'initializes a new Scenario with correct attributes' do
+      expect(scenario_instance).to be_a(Scenario)
+      expect(scenario_instance).to be_new_record
+      expect(scenario_instance.area_code).to eq 'nl'
+      expect(scenario_instance.end_year).to eq 2050
+      expect(scenario_instance.private).to be false
+      expect(scenario_instance.keep_compatible).to be true
+      expect(scenario_instance.user_values).to eq('foo' => 1.23)
+      expect(scenario_instance.balanced_values).to eq('bar' => 4.56)
+      expect(scenario_instance.active_couplings).to eq []
+      expect(scenario_instance.heat_network_orders).to be_empty
+      expect { scenario_instance.user_curves }.not_to raise_error
+    end
+  end
+
+  describe '#create_sortables' do
+    before { loader.send(:create_sortables) }
+
+    it 'builds one HeatNetworkOrder' do
+      heat_orders = scenario_instance.heat_network_orders
+      expect(heat_orders.first.temperature).to eq 'ht'
+      expect(heat_orders.first.order).to eq HeatNetworkOrder.default_order
+    end
+
+    it 'builds one ForecastStorageOrder' do
+      forecast_order = scenario_instance.forecast_storage_order
+      expect(forecast_order).to be_a(ForecastStorageOrder)
+      expect(forecast_order.order).to eq ForecastStorageOrder.default_order
+    end
+  end
+
+  describe '#create_curves' do
+    before { loader.send(:create_curves) }
+
+    it 'builds UserCurve records with correct keys and data' do
+      curve_keys = scenario_instance.user_curves.map(&:key)
+      expect(curve_keys).to match_array %w[curve_one curve_two]
+
+      curve_one = scenario_instance.user_curves.find { |c| c.key == 'curve_one' }
+      expect(curve_one.curve).to eq [0, 1, 2, 3]
+    end
+  end
+
+  describe '#scenario' do
+    it 'creates associations and persists the Scenario' do
+      allow(scenario_instance).to receive(:save!).and_return(true)
+
+      result = loader.scenario
+
+      expect(result).to be(scenario_instance)
+      expect(scenario_instance).to have_received(:save!)
+      expect(scenario_instance.heat_network_orders.size).to eq 1
+      expect(scenario_instance.user_curves.size).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
I thought it might be nice to put this work into a PR already so we can get a minimum viable product up and running ASAP.

### This PR:
- Includes the work from @noracato for dumping and loading scenarios as JSON.
  - This includes API endpoints for dump and load, and inspect routes.
- Expands functionality to allow single or multiple dump/load functionality for scenarios.
  - Currently, you can specify multiple scenario ids separated by commas to dump those scenarios. In the future I would like to expand this to include a dropdown with preset filters for scenario dumps like featured scenarios or scenarios belonging to a certain user.
  - You can dump a single scenario from the show view, or multiple from the index view. You upload scenarios via the index view.
- Post upload, you are redirected to a page with the links to the uploaded scenarios in ETModel, and sets the active api id to the first scenario of the bunch that you've uploaded (I think this makes it easy to see which scenarios you've uploaded in the index view).
- Spec has been added for the dump and load sub-models.

#### Outstanding issues:
- [ ] It's not that pretty
- [ ] Scenario sets are not yet implemented (especially featured would be nice)
- [ ] Occasionally if I don't reload the page correctly or navigate to it in a certain way, the download downloads an html for the scenarios index? Not sure what is causing this bug.

##### For the visuals - The buttons are just out of alignment?
![image](https://github.com/user-attachments/assets/55a58fbb-405c-492f-9b4d-facd2d2bf36a)


Closes #1569, #1570, #1571

