### PR TITLE
Updated load shifting adapter to properly account for deficit hours

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: 'd79f11d', github: 'quintel/merit'
+gem 'quintel_merit', ref: '2411622', github: 'quintel/merit'
 gem 'atlas',         ref: '8e854b1', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: 'c39c9b1', github: 'quintel/refinery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,8 +36,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: d79f11db131edbb0107542c681781a2a7fae1905
-  ref: d79f11d
+  revision: 2411622e264211d593f2c148ff30484d70cbedf2
+  ref: 2411622
   specs:
     quintel_merit (0.1.0)
       numo-narray


### PR DESCRIPTION
This refactor enforces a cumulative deficit limit to make sure the cumulative energy deficit is tracked over time. In this way, output should cease once the configured deficit_capacity is reached. The previous implementation treated the load curve as static, ignoring any notion of capacity constraints for shifting demand.

I've also added a small spec for the changes.

@kaskranenburgQ could you test whether these changes have the desired effect?

Closes #1535 (and maybe #1585).