### PR TITLE
Add nl2023 dataset

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'ruby-progressbar'
 
 # own gems
 gem 'quintel_merit', ref: '54d2be1', github: 'quintel/merit'
-gem 'atlas',         ref: '8e854b1', github: 'quintel/atlas'
+gem 'atlas',         ref: '267acc8', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: 'c39c9b1', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'ruby-progressbar'
 
 # own gems
 gem 'quintel_merit', ref: '54d2be1', github: 'quintel/merit'
-gem 'atlas',         ref: '267acc8', github: 'quintel/atlas'
+gem 'atlas',         ref: '311b2a6', github: 'quintel/atlas'
 gem 'fever',         ref: '2a91194', github: 'quintel/fever'
 gem 'refinery',      ref: 'c39c9b1', github: 'quintel/refinery'
 gem 'rubel',         ref: 'e36554a', github: 'quintel/rubel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 8e854b122c40dcb1669d990065bbc47f2c1364f6
-  ref: 8e854b1
+  revision: 267acc89ff2c6faf441d017e63a97f657a89b26c
+  ref: 267acc8
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 267acc89ff2c6faf441d017e63a97f657a89b26c
-  ref: 267acc8
+  revision: 311b2a6f7be43e4b57e76963c32316dc84ba39a4
+  ref: 311b2a6
   specs:
     atlas (1.0.0)
       activemodel (>= 7)


### PR DESCRIPTION
This PR makes the changes for the addition of `nl2023`, the dataset for the Netherlands with start year 2023.

Goes with:
- https://github.com/quintel/etmodel/pull/4552
- https://github.com/quintel/etengine/pull/1618
- https://github.com/quintel/etdataset/pull/1043
- https://github.com/quintel/documentation/pull/235
- https://github.com/quintel/etsource/pull/3301
- https://github.com/quintel/atlas/pull/173
- https://github.com/quintel/etlocal/pull/616