### PR TITLE
Dump n load

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
+
 module Api
   module V3
     class ScenariosController < BaseController
-
       rescue_from Scenario::YearInterpolator::InterpolationError do |ex|
         render json: { errors: [ex.message] }, status: :bad_request
       end
 
       load_resource except: %i[show create destroy dump]
-      load_and_authorize_resource class: Scenario, only: %i[index show create destroy dump]
+      load_and_authorize_resource class: Scenario, only: %i[index show destroy dump]
 
       before_action only: %i[batch] do
         # Only check that the user can read. We restrict the search in the action.
@@ -121,10 +122,12 @@ module Api
         # Weird ActiveResource bug: the user values attribute is nested inside
         # another user_values hash. Used when generating a scenario with the
         # average values of other scenarios.
-        inputs = params[:scenario][:user_values]["user_values"] rescue nil
-        if inputs
-          params[:scenario][:user_values] = inputs
+        inputs = begin
+                   params[:scenario][:user_values]['user_values']
+        rescue StandardError
+                   nil
         end
+        params[:scenario][:user_values] = inputs if inputs
 
         attrs = Scenario.default_attributes.merge(scenario_params || {})
         parent = nil
@@ -319,7 +322,9 @@ module Api
         if coupling_parameters[:force]
           force_uncouple
         else
-          coupling_parameters[:groups].each { |coupling| @scenario.deactivate_coupling(coupling.to_s) }
+          coupling_parameters[:groups].each do |coupling|
+            @scenario.deactivate_coupling(coupling.to_s)
+          end
           if @scenario.save
             render json: ScenarioSerializer.new(self, @scenario)
           else
@@ -406,9 +411,7 @@ module Api
           attrs[:user_values] = user_vals
         end
 
-        if attrs[:scenario]&.key?(:metadata)
-          attrs[:metadata] = filtered_metadata(attrs[:scenario])
-        end
+        attrs[:metadata] = filtered_metadata(attrs[:scenario]) if attrs[:scenario]&.key?(:metadata)
 
         attrs[:descale] = true if attrs[:descale] == 'true'
 
@@ -499,8 +502,8 @@ module Api
       # scenario which caused the error.
       #
       # Returns the result of the block.
-      def wrap_with_sentry_context
-        ScenarioSentryContext.with_context(@scenario) { yield }
+      def wrap_with_sentry_context(&)
+        ScenarioSentryContext.with_context(@scenario, &)
       end
     end
   end

--- a/app/controllers/inspect/scenarios_controller.rb
+++ b/app/controllers/inspect/scenarios_controller.rb
@@ -67,6 +67,17 @@ class Inspect::ScenariosController < Inspect::BaseController
     render :edit
   end
 
+  def load_dump
+    unless current_user.admin?
+      redirect_to root_path
+      return
+    end
+
+    json_data = JSON.parse(File.read(params.permit(:dump)[:dump].path)).with_indifferent_access
+    scenario = ScenarioPacker::Load.new(json_data).scenario
+    redirect_to inspect_scenario_path(id: scenario.id), notice: 'Scenario created'
+  end
+
   private
 
   def find_scenario

--- a/app/controllers/inspect/scenarios_controller.rb
+++ b/app/controllers/inspect/scenarios_controller.rb
@@ -95,7 +95,11 @@ module Inspect
 
     # GET /inspect/scenarios/dump?scenario_ids=1,2,3
     def dump
