### PR TITLE
Ensure determinism in merit order node participation

### DIFF
--- a/app/models/qernel/plugins/simple_merit_order.rb
+++ b/app/models/qernel/plugins/simple_merit_order.rb
@@ -140,7 +140,7 @@ module Qernel::Plugins
     def nodes(type, subtype)
       type_data = etsource_data[type.to_s]
 
-      (type_data || {}).map do |key, profile|
+      (type_data || {}).sort_by { |key, _| key }.map do |key, profile|
         node = @graph.node(key)
 
         if !subtype.nil? && @context.node_config(node).subtype != subtype


### PR DESCRIPTION
## Description
This PR fixes non-deterministic calculation results when loading dumped scenarios.

## The Problem
When dumping a scenario from beta and loading it locally (or vice versa), subsequent calculations produce slightly different results - even though the dumped JSON is identical. These differences appear as marginal changes in economic viability metrics for storage technologies.

### Root Cause
The non-determinism originates from cached ETSource data, not from the dump/load serialization process itself.

When you dump/load a scenario:
  - User data (user_values, user_sortables, user_curves) is serialized deterministically
  - ETSource cached data (merit order node structures) is NOT included in the dump
  - Each environment uses its own cached ETSource data during calculation
  - If the cached hash has different insertion order (e.g., beta has old cache, local builds fresh), Merit participants are added in different orders

When participants are processed in different orders, floating-point arithmetic associativity causes accumulated differences:
```
(0.1 + 0.2) + 0.3  # = 0.6000000000000001
 0.1 + (0.2 + 0.3)  # = 0.6
```

My hypothesis is that these tiny per-hour differences compound over thousands of hours, causing the marginal differences seen in #1615.

## Solution

Add .sort_by { |key, _| key } when iterating over cached merit order data in `simple_merit_order.rb`. This ensures iteration is always in sorted key order, regardless of the original hash insertion order in the cache.

### Testing
I cannot fully test this without deploying to beta (to verify the cache ordering fix works in both environments). However, 
  - Local console shows Rails.cache.exist?('merit_order_hash') → false
  - Beta console shows Rails.cache.exist?('merit_order_hash') → true

After deploying, beta's cache should be cleared to rebuild with deterministic ordering and then we can properly test.

Closes #1615