### PR TITLE
Rename de/dk scenarios' area_codes

### DIFF
--- a/db/migrate/20250702112742_retire_de_dk_2015.rb
+++ b/db/migrate/20250702112742_retire_de_dk_2015.rb
@@ -1,0 +1,17 @@
+require 'etengine/scenario_migration'
+
+class RetireDeDk2015 < ActiveRecord::Migration[7.1]
+  include ETEngine::ScenarioMigration
+
+  def up
+    migrate_scenarios do |scenario|
+      next unless ['de', 'dk'].include?(scenario.area_code)
+
+      if scenario.area_code == 'de'
+        scenario.area_code = 'DE_germany'
+      elsif scenario.area_code == 'dk'
+        scenario.area_code = 'DK_denmark'
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_19_132450) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_02_112742) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
Simple migration to rename the area codes for de/dk scenarios whose dataset is being retired.

de --> DE_germany
dk --> DK_denmark

Goes with:
- https://github.com/quintel/etsource/pull/3275
- https://github.com/quintel/etdataset/pull/1040
- https://github.com/quintel/etmodel/pull/4518
- https://github.com/quintel/my-etm/pull/145
- https://github.com/quintel/etengine/pull/1598