-      ids = extract_or_redirect_ids and return if ids.empty?
+      ids = parsed_scenario_ids
+      if ids.empty?
+        flash[:alert] = 'Please enter at least one scenario ID.'
+        return redirect_back(fallback_location: inspect_scenarios_path)
+      end
 
       packer = ScenarioPacker::DumpCollection.new(ids)
       send_data(packer.to_json,
@@ -119,20 +123,13 @@ module Inspect
 
     # Parses params[:scenario_ids], sets a flash + redirect if empty,
     # and returns a (possibly empty) Array of Integer IDs.
-    def extract_or_redirect_ids
+    def parsed_scenario_ids
       raw = params[:scenario_ids].to_s
-      ids = raw
-            .split(/\s*,\s*/)
-            .map(&:to_i)
-            .reject(&:zero?)
-            .uniq
-
-      if ids.empty?
-        flash[:alert] = 'Please enter at least one scenario ID.'
-        redirect_back(fallback_location: inspect_scenarios_path)
-      end
-
-      ids
+      raw
+        .split(/\s*,\s*/)
+        .map(&:to_i)
+        .reject(&:zero?)
+        .uniq
     end
 
     # Finds and sets the current scenario for edit/show/update actions

--- a/app/controllers/inspect/scenarios_controller.rb
+++ b/app/controllers/inspect/scenarios_controller.rb
@@ -69,28 +69,32 @@ class Inspect::ScenariosController < Inspect::BaseController
     render :edit
   end
 
-def load_dump
-  file = params.permit(:dump)[:dump]
-  unless file&.respond_to?(:path)
-    redirect_back fallback_location: root_path, alert: 'No file provided'
-    return
-  end
+  def load_dump
+    file = params.permit(:dump)[:dump]
+    unless file&.respond_to?(:path)
+      redirect_back fallback_location: root_path, alert: 'No file provided'
+      return
+    end
 
-  raw_data   = JSON.parse(File.read(file.path))
-  data_array = raw_data.is_a?(Array) ? raw_data : [raw_data]
+    raw_data   = JSON.parse(File.read(file.path))
+    data_array = raw_data.is_a?(Array) ? raw_data : [raw_data]
 
-  @scenarios = data_array.map { |sd| ScenarioPacker::Load.new(sd.with_indifferent_access).scenario }
+    @scenarios = data_array.map { |sd| ScenarioPacker::Load.new(sd.with_indifferent_access).scenario }
 
-  if @scenarios.one?
-    redirect_to inspect_scenario_path(id: @scenarios.first.id),
+    if @scenarios.one?
+      new_id = @scenarios.first.id
+      redirect_to inspect_scenario_path(
+                    id:              new_id,
+                    api_scenario_id: new_id
+                ),
                 notice: 'Scenario created'
-  else
-    api_id             = @scenarios.first.id
-    @api_scenario      = Scenario.find(api_id)
-    @scenario          = Scenario::Editable.new(@api_scenario)
-    render :load_results
+    else
+      api_id             = @scenarios.first.id
+      @api_scenario      = Scenario.find(api_id)
+      @scenario          = Scenario::Editable.new(@api_scenario)
+      render :load_results
+    end
   end
-end
 
   def download_dump
     # Determine which set to dump; default to user-provided IDs

--- a/app/controllers/inspect/scenarios_controller.rb
+++ b/app/controllers/inspect/scenarios_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Inspect
-  class ScenariosController < Inspect::BaseController
+  class ScenariosController < BaseController
     layout 'application'
 
     load_and_authorize_resource only: %i[load_dump dump], class: 'Scenario'

--- a/app/models/scenario_packer/dump.rb
+++ b/app/models/scenario_packer/dump.rb
@@ -1,0 +1,43 @@
+module ScenarioPacker
+  class Dump
+    # Creates a new Scenario API dumper.
+    #
+    # @param [Scenario] scenario
+    #   The scenarios for which we want JSON.
+    #
+    def initialize(scenario)
+      @resource   = scenario
+    end
+
+    # Creates a Hash suitable for conversion to JSON by Rails.
+    #
+    # @return [Hash{Symbol=>Object}]
+    #   The Hash containing the scenario attributes.
+    #
+    def as_json(*)
+      json = @resource.as_json(
+        only: %i[
+          area_code end_year private keep_compatible
+          user_values balanced_values active_couplings
+          user_curves
+        ]
+      )
+      json[:user_sortables] = @resource.user_sortables.each_with_object({}) do |sortable, hash|
+        next unless sortable.persisted?
+
+        if sortable.is_a?(HeatNetworkOrder)
+          hash[sortable.class] = [] unless hash.key?(sortable.class)
+          hash[sortable.class] << sortable.as_json.merge(temperature: sortable.temperature)
+        else
+          hash[sortable.class] = sortable.as_json
+        end
+      end
+
+      json[:user_curves] = @resource.user_curves.each_with_object({}) do |curve, hash|
+        hash[curve.key] = curve.curve
+      end
+
+      json
+    end
+  end
+end

--- a/app/models/scenario_packer/dump.rb
+++ b/app/models/scenario_packer/dump.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScenarioPacker
   class Dump
     # Creates a new Scenario API dumper.
@@ -6,7 +8,7 @@ module ScenarioPacker
     #   The scenarios for which we want JSON.
     #
     def initialize(scenario)
-      @resource   = scenario
+      @resource = scenario
     end
 
     # Creates a Hash suitable for conversion to JSON by Rails.

--- a/app/models/scenario_packer/dump.rb
+++ b/app/models/scenario_packer/dump.rb
@@ -34,7 +34,7 @@ module ScenarioPacker
       end
 
       json[:user_curves] = @resource.user_curves.each_with_object({}) do |curve, hash|
-        hash[curve.key] = curve.curve
+        hash[curve.key] = curve.curve.to_a
       end
 
       json

--- a/app/models/scenario_packer/dump_collection.rb
+++ b/app/models/scenario_packer/dump_collection.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ScenarioPacker
+  class DumpCollection
+    # Accepts an Array of IDs
+    #
+    # @param [Array<Integer>] ids
+    def initialize(ids)
+      @ids = Array(ids).map(&:to_i).uniq
+      @records_by_id = Scenario.where(id: @ids)
+                               .index_by(&:id)
+    end
+
+    # Returns an Array of Hashes, one per scenario
+    #
+    # @return [Array<Hash{Symbol=>Object}>]
+    def as_json(*)
+      @ids.filter_map do |id|
+        record = @records_by_id[id]
+        next unless record
+
+        Dump.new(record).as_json
+      end
+    end
+
+    # Pretty-printed JSON string
+    #
+    # @return [String]
+    def to_json(*)
+      JSON.pretty_generate(as_json(*))
+    end
+
+    # Derive a filename from the scenario IDs
+    #
+    # @return [String]
+    def filename
+      "#{@ids.join('-')}-dump.json"
+    end
+  end
+end

--- a/app/models/scenario_packer/load.rb
+++ b/app/models/scenario_packer/load.rb
@@ -1,0 +1,46 @@
+module ScenarioPacker
+  class Load
+    # Creates a new Scenario API loader.
+    #
+    # Loading through here will skip a lot of validations
+    def initialize(json_data)
+      @data = json_data
+      @scenario = Scenario.new(
+        @data.slice(*scenario_attributes)
+      )
+      @scenario.active_couplings = @data[:active_couplings].map(&:to_sym)
+    end
+
+    def scenario
+      create_sortables
+      create_curves
+
+      @scenario.save!
+
+      @scenario
+    end
+
+    def scenario_attributes
+      %i[
+        area_code end_year private keep_compatible
+        user_values balanced_values
+      ]
+    end
+
+    def create_sortables
+      @data['user_sortables'].each do |class_name, order|
+        if class_name == "HeatNetworkOrder"
+          order.each { |attrs| @scenario.heat_network_orders << HeatNetworkOrder.new(attrs)}
+        else
+          @scenario.public_send(:"#{class_name.underscore}=", class_name.constantize.new(order))
+        end
+      end
+    end
+
+    def create_curves
+      @data['user_curves'].each do |key, curve|
+        @scenario.user_curves << UserCurve.new(key: key, curve: curve)
+      end
+    end
+  end
+end

--- a/app/models/scenario_packer/load.rb
+++ b/app/models/scenario_packer/load.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ScenarioPacker
   class Load
     # Creates a new Scenario API loader.
@@ -29,8 +31,8 @@ module ScenarioPacker
 
     def create_sortables
       @data['user_sortables'].each do |class_name, order|
-        if class_name == "HeatNetworkOrder"
-          order.each { |attrs| @scenario.heat_network_orders << HeatNetworkOrder.new(attrs)}
+        if class_name == 'HeatNetworkOrder'
+          order.each { |attrs| @scenario.heat_network_orders << HeatNetworkOrder.new(attrs) }
         else
           @scenario.public_send(:"#{class_name.underscore}=", class_name.constantize.new(order))
         end
@@ -39,7 +41,7 @@ module ScenarioPacker
 
     def create_curves
       @data['user_curves'].each do |key, curve|
-        @scenario.user_curves << UserCurve.new(key: key, curve: curve)
+        @scenario.user_curves << UserCurve.new(key:, curve:)
       end
     end
   end

--- a/app/models/scenario_packer/load_collection.rb
+++ b/app/models/scenario_packer/load_collection.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module ScenarioPacker
+  class LoadCollection
+    attr_reader :scenarios
+
+    # Builds & loads straight from an uploaded file object
+    #
+    # @param [ActionDispatch::Http::UploadedFile] file
+    # @return [LoadCollection]
+    def self.from_file(file)
+      raise ArgumentError, 'No file provided' unless file.respond_to?(:path)
+
+      raw = JSON.parse(File.read(file.path))
+      data = raw.is_a?(Array) ? raw : [raw]
+      loader = new(data.map(&:with_indifferent_access))
+      loader.load_all
+      loader
+    end
+
+    def initialize(data_array)
+      @data_array = data_array
+      @scenarios  = []
+    end
+
+    def load_all
+      @scenarios = @data_array.map { |d| Load.new(d).scenario }
+    end
+
+    def first_id
+      scenarios.first&.id
+    end
+
+    def single?
+      scenarios.one?
+    end
+  end
+end

--- a/app/services/scenario_set_fetcher.rb
+++ b/app/services/scenario_set_fetcher.rb
@@ -1,0 +1,34 @@
+
+
+class ScenarioSetFetcher
+  def self.fetch(type:, params:)
+    case type.to_s
+    when 'featured'
+      fetch_featured(params)
+    when 'user_input'
+      fetch_user_input(params)
+    # TODO: add fetching scenarios belonging to a certain user (by email), quintel scenarios, key client scenarios and last 100 scenarios
+    else
+      []
+    end
+  end
+
+  def self.fetch_featured(params)
+    year  = params[:end_year].to_i
+    group = params[:group]
+    groups = MyEtm::FeaturedScenario.in_groups_per_end_year[year] || []
+    data   = groups.find { |g| g[:name] == group }
+    data ? data[:scenarios].map(&:scenario_id) : []
+  end
+
+  def self.fetch_user_input(params)
+    raw = params[:scenario_ids]
+    ids = if raw.is_a?(String)
+      raw.split(/\s*,\s*/)
+    else
+      Array(raw)
+    end
+
+    ids.map(&:to_i).reject(&:zero?).uniq
+  end
+end

--- a/app/services/scenario_set_fetcher.rb
+++ b/app/services/scenario_set_fetcher.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 
-
+# Fetches sets of scenario ids to quickly filter for preset queries when dumping scenarios for testing
 class ScenarioSetFetcher
   def self.fetch(type:, params:)
     case type.to_s

--- a/app/views/inspect/scenarios/_dump_form.html.haml
+++ b/app/views/inspect/scenarios/_dump_form.html.haml
@@ -1,0 +1,11 @@
+%section#dump_box
+  = form_with url: dump_inspect_scenarios_path, method: :get, local: true, html: { 'data-turbo': false } do |f|
+    .form-group
+      = f.label :scenario_ids, "Download a dump of scenarios by (comma-separated) scenario IDs", class: "control-label"
+      = f.text_field :scenario_ids,
+                     value: params[:scenario_ids],
+                     placeholder: "e.g. 1034534, 234573, etc",
+                     class: "form-control",
+                     id: "dump_scenario_ids"
+    .form-group.mt-2
+      = f.submit "Download Dump", class: "btn btn-primary"

--- a/app/views/inspect/scenarios/_dump_modal.html.haml
+++ b/app/views/inspect/scenarios/_dump_modal.html.haml
@@ -1,0 +1,22 @@
+#dumpModal.modal.hide.fade
+  .modal-header
+    %button.close{'data-dismiss' => 'modal'} ×
+    %h3 Download Scenarios
+
+  = form_tag dump_inspect_scenarios_path,
+             method: :get,
+             local: true,
+             data: { turbo: false },
+             id: 'dump_form',
+             class: 'form-inline' do
+
+    .modal-body
+      = label_tag :scenario_ids, 'Scenario IDs (comma-separated)', class: 'inline-label'
+      = text_field_tag :scenario_ids,
+                       params[:scenario_ids],
+                       placeholder: 'e.g. 1034534, 234573, etc',
+                       id: 'modal_scenario_ids',
+                       class: 'input-medium form-control'
+
+    .modal-footer
+      = submit_tag 'Download Dump', class: 'btn btn-primary'

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -4,6 +4,13 @@
 
 .row
   .span12
+    Import a dump
+    = form_with url: load_dump_inspect_scenarios_path do |f_load|
+      = f_load.file_field 'dump', accept: 'application/json'
+      = f_load.submit 'Create'
+
+.row
+  .span12
     = simple_form_for [:data, @scenario],
         :url => @scenario.new_record? ? inspect_scenarios_path : inspect_scenario_path(:id => @scenario) do |f|
       = f.input :end_year

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -4,13 +4,6 @@
 
 .row
   .span12
-    Import a dump
-    = form_with url: load_dump_inspect_scenarios_path do |f_load|
-      = f_load.file_field 'dump', accept: 'application/json'
-      = f_load.submit 'Create'
-
-.row
-  .span12
     = simple_form_for [:data, @scenario],
         :url => @scenario.new_record? ? inspect_scenarios_path : inspect_scenario_path(:id => @scenario) do |f|
       = f.input :end_year

--- a/app/views/inspect/scenarios/_import_modal.html.haml
+++ b/app/views/inspect/scenarios/_import_modal.html.haml
@@ -1,0 +1,25 @@
+#importModal.modal.hide.fade
+  .modal-header
+    %button.close{'data-dismiss' => 'modal'} ×
+    %h3 Import Scenarios
+
+  = form_tag load_dump_inspect_scenarios_path,
+             multipart: true,
+             local: true,
+             data: { turbo: false },
+             id: 'import_form',
+             class: 'form-inline' do
+
+    .modal-body
+      = label_tag :modal_dump_file, 'JSON file', class: 'inline-label'
+      = file_field_tag :dump,
+                       accept: 'application/json',
+                       id: 'modal_dump_file'
+
+    .modal-footer
+      = submit_tag 'Confirm Import',
+                   class: 'btn btn-primary'
+      = button_tag 'Close',
+                   type: 'button',
+                   class: 'btn',
+                   'data-dismiss' => 'modal'

--- a/app/views/inspect/scenarios/_load_modal.html.haml
+++ b/app/views/inspect/scenarios/_load_modal.html.haml
@@ -1,4 +1,4 @@
-#importModal.modal.hide.fade
+#loadModal.modal.hide.fade
   .modal-header
     %button.close{'data-dismiss' => 'modal'} ×
     %h3 Import Scenarios
@@ -19,7 +19,3 @@
     .modal-footer
       = submit_tag 'Confirm Import',
                    class: 'btn btn-primary'
-      = button_tag 'Close',
-                   type: 'button',
-                   class: 'btn',
-                   'data-dismiss' => 'modal'

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -1,30 +1,44 @@
 - content_for(:title, 'Scenarios')
-
 = render "inspect/shared/inspect_subnav"
 
-%section#search_box
-  = form_tag inspect_scenarios_path, method: :get do
-    = search_field_tag :q, params[:q], placeholder: 'Scenario ID'
+%section#search_box.mb-4
+  = form_tag inspect_scenarios_path, method: :get, class: 'd-flex align-items-center gap-2' do
+    = search_field_tag :q, params[:q], placeholder: 'Scenario ID', class: 'form-control'
     = submit_tag 'Search', class: 'btn'
 
-%p
-  = link_to "Create a new scenario", new_inspect_scenario_path, class: 'btn btn-primary'
-  - if params[:api_scenario_id]
-    = link_to 'View current scenario', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn'
+%div.d-flex.flex-wrap.align-items-center.mb-4.gap-4
+  / ─────────────── Actions ───────────────
+  %div
+    %h5.text-muted.mb-2 Actions
+    .btn-group
+      = link_to 'New scenario', new_inspect_scenario_path, class: 'btn btn-primary'
+      - if params[:api_scenario_id]
+        = link_to 'View current', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn btn-secondary'
 
-.row
-  .span12
-    %h3 Download scenarios by ID
-    = text_field_tag :scenario_ids,
-                     '',
-                     placeholder: 'e.g. 123,456,789',
-                     class: 'form-control w-auto d-inline-block',
-                     id: 'scenario_ids_input'
-    = link_to 'Download Dump',
-              '#',
-              class: 'btn btn-primary ms-2 disabled',
-              id: 'download_link',
-              download: ''
+  / ─────────────── Download ───────────────
+  %div
+    %h5.text-muted.mb-2 Download by ID
+    .input-group
+      = text_field_tag :scenario_ids,
+                       '',
+                       placeholder: 'e.g. 123,456,789',
+                       class: 'form-control w-auto',
+                       id: 'scenario_ids_input'
+      = link_to 'Download Dump',
+                '#',
+                id: 'download_link',
+                class: 'btn btn-secondary disabled',
+                download: ''
+
+  / ─────────────── Import ───────────────
+  %div
+    %h5.text-muted.mb-2 Import dump
+    = form_with url: load_dump_inspect_scenarios_path,
+                method: :post,
+                local: true,
+                html: { multipart: true, class: 'd-flex align-items-center gap-2', data: { turbo: false } } do |f|
+      = f.file_field :dump, accept: 'application/json', class: 'form-control'
+      = f.submit 'Create scenarios', class: 'btn btn-secondary'
 
 :javascript
   document.addEventListener('DOMContentLoaded', function() {
@@ -42,18 +56,11 @@
         return;
       }
 
-      link.href = baseUrl + '?type=user_input&scenario_ids=' + encodeURIComponent(ids);
+      link.href     = baseUrl + '?type=user_input&scenario_ids=' + encodeURIComponent(ids);
       link.download = 'scenarios-' + ids.split(',').join('-') + '-dump.json';
       link.classList.remove('disabled');
     });
   });
