### PR TITLE
Separate the fuel_costs_dispatchable from the fuel_costs

### DIFF
--- a/app/models/qernel/node_api/conversion.rb
+++ b/app/models/qernel/node_api/conversion.rb
@@ -90,8 +90,8 @@ module Qernel
       end
 
       # TODO: This is an extraneous method implemented as a quick fix
-      def fuel_costs_dispatchable_per(unit)
-        convert_to(fuel_costs_dispatchable, unit)
+      def fuel_costs_hourly_electricity_per(unit)
+        convert_to(fuel_costs_hourly_electricity, unit)
       end
 
       def revenue_per(unit)

--- a/app/models/qernel/node_api/conversion.rb
+++ b/app/models/qernel/node_api/conversion.rb
@@ -89,6 +89,11 @@ module Qernel
         convert_to(fuel_costs, unit)
       end
 
+      # TODO: This is an extraneous method implemented as a quick fix
+      def fuel_costs_dispatchable_per(unit)
+        convert_to(fuel_costs_dispatchable, unit)
+      end
+
       def revenue_per(unit)
         convert_to(revenue, unit)
       end

--- a/app/models/qernel/node_api/cost.rb
+++ b/app/models/qernel/node_api/cost.rb
@@ -229,13 +229,14 @@ module Qernel
         end
       end
 
