### PR TITLE
Add nil safety-check for fuel_costs_excluding_electricity

### DIFF
--- a/app/models/qernel/node_api/cost.rb
+++ b/app/models/qernel/node_api/cost.rb
@@ -457,8 +457,10 @@ module Qernel
           node.inputs.sum(0.0) do |slot|
             if slot.carrier.key == :electricity
               0.0
-            else
+            elsif slot.carrier.cost_per_mj && slot.conversion && typical_input
               slot.carrier.cost_per_mj * slot.conversion * typical_input
+            else
+              0.0
             end
           end
         end


### PR DESCRIPTION
This is an attempted fix for #1601 where the costs_parameters.csv doesn't download well because cost_per_mj is nil for:
	•	electricity
	•	network_gas
	•	useable_heat
	•	steam_hot_water
	
in:
```
slot.carrier.cost_per_mj * slot.conversion * typical_input
```

Is it fine to fall back to 0.0 here? This is only meant to apply for carriers with costs_per_mj set, so maybe the bigger issue is a question of why this method is even being called for the incorrect carriers?

Interested to hear if you have some insight into this @noracato - or if you think further investigation is necessary