-
-.row
-  .span12
-    Import a dump
-    = form_with url: load_dump_inspect_scenarios_path do |f_load|
-      = f_load.file_field 'dump', accept: 'application/json'
-      = f_load.submit 'Create scenarios', class: 'btn btn-primary'
 
 %table.table.table-condensed.scenario-list
   %thead

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -141,6 +141,8 @@
     %button.close{'data-dismiss' => 'modal'} ×
     %h3 Download Scenarios
   .modal-body
+    %p.text-muted
+      Enter one or more scenario IDs, separated by commas (e.g. <code>123, 456</code>), to download a JSON dump of their data.
     = form_tag download_dump_inspect_scenarios_path(format: :json),
                method: :get,
                id: 'download_form',
@@ -148,7 +150,7 @@
       = label_tag :modal_scenario_ids, 'Scenario IDs', class: 'inline-label'
       = text_field_tag :scenario_ids,
                        '',
-                       placeholder: 'e.g. 123,456',
+                       placeholder: '123,456',
                        class: 'input-medium',
                        id: 'modal_scenario_ids'
   .modal-footer

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -14,74 +14,17 @@
         = link_to "Create a new scenario", new_inspect_scenario_path, class: 'btn btn-primary'
         - if params[:api_scenario_id]
           = link_to 'View current scenario', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn'
-
-
     / ──────────── Download + Import ─────────────
     .span6.text-right
-      = button_tag 'Download Dump',
-                   type: 'button',
-                   class: 'btn btn-primary',
-                   style: 'min-width:130px; text-align:center;',
-                   'data-toggle' => 'modal',
-                   'data-target' => '#downloadModal'
+      = render "dump_form"
       = button_tag 'Import dump',
-                  type: 'button',
-                  class: 'btn btn-secondary',
-                  style: 'min-width:130px; text-align:center;',
-                  'data-toggle' => 'modal',
-                  'data-target' => '#importModal'
+              type: 'button',
+              class: 'btn btn-secondary mt-2',
+              style: 'min-width:130px; text-align:center;',
+              'data-toggle' => 'modal',
+              'data-target' => '#importModal'
 