+      # TODO: Added fuel_costs_dispatchable as a quick fix - these fuel costs are not equal to the other fuel_costs
       # Public: The OPEX in €/year produced by a “typical” plant.
       #
       # Returns a float (€)
       def operating_expenses_including_fuel
         fetch(:operating_expenses_including_fuel) do
           operating_expenses + (
-              fuel_costs + (
+              fuel_costs_dispatchable + (
               co2_emissions_costs_per_typical_input +
               captured_biogenic_co2_costs_per_typical_input
               ) * typical_input
@@ -435,6 +436,22 @@ module Qernel
       #
       # Returns the the yearly fuel costs for one single plant.
       def fuel_costs
+        fetch(:fuel_costs) do
+          if typical_input && typical_input < 0
+            raise IllegalNegativeError.new(self, :typical_input, typical_input)
+          end
+          typical_input * weighted_carrier_cost_per_mj
+        end
+      end
+
+      # TODO: This is an extraneous method implemented as a quick fix
+      # Internal: Calculates the fuel costs for a single dispatchable plant
+      #
+      # Based on the input of fuel for one plant and the weighted costs of this / these carrier(s)
+      # per mj.
+      #
+      # Returns the the yearly fuel costs for one single dispatchable plant.
+      def fuel_costs_dispatchable
         fetch(:fuel_costs) do
           if typical_input && typical_input < 0
             raise IllegalNegativeError.new(self, :typical_input, typical_input)

--- a/app/models/qernel/node_api/cost.rb
+++ b/app/models/qernel/node_api/cost.rb
@@ -229,14 +229,14 @@ module Qernel
         end
       end
 
-      # TODO: Added fuel_costs_dispatchable as a quick fix - these fuel costs are not equal to the other fuel_costs
+      # TODO: Added fuel_costs_hourly_electricity as a quick fix - these fuel costs are not equal to the other fuel_costs
       # Public: The OPEX in €/year produced by a “typical” plant.
       #
       # Returns a float (€)
       def operating_expenses_including_fuel
         fetch(:operating_expenses_including_fuel) do
           operating_expenses + (
-              fuel_costs_dispatchable + (
+              fuel_costs_hourly_electricity + (
               co2_emissions_costs_per_typical_input +
               captured_biogenic_co2_costs_per_typical_input
               ) * typical_input
@@ -445,13 +445,13 @@ module Qernel
       end
 
       # TODO: This is an extraneous method implemented as a quick fix
-      # Internal: Calculates the fuel costs for a single dispatchable plant
+      # Internal: Calculates the fuel costs for a single plant, with the electricity costs calculated on an hourly basis
       #
       # Based on the input of fuel for one plant and the weighted costs of this / these carrier(s)
       # per mj.
       #
       # Returns the the yearly fuel costs for one single dispatchable plant.
-      def fuel_costs_dispatchable
+      def fuel_costs_hourly_electricity
         fetch(:fuel_costs) do
           if typical_input && typical_input < 0
             raise IllegalNegativeError.new(self, :typical_input, typical_input)

--- a/spec/models/qernel/node_api/cost_spec.rb
+++ b/spec/models/qernel/node_api/cost_spec.rb
@@ -661,7 +661,7 @@ describe 'Qernel::NodeApi cost calculations' do
     end
   end
 
-  describe '#fuel_costs' do
+  describe '#fuel_costs_dispatchable' do
     context 'with only electricity as input' do
       before do
         node.add_slot(build_slot(node, :useable_heat, :output, 0.9))
@@ -675,7 +675,7 @@ describe 'Qernel::NodeApi cost calculations' do
       end
 
       it 'calculates fuel costs per output' do
-        expect(node.node_api.fuel_costs_per(:mwh_heat)).to eq(400000000.0)
+        expect(node.node_api.fuel_costs_dispatchable_per(:mwh_heat)).to eq(400000000.0)
       end
     end
 
@@ -695,7 +695,7 @@ describe 'Qernel::NodeApi cost calculations' do
       end
 
       it 'calculates fuel costs per output' do
-        expect(node.node_api.fuel_costs_per(:mwh_heat)).to eq(8000.0)
+        expect(node.node_api.fuel_costs_dispatchable_per(:mwh_heat)).to eq(8000.0)
       end
     end
 
@@ -723,7 +723,7 @@ describe 'Qernel::NodeApi cost calculations' do
       end
 
       it 'calculates fuel costs per output' do
-        expect(node.node_api.fuel_costs_per(:mwh_heat)).to eq(24012000.0)
+        expect(node.node_api.fuel_costs_dispatchable_per(:mwh_heat)).to eq(24012000.0)
       end
     end
   end

--- a/spec/models/qernel/node_api/cost_spec.rb
+++ b/spec/models/qernel/node_api/cost_spec.rb
@@ -661,7 +661,7 @@ describe 'Qernel::NodeApi cost calculations' do
     end
   end
 
-  describe '#fuel_costs_dispatchable' do
+  describe '#fuel_costs_hourly_electricity' do
     context 'with only electricity as input' do
       before do
         node.add_slot(build_slot(node, :useable_heat, :output, 0.9))
@@ -675,7 +675,7 @@ describe 'Qernel::NodeApi cost calculations' do
       end
 
       it 'calculates fuel costs per output' do
-        expect(node.node_api.fuel_costs_dispatchable_per(:mwh_heat)).to eq(400000000.0)
+        expect(node.node_api.fuel_costs_hourly_electricity_per(:mwh_heat)).to eq(400000000.0)
       end
     end
 
@@ -695,7 +695,7 @@ describe 'Qernel::NodeApi cost calculations' do
       end
 
       it 'calculates fuel costs per output' do
-        expect(node.node_api.fuel_costs_dispatchable_per(:mwh_heat)).to eq(8000.0)
+        expect(node.node_api.fuel_costs_hourly_electricity_per(:mwh_heat)).to eq(8000.0)
       end
     end
 
@@ -723,7 +723,7 @@ describe 'Qernel::NodeApi cost calculations' do
       end
 
       it 'calculates fuel costs per output' do
-        expect(node.node_api.fuel_costs_dispatchable_per(:mwh_heat)).to eq(24012000.0)
+        expect(node.node_api.fuel_costs_hourly_electricity_per(:mwh_heat)).to eq(24012000.0)
       end
     end
   end


### PR DESCRIPTION
As discussed, the changes required to peel off the fuel costs for dispatchables. Naming is certainly up for discussion. The specs pass and the download downloads 👍.

Closes #1601