### PR TITLE
Reference the updated blackout-deficit commit in merit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ gem 'parallel'
 gem 'ruby-progressbar'
 
 # own gems
-gem 'quintel_merit', ref: 'd79f11d', github: 'quintel/merit'
+gem 'quintel_merit', ref: '2411622', github: 'quintel/merit'
 gem 'atlas',         ref: '8e854b1', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: 'c39c9b1', github: 'quintel/refinery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,8 +36,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/merit.git
-  revision: d79f11db131edbb0107542c681781a2a7fae1905
-  ref: d79f11d
+  revision: 2411622e264211d593f2c148ff30484d70cbedf2
+  ref: 2411622
   specs:
     quintel_merit (0.1.0)
       numo-narray


### PR DESCRIPTION
As described in [this issue](https://github.com/quintel/etengine/issues/1535), now Optimizing Storage technologies no longer set the price, but rather take their price flexibly like other flex technologies.

Goes with [this Merit PR](https://github.com/quintel/merit/pull/158)

Closes #1535 and closes #1585.