-:javascript
-  document.addEventListener('DOMContentLoaded', function() {
-    const input  = document.getElementById('scenario_ids_input');
-    const button = document.getElementById('download_button');
-    const baseUrl = button.dataset.baseUrl;
-    const VALID_PATTERN = /^\s*\d+(?:\s*,\s*\d+)*\s*$/;
-
-    input.addEventListener('input', () => {
-      let raw = input.value;
-      if (!VALID_PATTERN.test(raw)) {
-        button.disabled = true;
-        button.removeAttribute('href');
-        return;
-      }
-      raw = raw.replace(/\s+/g, '');
-      const params = new URLSearchParams({
-        type:        'user_input',
-        scenario_ids: raw
-      });
-      const href = `${baseUrl}?${params.toString()}`;
-
-      button.disabled = false;
-      button.setAttribute('onclick', `window.location='${href}'`);
-    });
-  });
-
-  document.addEventListener('DOMContentLoaded', function() {
-    // Download confirm
-    document.getElementById('confirm_download').addEventListener('click', function() {
-      var ids = document.getElementById('modal_scenario_ids').value;
-      if (!ids.match(/^\s*\d+(?:\s*,\s*\d+)*\s*$/)) {
-        alert('Please enter a comma-separated list of numbers.');
-        return;
-      }
-      var form = document.getElementById('download_form');
-      ids = ids.replace(/\s+/g, '');
-      form.action = form.action + '?scenario_ids=' + encodeURIComponent(ids);
-      form.submit();
-    });
-
-    // Import confirm
-    document.getElementById('confirm_import').addEventListener('click', function() {
-      var fileInput = document.getElementById('modal_dump_file');
-      if (!fileInput.value) {
-        alert('Please choose a JSON file to import.');
-        return;
-      }
-      document.getElementById('import_form').submit();
-    });
-  });
-
+  = render 'import_modal'
 
 
 %table.table.table-condensed.scenario-list
@@ -134,56 +77,3 @@
           - else
             = link_to 'Make active', inspect_scenarios_path(@list_params.to_h.symbolize_keys.merge(api_scenario_id: s.id))
           = link_to 'Edit', edit_inspect_scenario_path(:id => s.id)
-
-/ Download Modal
-#downloadModal.modal.hide.fade
-  .modal-header
-    %button.close{'data-dismiss' => 'modal'} ×
-    %h3 Download Scenarios
-  .modal-body
-    %p.text-muted
-      Enter one or more scenario IDs, separated by commas (e.g. <code>123, 456</code>), to download a JSON dump of their data.
-    = form_tag download_dump_inspect_scenarios_path(format: :json),
-               method: :get,
-               id: 'download_form',
-               class: 'form-inline' do
-      = label_tag :modal_scenario_ids, 'Scenario IDs', class: 'inline-label'
-      = text_field_tag :scenario_ids,
-                       '',
-                       placeholder: '123,456',
-                       class: 'input-medium',
-                       id: 'modal_scenario_ids'
-  .modal-footer
-    = button_tag 'Confirm Download',
-                 type: 'button',
-                 id: 'confirm_download',
-                 class: 'btn btn-primary'
-    = button_tag 'Close',
-                 type: 'button',
-                 class: 'btn',
-                 'data-dismiss' => 'modal'
-
-/ Import Modal
-#importModal.modal.hide.fade
-  .modal-header
-    %button.close{'data-dismiss' => 'modal'} ×
-    %h3 Import Scenarios
-  .modal-body
-    = form_tag load_dump_inspect_scenarios_path,
-               multipart: true,
-               local: true,
-               id: 'import_form',
-               class: 'form-inline' do
-      = label_tag :modal_dump_file, 'JSON file', class: 'inline-label'
-      = file_field_tag :dump,
-                       accept: 'application/json',
-                       id: 'modal_dump_file'
-  .modal-footer
-    = button_tag 'Confirm Import',
-                 type: 'button',
-                 id: 'confirm_import',
-                 class: 'btn btn-primary'
-    = button_tag 'Close',
-                 type: 'button',
-                 class: 'btn',
-                 'data-dismiss' => 'modal'

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -1,66 +1,88 @@
 - content_for(:title, 'Scenarios')
 = render "inspect/shared/inspect_subnav"
 
-%section#search_box.mb-4
-  = form_tag inspect_scenarios_path, method: :get, class: 'd-flex align-items-center gap-2' do
-    = search_field_tag :q, params[:q], placeholder: 'Scenario ID', class: 'form-control'
-    = submit_tag 'Search', class: 'btn'
+.container-fluid
+  .row-fluid
+    .span6
+      / ──────────── New + Search ───────────────────
+      %section#search_box
+        = form_tag inspect_scenarios_path, method: :get do
+          = search_field_tag :q, params[:q], placeholder: 'Scenario ID'
+          = submit_tag 'Search', class: 'btn'
 
-%div.d-flex.flex-wrap.align-items-center.mb-4.gap-4
-  / ─────────────── Actions ───────────────
-  %div
-    %h5.text-muted.mb-2 Actions
-    .btn-group
-      = link_to 'New scenario', new_inspect_scenario_path, class: 'btn btn-primary'
-      - if params[:api_scenario_id]
-        = link_to 'View current', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn btn-secondary'
+      %p
+        = link_to "Create a new scenario", new_inspect_scenario_path, class: 'btn btn-primary'
+        - if params[:api_scenario_id]
+          = link_to 'View current scenario', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn'
 
-  / ─────────────── Download ───────────────
-  %div
-    %h5.text-muted.mb-2 Download by ID
-    .input-group
-      = text_field_tag :scenario_ids,
-                       '',
-                       placeholder: 'e.g. 123,456,789',
-                       class: 'form-control w-auto',
-                       id: 'scenario_ids_input'
-      = link_to 'Download Dump',
-                '#',
-                id: 'download_link',
-                class: 'btn btn-secondary disabled',
-                download: ''
 
