### PR TITLE
Guard atlas cache cleanup against missing files

### DIFF
--- a/app/models/etsource/atlas_loader.rb
+++ b/app/models/etsource/atlas_loader.rb
@@ -64,7 +64,15 @@ module Etsource
       #
       # Returns nothing.
       def expire_all!
-        Pathname.glob(@directory.join('*.pack')).each(&:delete) if @directory.directory?
+        return unless @directory.directory?
+
+        Pathname.glob(@directory.join('*.pack')).each do |path|
+          begin
+            path.delete
+          rescue => e
+            warn "Failed to delete #{path}: #{e.message}"
+          end
+        end
       end
 
       private


### PR DESCRIPTION
## Description
Previously, the expire_all! method would fail silently if file deletions raised exceptions (e.g., missing files or permission errors). The updated version ensures failures are logged without interrupting the cleanup process.

When the app is started in dev mode, both the web and css/tailwinds processes load the rails environment and call etsource.rb, so Etsource::Dataset::Import.loader.expire_all! is called by both processes. Potentially there is a race condition causing issues with refreshing the cache that the begin/rescue block avoids.

For me at least this solved the problem - would be interested to see if that works in general / for you @aaccensi 

Closes #1658