### PR TITLE
Fix ScenarioUser coupling bug

### DIFF
--- a/app/models/scenario_user.rb
+++ b/app/models/scenario_user.rb
@@ -16,7 +16,7 @@ class ScenarioUser < ApplicationRecord
   def couple_existing_user
     return unless user_email.present? && user_id.blank?
 
-    couple_to(User.find_by(id: user_id))
+    couple_to(User.find_by(user_email: user_email))
   end
 
   # Couples the record to an existing User.

--- a/spec/models/scenario_user_spec.rb
+++ b/spec/models/scenario_user_spec.rb
@@ -43,6 +43,60 @@ describe ScenarioUser do
     end
   end
 
+  describe '#couple_existing_user' do
+    context 'when a user with the email exists in the system' do
+      let(:existing_user) { create(:user, user_email: 'existing@test.com') }
+      let(:scenario_user) do
+        build(:scenario_user, scenario: scenario, user_email: 'existing@test.com', user_id: nil)
+      end
+
+      before { existing_user }
+
+      it 'couples the scenario_user to the existing user on create' do
+        scenario_user.save!
+        expect(scenario_user.user_id).to eq(existing_user.id)
+      end
+
+      it 'removes the user_email after coupling' do
+        scenario_user.save!
+        expect(scenario_user.user_email).to be_nil
+      end
+    end
+
+    context 'when no user with the email exists' do
+      let(:scenario_user) do
+        build(:scenario_user, scenario: scenario, user_email: 'newuser@test.com', user_id: nil)
+      end
+
+      it 'keeps the user_email' do
+        scenario_user.save!
+        expect(scenario_user.user_email).to eq('newuser@test.com')
+      end
+
+      it 'does not set a user_id' do
+        scenario_user.save!
+        expect(scenario_user.user_id).to be_nil
+      end
+    end
+
+    context 'when user_id is already set' do
+      let(:user) { create(:user) }
+      let(:scenario_user) do
+        build(:scenario_user, scenario: scenario, user_id: user.id, user_email: nil)
+      end
+
+      it 'does not change the user_id' do
+        scenario_user.save!
+        expect(scenario_user.user_id).to eq(user.id)
+      end
+
+      it 'keeps user_email nil' do
+        scenario_user.save!
+        expect(scenario_user.user_email).to be_nil
+      end
+    end
+  end
+
   it 'allows updating the role if not the last scenario owner' do
     # The first user added will automatically become the scenario owner
     scenario.user = create(:user)


### PR DESCRIPTION
This PR:
- Fixed bug in ScenarioUser.couple_existing_user which was looking up by user_id rather than user_email
- Expanded test coverage: added spec covering the user coupling logic more fulsomely

## Motivation:
Users added as collaborators via MyETM were not being properly linked to their accounts in ETEngine. The couple_existing_user hook never actually coupled users because it looked up User.find_by(id: user_id)
  when user_id was nil. This meant:
  - Existing users added by email weren't immediately coupled to their account
  - Collaboration permissions weren't working across MyETM and ETEngine

---

### Testing
Added spec to check:
  - Existing users are automatically coupled when added by email
  - Non-existent users remain pending with user_email set
  - Duplicate user detection works correctly via unique indices
  - User signup triggers automatic coupling of pending ScenarioUser records
  
---

### Open questions:
- Do we want to show pending users (as in, scenario user with email but no id) on the etengine inspect scenario view?

Goes with this [MyETM PR](https://github.com/quintel/my-etm/pull/177)