-  / ─────────────── Import ───────────────
-  %div
-    %h5.text-muted.mb-2 Import dump
-    = form_with url: load_dump_inspect_scenarios_path,
-                method: :post,
-                local: true,
-                html: { multipart: true, class: 'd-flex align-items-center gap-2', data: { turbo: false } } do |f|
-      = f.file_field :dump, accept: 'application/json', class: 'form-control'
-      = f.submit 'Create scenarios', class: 'btn btn-secondary'
+    / ──────────── Download + Import ─────────────
+    .span6.text-right
+      = button_tag 'Download Dump',
+                   type: 'button',
+                   class: 'btn btn-primary',
+                   style: 'min-width:130px; text-align:center;',
+                   'data-toggle' => 'modal',
+                   'data-target' => '#downloadModal'
+      = button_tag 'Import dump',
+                  type: 'button',
+                  class: 'btn btn-secondary',
+                  style: 'min-width:130px; text-align:center;',
+                  'data-toggle' => 'modal',
+                  'data-target' => '#importModal'
 
 :javascript
   document.addEventListener('DOMContentLoaded', function() {
-    var input = document.getElementById('scenario_ids_input');
-    var link  = document.getElementById('download_link');
-    var baseUrl = "#{download_dump_inspect_scenarios_path}";
+    const input  = document.getElementById('scenario_ids_input');
+    const button = document.getElementById('download_button');
+    const baseUrl = button.dataset.baseUrl;
+    const VALID_PATTERN = /^\s*\d+(?:\s*,\s*\d+)*\s*$/;
 
-    input.addEventListener('input', function() {
-      var ids = input.value.replace(/[^\d,]/g, '').trim();
-
-      if (!ids) {
-        link.classList.add('disabled');
-        link.removeAttribute('href');
-        link.removeAttribute('download');
+    input.addEventListener('input', () => {
+      let raw = input.value;
+      if (!VALID_PATTERN.test(raw)) {
+        button.disabled = true;
+        button.removeAttribute('href');
         return;
       }
+      raw = raw.replace(/\s+/g, '');
+      const params = new URLSearchParams({
+        type:        'user_input',
+        scenario_ids: raw
+      });
+      const href = `${baseUrl}?${params.toString()}`;
 
-      link.href     = baseUrl + '?type=user_input&scenario_ids=' + encodeURIComponent(ids);
-      link.download = 'scenarios-' + ids.split(',').join('-') + '-dump.json';
-      link.classList.remove('disabled');
+      button.disabled = false;
+      button.setAttribute('onclick', `window.location='${href}'`);
     });
   });
+
+  document.addEventListener('DOMContentLoaded', function() {
+    // Download confirm
+    document.getElementById('confirm_download').addEventListener('click', function() {
+      var ids = document.getElementById('modal_scenario_ids').value;
+      if (!ids.match(/^\s*\d+(?:\s*,\s*\d+)*\s*$/)) {
+        alert('Please enter a comma-separated list of numbers.');
+        return;
+      }
+      var form = document.getElementById('download_form');
+      ids = ids.replace(/\s+/g, '');
+      form.action = form.action + '?scenario_ids=' + encodeURIComponent(ids);
+      form.submit();
+    });
+
+    // Import confirm
+    document.getElementById('confirm_import').addEventListener('click', function() {
+      var fileInput = document.getElementById('modal_dump_file');
+      if (!fileInput.value) {
+        alert('Please choose a JSON file to import.');
+        return;
+      }
+      document.getElementById('import_form').submit();
+    });
+  });
+
+
 
 %table.table.table-condensed.scenario-list
   %thead
@@ -112,3 +134,54 @@
           - else
             = link_to 'Make active', inspect_scenarios_path(@list_params.to_h.symbolize_keys.merge(api_scenario_id: s.id))
           = link_to 'Edit', edit_inspect_scenario_path(:id => s.id)
+
+/ Download Modal
+#downloadModal.modal.hide.fade
+  .modal-header
+    %button.close{'data-dismiss' => 'modal'} ×
+    %h3 Download Scenarios
+  .modal-body
+    = form_tag download_dump_inspect_scenarios_path(format: :json),
+               method: :get,
+               id: 'download_form',
+               class: 'form-inline' do
+      = label_tag :modal_scenario_ids, 'Scenario IDs', class: 'inline-label'
+      = text_field_tag :scenario_ids,
+                       '',
+                       placeholder: 'e.g. 123,456',
+                       class: 'input-medium',
+                       id: 'modal_scenario_ids'
+  .modal-footer
+    = button_tag 'Confirm Download',
+                 type: 'button',
+                 id: 'confirm_download',
+                 class: 'btn btn-primary'
+    = button_tag 'Close',
+                 type: 'button',
+                 class: 'btn',
+                 'data-dismiss' => 'modal'
+
+/ Import Modal
+#importModal.modal.hide.fade
+  .modal-header
+    %button.close{'data-dismiss' => 'modal'} ×
+    %h3 Import Scenarios
+  .modal-body
+    = form_tag load_dump_inspect_scenarios_path,
+               multipart: true,
+               local: true,
+               id: 'import_form',
+               class: 'form-inline' do
+      = label_tag :modal_dump_file, 'JSON file', class: 'inline-label'
+      = file_field_tag :dump,
+                       accept: 'application/json',
+                       id: 'modal_dump_file'
+  .modal-footer
+    = button_tag 'Confirm Import',
+                 type: 'button',
+                 id: 'confirm_import',
+                 class: 'btn btn-primary'
+    = button_tag 'Close',
+                 type: 'button',
+                 class: 'btn',
+                 'data-dismiss' => 'modal'

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -12,6 +12,49 @@
   - if params[:api_scenario_id]
     = link_to 'View current scenario', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn'
 
+.row
+  .span12
+    %h3 Download scenarios by ID
+    = text_field_tag :scenario_ids,
+                     '',
+                     placeholder: 'e.g. 123,456,789',
+                     class: 'form-control w-auto d-inline-block',
+                     id: 'scenario_ids_input'
+    = link_to 'Download Dump',
+              '#',
+              class: 'btn btn-primary ms-2 disabled',
+              id: 'download_link',
+              download: ''
+
+:javascript
+  document.addEventListener('DOMContentLoaded', function() {
+    var input = document.getElementById('scenario_ids_input');
+    var link  = document.getElementById('download_link');
+    var baseUrl = "#{download_dump_inspect_scenarios_path}";
+
+    input.addEventListener('input', function() {
+      var ids = input.value.replace(/[^\d,]/g, '').trim();
+
+      if (!ids) {
+        link.classList.add('disabled');
+        link.removeAttribute('href');
+        link.removeAttribute('download');
+        return;
+      }
+
+      link.href = baseUrl + '?type=user_input&scenario_ids=' + encodeURIComponent(ids);
+      link.download = 'scenarios-' + ids.split(',').join('-') + '-dump.json';
+      link.classList.remove('disabled');
+    });
+  });
+
+.row
+  .span12
+    Import a dump
+    = form_with url: load_dump_inspect_scenarios_path do |f_load|
+      = f_load.file_field 'dump', accept: 'application/json'
+      = f_load.submit 'Create scenarios', class: 'btn btn-primary'
+
 %table.table.table-condensed.scenario-list
   %thead
     %tr

--- a/app/views/inspect/scenarios/index.html.haml
+++ b/app/views/inspect/scenarios/index.html.haml
@@ -14,23 +14,30 @@
         = link_to "Create a new scenario", new_inspect_scenario_path, class: 'btn btn-primary'
         - if params[:api_scenario_id]
           = link_to 'View current scenario', inspect_scenario_path(id: params[:api_scenario_id]), class: 'btn'
+
     / ──────────── Download + Import ─────────────
     .span6.text-right
-      = render "dump_form"
+      = button_tag 'Download dump',
+                   type: 'button',
+                   class: 'btn btn-primary',
+                   style: 'min-width:130px; text-align:center;',
+                   'data-toggle' => 'modal',
+                   'data-target' => '#dumpModal'
+
       = button_tag 'Import dump',
-              type: 'button',
-              class: 'btn btn-secondary mt-2',
-              style: 'min-width:130px; text-align:center;',
-              'data-toggle' => 'modal',
-              'data-target' => '#importModal'
+                   type: 'button',
+                   class: 'btn btn-secondary mt-2',
+                   style: 'min-width:130px; text-align:center;',
+                   'data-toggle' => 'modal',
+                   'data-target' => '#loadModal'
 
-  = render 'import_modal'
-
+  = render 'dump_modal'
+  = render 'load_modal'
 
 %table.table.table-condensed.scenario-list
   %thead
     %tr
-      %th{:colspan => 8} Scenario count: #{Scenario.count}
+      %th{ colspan: 8 } Scenario count: #{Scenario.count}
     %tr
       %th.narrow.text-center Visibility
       %th ID
@@ -41,7 +48,7 @@
       %th
   %tfoot
     %tr
-      %td{:colspan => 8}= paginate @scenarios
+      %td{ colspan: 8 }= paginate @scenarios
   %tbody
     - @scenarios.each do |s|
       %tr{ class: s.id.to_s == params[:api_scenario_id] ? 'active' : '' }
@@ -53,7 +60,7 @@
           - else
             %span.tag.gray Public
         %td
-          = link_to s.id, inspect_scenario_path(:id => s.id)
+          = link_to s.id, inspect_scenario_path(id: s.id)
           - if s.title
             %span{ style: 'margin: 0 0.25rem 0 0.5rem; font-weight: normal' }= s.title
           - if s.id.to_s == params[:api_scenario_id]
@@ -62,7 +69,7 @@
           - if s.scenario_users.present?
             - s.scenario_users.each do |scenario_user|
               - if scenario_user.user
-                = link_to("#{scenario_user.user.name} (#{User::ROLES[scenario_user.role_id].to_s.humanize})", user_path(scenario_user.user))
+                = link_to "#{scenario_user.user.name} (#{User::ROLES[scenario_user.role_id].to_s.humanize})", user_path(scenario_user.user)
               - else
                 %span.muted= "#{scenario_user.email} (#{User::ROLES[scenario_user.role_id].to_s.humanize})"
           - else
@@ -76,4 +83,4 @@
             %span.muted Make active
           - else
             = link_to 'Make active', inspect_scenarios_path(@list_params.to_h.symbolize_keys.merge(api_scenario_id: s.id))
-          = link_to 'Edit', edit_inspect_scenario_path(:id => s.id)
+          = link_to 'Edit', edit_inspect_scenario_path(id: s.id)

--- a/app/views/inspect/scenarios/load_results.html.haml
+++ b/app/views/inspect/scenarios/load_results.html.haml
@@ -1,0 +1,20 @@
+- content_for(:title, 'Imported Scenarios')
+
+= render "inspect/shared/inspect_subnav"
+
+.row
+  .span12
+    %h3 Scenarios Created Successfully
+
+    %p The scenarios are now available at the following URLs:
+
+    %ul
+      - @scenarios.each do |scenario|
+        - url = "#{Settings.etmodel}/scenarios/#{scenario.id}"
+        %li
+          = link_to url, url, target: '_blank', rel: 'noopener'
+
+    %p
+    = link_to 'Back to scenarios list',
+                inspect_scenarios_path,
+                class: 'btn btn-secondary mt-3'

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -1,17 +1,14 @@
 - content_for(:title, 'Scenario')
-
 = render "inspect/shared/inspect_subnav"
 
-%div{ style: 'float: right' }
+%div{ style: 'float: right;' }
+  = form_with url: dump_inspect_scenarios_path,
+              method: :get,
+              local: true,
+              html: { 'data-turbo': false, style: 'display: inline; margin-right: 0.5rem;' } do |f|
+    = f.hidden_field :scenario_ids, value: @scenario.id
+    = f.submit "Download Dump", class: 'btn btn-secondary'
   = link_to 'Edit scenario', edit_inspect_scenario_path(@scenario), class: 'btn btn-primary'
-
-.row{ style: 'margin-bottom: 0.8rem;' }
-  .span12{ style: 'display: flex; align-items: center;' }
-    %span{ style: 'margin-right: 0.8rem; white-space: nowrap;' }
-      Export current scenario
-    = link_to 'Download Dump',
-        download_dump_inspect_scenarios_path(@scenario.id, scenario_ids: [ @scenario.id ]),
-        class: 'btn btn-secondary'
 
 .row
   .span8
@@ -73,7 +70,6 @@
 .row
   .span10
     - {future: @scenario.inputs.future, present: @scenario.inputs.present}.each do |name, inputs|
-
       %h3== Inputs #{name}
       - if inputs.empty?
         %p No updates
@@ -87,7 +83,7 @@
               %td.span1.tar min
               %td.span1.tar max
           %tbody
-            - inputs.group_by{|h| h.first.share_group.to_s }.each do |share_group, input_value|
+            - inputs.group_by { |h| h.first.share_group.to_s }.each do |share_group, input_value|
               %tr
                 %td(colspan=2)
                   %strong
@@ -97,7 +93,7 @@
                     = auto_number input_value.map(&:last).compact.sum rescue 'error'
                 %td(colspan=2)
 
-              - input_value.sort_by{|iv| iv.first.key.to_s}.each do |input, value|
+              - input_value.sort_by { |iv| iv.first.key.to_s }.each do |input, value|
                 %tr
                   %td.tar= input.id
                   %td= input.key

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -5,13 +5,13 @@
 %div{ style: 'float: right' }
   = link_to 'Edit scenario', edit_inspect_scenario_path(@scenario), class: 'btn btn-primary'
 
-.row
-  .span12
-    Export current scenario as dump
+.row{ style: 'margin-bottom: 0.8rem;' }
+  .span12{ style: 'display: flex; align-items: center;' }
+    %span{ style: 'margin-right: 0.8rem; white-space: nowrap;' }
+      Export current scenario
     = link_to 'Download Dump',
         download_dump_inspect_scenarios_path(@scenario.id, scenario_ids: [ @scenario.id ]),
-        class:    'btn btn-secondary',
-        download: "scenario-#{@scenario.id}-dump.json"
+        class: 'btn btn-secondary'
 
 .row
   .span8

--- a/app/views/inspect/scenarios/show.html.haml
+++ b/app/views/inspect/scenarios/show.html.haml
@@ -6,6 +6,14 @@
   = link_to 'Edit scenario', edit_inspect_scenario_path(@scenario), class: 'btn btn-primary'
 
 .row
+  .span12
+    Export current scenario as dump
+    = link_to 'Download Dump',
+        download_dump_inspect_scenarios_path(@scenario.id, scenario_ids: [ @scenario.id ]),
+        class:    'btn btn-secondary',
+        download: "scenario-#{@scenario.id}-dump.json"
+
+.row
   .span8
     %table.table
       %tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
           get :sankey,                 to: 'export#sankey'
           get :storage_parameters,     to: 'export#storage_parameters'
           get :merit
+          get :dump
           put :dashboard
           post :interpolate
           post :uncouple
@@ -35,6 +36,7 @@ Rails.application.routes.draw do
 
         collection do
           post :merge
+          post :load_dump
           get  :templates
           get  'versions', to: 'scenario_version_tags#index'
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,6 +162,7 @@ Rails.application.routes.draw do
 
       resources :scenarios, only: %i[index show edit update new create] do
         put :fix, on: :member
+        post :load_dump, on: :collection
       end
 
       # Checks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,8 @@ Rails.application.routes.draw do
 
     resources :scenarios, only: [] do
       collection do
-        get 'download_dump', to: 'scenarios#download_dump'
+        get :download_dump
+        post :load_dump
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,7 +130,7 @@ Rails.application.routes.draw do
 
     resources :scenarios, only: [] do
       collection do
-        get :download_dump
+        get :dump
         post :load_dump
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,12 @@ Rails.application.routes.draw do
 
     get 'search.js' => 'search#index', as: :search_autocomplete
 
+    resources :scenarios, only: [] do
+      collection do
+        get 'download_dump', to: 'scenarios#download_dump'
+      end
+    end
+
     scope '/:api_scenario_id' do
       root to: 'pages#index'
       post '/clear_cache' => 'pages#clear_cache', as: 'clear_cache'
@@ -163,7 +169,6 @@ Rails.application.routes.draw do
       resources :scenarios, only: %i[index show edit update new create] do
         put :fix, on: :member
         post :load_dump, on: :collection
-        get :download_dump, on: :collection
       end
 
       # Checks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,7 @@ Rails.application.routes.draw do
       resources :scenarios, only: %i[index show edit update new create] do
         put :fix, on: :member
         post :load_dump, on: :collection
+        get :download_dump, on: :collection
       end
 
       # Checks

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,1 @@
+etmodel: http://localhost:3001

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -2,6 +2,8 @@ etsource_lazy_load_dataset: false
 etsource_export: tmp/etsource
 etsource_working_copy: <%= ENV.fetch('ETSOURCE_PATH', '/app/etsource') %>
 
+etmodel: https://energytransitionmodel.com
+
 identity:
   issuer: https://my.energytransitionmodel.com
   client_uri: https://engine.energytransitionmodel.com

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -2,6 +2,8 @@ etsource_lazy_load_dataset: false
 etsource_export: tmp/etsource
 etsource_working_copy: <%= ENV.fetch('ETSOURCE_PATH', '/app/etsource') %>
 
+etmodel: https://beta.energytransitionmodel.com
+
 identity:
   issuer: <%= ENV.fetch('OPENID_ISSUER', 'https://beta.my.energytransitionmodel.com') %>
   client_uri: <%= ENV.fetch('IDENTITY_CLIENT_URI', 'https://beta.engine.energytransitionmodel.com') %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,8 +130,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_14_114442) do
     t.text "active_couplings_old", size: :medium
     t.binary "user_values", size: :long
     t.binary "balanced_values", size: :medium
-    t.binary "metadata", size: :medium
     t.binary "active_couplings", size: :medium
+    t.binary "metadata", size: :medium
     t.index ["created_at"], name: "index_scenarios_on_created_at"
   end
 

--- a/spec/models/scenario_packer/dump_collection_spec.rb
+++ b/spec/models/scenario_packer/dump_collection_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe ScenarioPacker::DumpCollection do
+  let(:ids) { [1, 2, 3] }
+  let(:records) do
+    ids.map do |i|
+      double('Scenario', id: i)
+    end
+  end
+  let(:dummy_hashes) { ids.map { |i| { id: i, foo: "bar#{i}" } } }
+
+  before do
+    # Stub AR query
+    allow(Scenario).to receive(:where).with(id: ids).and_return(records)
+
+    # Stub Dump serializer
+    records.each_with_index do |rec, idx|
+      dump = double('Dump', as_json: dummy_hashes[idx])
+      allow(ScenarioPacker::Dump).to receive(:new).with(rec).and_return(dump)
+    end
+  end
+
+  describe '#as_json' do
+    it 'returns array of scenario hashes in original order' do
+      collection = described_class.new(ids)
+      expect(collection.as_json).to eq(dummy_hashes)
+    end
+
+    it 'filters out missing records' do
+      sparse_ids = [1, 99, 2]
+      available_records = records.select { |r| sparse_ids.include?(r.id) }
+
+      allow(Scenario).to receive(:where)
+        .with(id: sparse_ids)
+        .and_return(available_records)
+
+      collection = described_class.new(sparse_ids)
+      expected_hashes = [dummy_hashes[0], dummy_hashes[1]]
+
+      expect(collection.as_json).to eq(expected_hashes)
+    end
+  end
+
+  describe '#to_json' do
+    it 'returns pretty-printed JSON string of hashes' do
+      json_str = described_class.new(ids).to_json
+      parsed = JSON.parse(json_str)
+
+      expect(parsed).to eq(dummy_hashes.map(&:stringify_keys))
+    end
+  end
+
+  describe '#filename' do
+    it 'joins ids with hyphens and appends -dump.json' do
+      collection = described_class.new(ids)
+      expect(collection.filename).to eq('1-2-3-dump.json')
+    end
+  end
+end

--- a/spec/models/scenario_packer/dump_collection_spec.rb
+++ b/spec/models/scenario_packer/dump_collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe ScenarioPacker::DumpCollection do

--- a/spec/models/scenario_packer/dump_spec.rb
+++ b/spec/models/scenario_packer/dump_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe ScenarioPacker::Dump, type: :model do
+  subject(:dumper) { described_class.new(scenario) }
+
   let!(:scenario) do
     scenario = create(
       :scenario,
@@ -20,20 +22,18 @@ RSpec.describe ScenarioPacker::Dump, type: :model do
 
     create(
       :heat_network_order,
-      scenario:    scenario,
+      scenario:,
       temperature: 'ht',
       order:       HeatNetworkOrder.default_order
     )
 
     scenario.create_forecast_storage_order!(order: ForecastStorageOrder.default_order)
 
-    create(:user_curve, scenario: scenario, key: 'c1', curve: [1, 2, 3])
-    create(:user_curve, scenario: scenario, key: 'c2', curve: [4, 5, 6])
+    create(:user_curve, scenario:, key: 'c1', curve: [1, 2, 3])
+    create(:user_curve, scenario:, key: 'c2', curve: [4, 5, 6])
 
     scenario
   end
-
-  subject(:dumper) { described_class.new(scenario) }
   let(:json_data)  { dumper.as_json }
   let(:data)       { json_data.with_indifferent_access }
 
@@ -57,15 +57,15 @@ RSpec.describe ScenarioPacker::Dump, type: :model do
     serialized_heat_orders = data[:user_sortables][HeatNetworkOrder]
 
     expect(serialized_heat_orders).to be_an(Array)
-    expect(serialized_heat_orders.first['temperature']).to eq 'ht'
-    expect(serialized_heat_orders.first['order']).to eq HeatNetworkOrder.default_order
+    expect(serialized_heat_orders.first['temperature']).to eq('ht')
+    expect(serialized_heat_orders.first['order']).to eq(HeatNetworkOrder.default_order)
   end
 
   it 'serializes forecast_storage_order under user_sortables as a Hash' do
     serialized_forecast_order = data[:user_sortables][ForecastStorageOrder]
 
     expect(serialized_forecast_order).to be_a(Hash)
-    expect(serialized_forecast_order['order']).to eq ForecastStorageOrder.default_order
+    expect(serialized_forecast_order['order']).to eq(ForecastStorageOrder.default_order)
   end
 
   it 'renders user_curves as plain arrays' do

--- a/spec/models/scenario_packer/dump_spec.rb
+++ b/spec/models/scenario_packer/dump_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ScenarioPacker::Dump, type: :model do
+  let!(:scenario) do
+    scenario = create(
+      :scenario,
+      area_code:       'nl',
+      end_year:        2040,
+      private:         false,
+      keep_compatible: true
+    )
+
+    scenario.update!(
+      user_values:      { 'foo' => 9.87 },
+      balanced_values:  { 'bar' => 6.54 },
+      active_couplings: []
+    )
+
+    create(
+      :heat_network_order,
+      scenario:    scenario,
+      temperature: 'ht',
+      order:       HeatNetworkOrder.default_order
+    )
+
+    scenario.create_forecast_storage_order!(order: ForecastStorageOrder.default_order)
+
+    create(:user_curve, scenario: scenario, key: 'c1', curve: [1, 2, 3])
+    create(:user_curve, scenario: scenario, key: 'c2', curve: [4, 5, 6])
+
+    scenario
+  end
+
+  subject(:dumper) { described_class.new(scenario) }
+  let(:json_data)  { dumper.as_json }
+  let(:data)       { json_data.with_indifferent_access }
+
+  it 'exposes the basic scenario attributes' do
+    expected_attributes = {
+      'area_code'        => 'nl',
+      'end_year'         => 2040,
+      'private'          => false,
+      'keep_compatible'  => true,
+      'user_values'      => { 'foo' => 9.87 },
+      'balanced_values'  => { 'bar' => 6.54 },
+      'active_couplings' => []
+    }
+
+    actual_attributes = json_data.slice(*expected_attributes.keys)
+
+    expect(actual_attributes).to eq(expected_attributes)
+  end
+
+  it 'serializes heat_network_orders under user_sortables as an Array' do
+    serialized_heat_orders = data[:user_sortables][HeatNetworkOrder]
+
+    expect(serialized_heat_orders).to be_an(Array)
+    expect(serialized_heat_orders.first['temperature']).to eq 'ht'
+    expect(serialized_heat_orders.first['order']).to eq HeatNetworkOrder.default_order
+  end
+
+  it 'serializes forecast_storage_order under user_sortables as a Hash' do
+    serialized_forecast_order = data[:user_sortables][ForecastStorageOrder]
+
+    expect(serialized_forecast_order).to be_a(Hash)
+    expect(serialized_forecast_order['order']).to eq ForecastStorageOrder.default_order
+  end
+
+  it 'renders user_curves as plain arrays' do
+    expect(data[:user_curves]).to eq({
+      'c1' => [1, 2, 3],
+      'c2' => [4, 5, 6]
+    })
+  end
+
+  it 'does not include unsaved sortables' do
+    scenario.heat_network_orders.build(
+      temperature: 'mt',
+      order: HeatNetworkOrder.default_order
+    )
+
+    serialized_orders = described_class
+      .new(scenario)
+      .as_json
+      .with_indifferent_access
+      .dig(:user_sortables, HeatNetworkOrder) || []
+
+    temperatures = serialized_orders.map { |order| order['temperature'] }
+
+    expect(temperatures).not_to include('mt')
+  end
+end

--- a/spec/models/scenario_packer/load_collection_spec.rb
+++ b/spec/models/scenario_packer/load_collection_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+RSpec.describe ScenarioPacker::LoadCollection do
+  describe '.from_file' do
+    let(:file) { Tempfile.new('dump.json') }
+
+    after { file.close! }
+
+    context 'when file does not respond to path' do
+      it 'raises ArgumentError' do
+        fake = double('File')
+        expect { described_class.from_file(fake) }
+          .to raise_error(ArgumentError, /No file provided/)
+      end
+    end
+
+    context 'when file has JSON object' do
+      let(:scenario1) { double('Scenario', id: 10) }
+
+      before do
+        file.write({ foo: 'bar' }.to_json)
+        file.rewind
+
+        loader = double('Load', scenario: scenario1)
+        allow(ScenarioPacker::Load).to receive(:new).and_return(loader)
+      end
+
+      it 'loads one scenario and returns loader' do
+        result = described_class.from_file(file)
+
+        expect(result).to be_a(described_class)
+        expect(result.scenarios).to eq([scenario1])
+        expect(result.first_id).to eq(10)
+        expect(result.single?).to be true
+      end
+    end
+
+    context 'when file has JSON array' do
+      let(:scenario1) { double('Scenario', id: 1) }
+      let(:scenario2) { double('Scenario', id: 2) }
+
+      before do
+        file.write([{ foo: 'a' }, { foo: 'b' }].to_json)
+        file.rewind
+
+        loaders = [
+          double('Load', scenario: scenario1),
+          double('Load', scenario: scenario2)
+        ]
+
+        allow(ScenarioPacker::Load)
+          .to receive(:new)
+          .and_return(*loaders)
+      end
+
+      it 'loads multiple scenarios correctly' do
+        result = described_class.from_file(file)
+
+        aggregate_failures do
+          expect(result.scenarios).to eq([scenario1, scenario2])
+          expect(result.first_id).to eq(1)
+          expect(result.single?).to be false
+        end
+      end
+    end
+  end
+
+  describe '#load_all' do
+    subject(:collection) { described_class.new(data) }
+
+    let(:data)      { [{}, {}] }
+    let(:scenarios) { [double('Scenario1'), double('Scenario2')] }
+    let(:loaders)   { scenarios.map { |s| double('Load', scenario: s) } }
+
+    it 'populates scenarios via Load in order' do
+      allow(ScenarioPacker::Load).to receive(:new).and_return(*loaders)
+      collection.load_all
+      expect(collection.scenarios).to eq(scenarios)
+    end
+  end
+end

--- a/spec/models/scenario_packer/load_collection_spec.rb
+++ b/spec/models/scenario_packer/load_collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe ScenarioPacker::LoadCollection do
@@ -31,7 +33,7 @@ RSpec.describe ScenarioPacker::LoadCollection do
         expect(result).to be_a(described_class)
         expect(result.scenarios).to eq([scenario1])
         expect(result.first_id).to eq(10)
-        expect(result.single?).to be true
+        expect(result.single?).to be(true)
       end
     end
 
@@ -59,7 +61,7 @@ RSpec.describe ScenarioPacker::LoadCollection do
         aggregate_failures do
           expect(result.scenarios).to eq([scenario1, scenario2])
           expect(result.first_id).to eq(1)
-          expect(result.single?).to be false
+          expect(result.single?).to be(false)
         end
       end
     end

--- a/spec/models/scenario_packer/load_spec.rb
+++ b/spec/models/scenario_packer/load_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ScenarioPacker::Load, type: :model do
+  let(:scenario_data) do
+    {
+      area_code:        'nl',
+      end_year:         2050,
+      private:          false,
+      keep_compatible:  true,
+      user_values:      { foo: 1.23 },
+      balanced_values:  { bar: 4.56 },
+      active_couplings: [],
+      'user_sortables' => {
+        'HeatNetworkOrder' => [
+          { 'temperature' => 'ht', 'order' => HeatNetworkOrder.default_order }
+        ],
+        'ForecastStorageOrder' => { 'order' => ForecastStorageOrder.default_order }
+      },
+      'user_curves' => {
+        'curve_one' => [0, 1, 2, 3],
+        'curve_two' => [4, 5, 6, 7]
+      }
+    }.with_indifferent_access
+  end
+
+  subject(:loader) { described_class.new(scenario_data) }
+  let(:scenario_instance) { loader.instance_variable_get(:@scenario) }
+
+  describe '#initialize' do
+    it 'initializes a new Scenario with correct attributes' do
+      expect(scenario_instance).to be_a(Scenario)
+      expect(scenario_instance).to be_new_record
+      expect(scenario_instance.area_code).to eq 'nl'
+      expect(scenario_instance.end_year).to eq 2050
+      expect(scenario_instance.private).to be false
+      expect(scenario_instance.keep_compatible).to be true
+      expect(scenario_instance.user_values).to eq('foo' => 1.23)
+      expect(scenario_instance.balanced_values).to eq('bar' => 4.56)
+      expect(scenario_instance.active_couplings).to eq []
+      expect(scenario_instance.heat_network_orders).to be_empty
+      expect { scenario_instance.user_curves }.not_to raise_error
+    end
+  end
+
+  describe '#create_sortables' do
+    before { loader.send(:create_sortables) }
+
+    it 'builds one HeatNetworkOrder' do
+      heat_orders = scenario_instance.heat_network_orders
+      expect(heat_orders.first.temperature).to eq 'ht'
+      expect(heat_orders.first.order).to eq HeatNetworkOrder.default_order
+    end
+
+    it 'builds one ForecastStorageOrder' do
+      forecast_order = scenario_instance.forecast_storage_order
+      expect(forecast_order).to be_a(ForecastStorageOrder)
+      expect(forecast_order.order).to eq ForecastStorageOrder.default_order
+    end
+  end
+
+  describe '#create_curves' do
+    before { loader.send(:create_curves) }
+
+    it 'builds UserCurve records with correct keys and data' do
+      curve_keys = scenario_instance.user_curves.map(&:key)
+      expect(curve_keys).to match_array %w[curve_one curve_two]
+
+      curve_one = scenario_instance.user_curves.find { |c| c.key == 'curve_one' }
+      expect(curve_one.curve).to eq [0, 1, 2, 3]
+    end
+  end
+
+  describe '#scenario' do
+    it 'creates associations and persists the Scenario' do
+      allow(scenario_instance).to receive(:save!).and_return(true)
+
+      result = loader.scenario
+
+      expect(result).to be(scenario_instance)
+      expect(scenario_instance).to have_received(:save!)
+      expect(scenario_instance.heat_network_orders.size).to eq 1
+      expect(scenario_instance.user_curves.size).to eq 2
+    end
+  end
+end

--- a/spec/models/scenario_packer/load_spec.rb
+++ b/spec/models/scenario_packer/load_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe ScenarioPacker::Load, type: :model do
+  subject(:loader) { described_class.new(scenario_data) }
+
   let(:scenario_data) do
     {
       area_code:        'nl',
@@ -24,21 +26,19 @@ RSpec.describe ScenarioPacker::Load, type: :model do
       }
     }.with_indifferent_access
   end
-
-  subject(:loader) { described_class.new(scenario_data) }
   let(:scenario_instance) { loader.instance_variable_get(:@scenario) }
 
   describe '#initialize' do
     it 'initializes a new Scenario with correct attributes' do
       expect(scenario_instance).to be_a(Scenario)
       expect(scenario_instance).to be_new_record
-      expect(scenario_instance.area_code).to eq 'nl'
-      expect(scenario_instance.end_year).to eq 2050
-      expect(scenario_instance.private).to be false
-      expect(scenario_instance.keep_compatible).to be true
+      expect(scenario_instance.area_code).to eq('nl')
+      expect(scenario_instance.end_year).to eq(2050)
+      expect(scenario_instance.private).to be(false)
+      expect(scenario_instance.keep_compatible).to be(true)
       expect(scenario_instance.user_values).to eq('foo' => 1.23)
       expect(scenario_instance.balanced_values).to eq('bar' => 4.56)
-      expect(scenario_instance.active_couplings).to eq []
+      expect(scenario_instance.active_couplings).to eq([])
       expect(scenario_instance.heat_network_orders).to be_empty
       expect { scenario_instance.user_curves }.not_to raise_error
     end
@@ -49,14 +49,14 @@ RSpec.describe ScenarioPacker::Load, type: :model do
 
     it 'builds one HeatNetworkOrder' do
       heat_orders = scenario_instance.heat_network_orders
-      expect(heat_orders.first.temperature).to eq 'ht'
-      expect(heat_orders.first.order).to eq HeatNetworkOrder.default_order
+      expect(heat_orders.first.temperature).to eq('ht')
+      expect(heat_orders.first.order).to eq(HeatNetworkOrder.default_order)
     end
 
     it 'builds one ForecastStorageOrder' do
       forecast_order = scenario_instance.forecast_storage_order
       expect(forecast_order).to be_a(ForecastStorageOrder)
-      expect(forecast_order.order).to eq ForecastStorageOrder.default_order
+      expect(forecast_order.order).to eq(ForecastStorageOrder.default_order)
     end
   end
 
@@ -65,10 +65,10 @@ RSpec.describe ScenarioPacker::Load, type: :model do
 
     it 'builds UserCurve records with correct keys and data' do
       curve_keys = scenario_instance.user_curves.map(&:key)
-      expect(curve_keys).to match_array %w[curve_one curve_two]
+      expect(curve_keys).to match_array(%w[curve_one curve_two])
 
       curve_one = scenario_instance.user_curves.find { |c| c.key == 'curve_one' }
-      expect(curve_one.curve).to eq [0, 1, 2, 3]
+      expect(curve_one.curve).to eq([0, 1, 2, 3])
     end
   end
 
@@ -80,8 +80,8 @@ RSpec.describe ScenarioPacker::Load, type: :model do
 
       expect(result).to be(scenario_instance)
       expect(scenario_instance).to have_received(:save!)
-      expect(scenario_instance.heat_network_orders.size).to eq 1
-      expect(scenario_instance.user_curves.size).to eq 2
+      expect(scenario_instance.heat_network_orders.size).to eq(1)
+      expect(scenario_instance.user_curves.size).to eq(2)
     end
   end
 end


### PR DESCRIPTION
PR for MVP:

### This PR:
- Includes the work from @noracato for dumping and loading scenarios as JSON.
  - This includes API endpoints for dump and load, and inspect routes.
- Expands functionality to allow single or multiple dump/load functionality for scenarios.
  - Currently, you can specify multiple scenario ids separated by commas to dump those scenarios. In the future I would like to expand this to include a dropdown with preset filters for scenario dumps like featured scenarios or scenarios belonging to a certain user.
  - You can dump a single scenario from the show view, or multiple from the index view. You upload scenarios via the index view.
- Post upload, you are redirected to a page with the links to the uploaded scenarios in ETModel, and sets the active api id to the first scenario of the bunch that you've uploaded (I think this makes it easy to see which scenarios you've uploaded in the index view).
- Spec has been added for the dump and load sub-models.


#### Outstanding issues:
- [ ] Scenario sets are not yet implemented (especially featured would be nice)
- [ ] Maybe we need more internal documentation on this feature? I think how it is currently implemented is fairly logical at least.
- [ ] I set the etmodel urls in config/settings/<env>.yml for each environment. Is that ok? Kyra had requested that after importing, it would be helpful to have a page with the links to the front end for the scenarios you imported.

Closes #1569, #1570, #1571

