### PR TITLE
Handling booleans in the inputs endpoint

### DIFF
--- a/app/serializers/boolean_input_serializer.rb
+++ b/app/serializers/boolean_input_serializer.rb
@@ -1,0 +1,16 @@
+class BooleanInputSerializer < InputSerializer
+  def as_json(*)
+    json   = super
+
+    values = Input.cache(@scenario.original).read(@scenario.original, @input)
+    default_val = @default_values_from.call(values)
+    user_val    = @scenario.user_values[@input.key] || @scenario.balanced_values[@input.key]
+
+    json[:min]     = false
+    json[:max]     = true
+    json[:default] = default_val == 1.0
+    json[:unit]    = 'bool'
+
+    json
+  end
+end

--- a/app/serializers/input_serializer.rb
+++ b/app/serializers/input_serializer.rb
@@ -52,7 +52,14 @@ class InputSerializer
   # @return [InputSerializer]
   #   Returns the input serializer (or subclass) instance.
   def self.serializer_for(input, *args, **kwargs)
-    klass = input.unit == 'enum' ? EnumInputSerializer : self
+    klass =
+      if input.unit == 'bool'
+        BooleanInputSerializer
+      elsif input.unit == 'enum'
+        EnumInputSerializer
+      else
+        self
+      end
     klass.new(input, *args, **kwargs)
   end
 


### PR DESCRIPTION
This draft PR implements a boolean input serializer so booleans are treated as true/false values in the inputs api.

Before:
```
  "heat_storage_enabled_lt": {
    "min": 0.0,
    "max": 1.0,
    "default": 0.0,
    "unit": "bool",
    "disabled": false
  }
```

After:
```
  "heat_storage_enabled_lt": {
    "min": false,
    "max": true,
    "default": false,
    "unit": "bool",
    "disabled": false
  }
```

There is a discussion to be had about how best to handle booleans, enums and other types in the inputs API. A few suggestions that have been mentioned include:
- Splitting the 'settings' out into a separate endpoint or section
- Ordering the response or splitting it based on whether inputs are continuous or discrete

One of the pain points identified is that when performing regionalisation or amalgamation, boolean values may end up as split fraction rather than a binary 0 or 1, and the scenario validation happens lazily rather than on update/create for the inputs so this can only be validated 'later' in the model. This boolean serializer converts the values into 'true' or 'false' enumerations to avoid that issue. However, we could also consider alternative solutions including:
- Leaving the booleans as values and enforcing high-level validation when you 'put' inputs into the model
- Handling fractional booleans as input by resolving to the closest solution (seems like a bad idea)
- Separating 'type' and 'unit' where 'type' can imply whether it is a discrete or continuous unit, a list etc and unit can focus on the actual unit of that type (maybe booleans and enums don't have a unit, I'm not sure about all the use cases here)