### PR TITLE
Add migration for FLH change in hydrogen production nodes

### DIFF
--- a/db/migrate/20250804081157_update_reformer_capacity.rb
+++ b/db/migrate/20250804081157_update_reformer_capacity.rb
@@ -1,0 +1,26 @@
+require 'etengine/scenario_migration'
+
+# The full load hours of ammonia reformers and Liquid H2 regasifiers have been updated from 4690 to 7884.
+#
+# This migration scales ammonia reformers and Liquid H2 regasifiers in existing scenarios to account for the change.
+#
+
+class UpdateReformerCapacity < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+
+  def do_migrate()
+    migrate_scenarios do |scenario|
+      if scenario.user_values.key?('capacity_of_energy_hydrogen_lohc_reformer')
+        scenario.user_values['capacity_of_energy_hydrogen_lohc_reformer'] *= (4690.0 / 7884.0)
+      end
+      if scenario.user_values.key?('capacity_of_energy_hydrogen_liquid_hydrogen_regasifier')
+        scenario.user_values['capacity_of_energy_hydrogen_liquid_hydrogen_regasifier'] *= (4690.0 / 7884.0)
+      end
+    end
+  end
+
+  def up
+    do_migrate()
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_22_144555) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_04_081157) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false
@@ -161,6 +161,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_22_144555) do
     t.string "user_email"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "forecast_storage_orders", "scenarios"
   add_foreign_key "heat_network_orders", "scenarios"


### PR DESCRIPTION
This PR adds a migration to accommodate the FLH change of LH2 regasifiers & LOHC reformers in https://github.com/quintel/etsource/pull/3287 & https://github.com/quintel/etdataset/pull/1046. 

Goes together with:
https://github.com/quintel/etdataset/pull/1046
https://github.com/quintel/etsource/pull/3287

