### PR TITLE
Add DATASET_CURVE(key) method for GQL lookup

### DIFF
--- a/app/models/gql/runtime/functions/lookup.rb
+++ b/app/models/gql/runtime/functions/lookup.rb
@@ -327,7 +327,7 @@ module Gql::Runtime
       # Returns an array of 8760 numeric values.
       def DATASET_CURVE(key)
         curves = Qernel::Causality::Curves.new(scope.graph, rotate: 0)
-        curves.send(:load_curve, key, nil).to_a
+        curves.curve(key, nil).to_a
       end
     end
   end


### PR DESCRIPTION
Adding this new GQL method allows curves to be loaded from the dataset by key.

The motivation for this change is the p2h project, where the air_temperature needs to be queried for the purposes of adding the chart in that project.

These changes enable GQL queries like:
```
DATASET_CURVE('weather/air_temperature')
DATASET_CURVE('total_demand')
```

The key can be:
  - A curve set path: 'weather/air_temperature', 'solar/pv'
  - A simple profile name: 'total_demand', 'buildings_heating'
  - A user-attached curve

This PR closes #1644. 

There is an additional consideration - This function relies on the causality curves module, and a graph needs to be established to query the curves this way. In the future, we may consider moving this curves module out of Causality so it can be used more generally like for cases like this. I will open an enhancement issue for this 

