### PR TITLE
Api collections

### DIFF
--- a/app/services/upsert_transition_path.rb
+++ b/app/services/upsert_transition_path.rb
@@ -21,13 +21,35 @@ class UpsertTransitionPath
   # Creates or updates the collection.
   #
   # Returns the collection data from MyETM.
-  def call(params:, client:)
-    result = yield upsert_transition_path(client, params)
+  def call(params:, ability:, client:)
+    scenarios = find_scenarios(ability, params[:scenario_ids])
+    yield validate_scenario_ids(params[:scenario_ids], scenarios)
+
+    result = yield upsert_transition_path(client, full_params(params))
 
     Success(result)
   end
 
   private
+
+  def find_scenarios(ability, ids)
+    Scenario.accessible_by(ability).where(id: ids).order(:end_year) if ids
+  end
+
+  # Verifies that the user has access to all the scenarios. The params themselves will be validated
+  # by MyETM.
+  def validate_scenario_ids(ids, scenarios)
+    return Success() unless ids
+
+    accessible_ids = scenarios.map(&:id)
+
+    if accessible_ids == ids.sort
+      Success(accessible_ids)
+    else
+      missing_ids = ids - accessible_ids
+      Failure(scenario_ids: missing_ids.index_with { |_id| ['does not exist'] })
+    end
+  end
 
   def upsert_transition_path(client, params)
     Success(client.public_send(@method, @endpoint_path, params).body)
@@ -35,5 +57,9 @@ class UpsertTransitionPath
     Failure(e.response[:body]['errors'])
   rescue Faraday::ResourceNotFound
     Failure(ServiceResponse.not_found)
+  end
+
+  def full_params(params)
+    params.merge(version: Settings.version_tag)
   end
 end

--- a/spec/services/upsert_transition_path_spec.rb
+++ b/spec/services/upsert_transition_path_spec.rb
@@ -6,7 +6,19 @@ RSpec.describe UpsertTransitionPath do
   let!(:scenario1) { create(:scenario, end_year: 2040, user: user) }
   let!(:scenario2) { create(:scenario, end_year: 2050, user: user) }
 
+  let(:token) do
+    {
+      iss: Settings.identity.api_url,
+      aud: 'all_clients',
+      sub: 1,
+      exp: 2730367768, # Static expiration
+      scopes: %w[read write]
+    }.with_indifferent_access
+  end
+
   let(:params)  { { scenario_ids: [scenario1.id, scenario2.id], title: 'My transition path' } }
+  let(:ability) { Api::TokenAbility.new(token, user) }
+
   let(:url_base) { Collection.version.collections_url }
   let(:url_slug)  { "#{params[:scenario_ids].join(',')},10" }
   let(:url_query)  { "locale=#{I18n.locale}&title=#{ERB::Util.url_encode(params[:title])}" }
@@ -14,24 +26,31 @@ RSpec.describe UpsertTransitionPath do
   let(:client) do
     Faraday.new do |builder|
       builder.adapter(:test) do |stub|
-        stub.put('/api/v1/collections/123') do
+        request_params = params.merge(
+          version: Settings.version_tag
+        )
+
+        stub.put('/api/v1/collections/123', request_params) do
           [
             200,
             { 'Content-Type' => 'application/json' },
             {
-              'id'                  => 123,
-              'title'               => params[:title],
-              'version'             => 'latest', 
-              'scenario_ids'        => params[:scenario_ids],
-              'saved_scenario_ids'  => [1],
-              'collections_app_url' => "#{:url_base}/#{:url_slug}?#{:url_query}",
-              'created_at'          => '2022-12-21T19:45:09Z',
-              'updated_at'          => '2022-12-22T12:34:50Z',
-              'discarded_at'        => nil,
-              'discarded'           => false,
-              'interpolation'       => true,
-              'interpolation_params'=> { 'area_code' => scenario2.area_code, 'end_years' => [2030, 2040, scenario2.end_year] },
-              'owner'               => { 'id' => user.id, 'name' => user.name }
+              'id'                   => 123,
+              'title'                => params[:title],
+              'version'              => 'latest',
+              'scenario_ids'         => params[:scenario_ids],
+              'saved_scenario_ids'   => [1],
+              'collections_app_url'  => "#{:url_base}/#{:url_slug}?#{:url_query}",
+              'created_at'           => '2022-12-21T19:45:09Z',
+              'updated_at'           => '2022-12-22T12:34:50Z',
+              'discarded_at'         => nil,
+              'discarded'            => false,
+              'owner'                => { 'id' => user.id, 'name' => user.name },
+              'interpolation'        => true,
+              'interpolation_params' => {
+                'area_code' => scenario2.area_code,
+                'end_years' => [2030, 2040, scenario2.end_year]
+              }
             }
           ]
         end
@@ -43,7 +62,7 @@ RSpec.describe UpsertTransitionPath do
     described_class.new(
       endpoint_path: '/api/v1/collections/123',
       method: :put
-    ).call(params:, client:)
+    ).call(params:, ability:, client:)
   end
 
   context 'when given valid params' do
@@ -53,19 +72,22 @@ RSpec.describe UpsertTransitionPath do
 
     it 'returns the transition path data' do
       expect(result.value!).to eq({
-        'id'                  => 123,
-        'title'               => 'My transition path',
-        'version'             => 'latest', 
-        'scenario_ids'        => [scenario1.id, scenario2.id],
-        'saved_scenario_ids'  => [1],
-        'collections_app_url' => "#{:url_base}/#{:url_slug}?#{:url_query}",
-        'created_at'          => '2022-12-21T19:45:09Z',
-        'updated_at'          => '2022-12-22T12:34:50Z',
-        'discarded_at'        => nil,
-        'discarded'           => false,
-        'interpolation'       => true,
-        'interpolation_params'=> { 'area_code' => scenario2.area_code, 'end_years' => [2030, 2040, scenario2.end_year] },
-        'owner'               => { 'id' => user.id, 'name' => user.name }
+        'id'                   => 123,
+        'title'                => 'My transition path',
+        'version'              => 'latest',
+        'scenario_ids'         => [scenario1.id, scenario2.id],
+        'saved_scenario_ids'   => [1],
+        'collections_app_url'  => "#{:url_base}/#{:url_slug}?#{:url_query}",
+        'created_at'           => '2022-12-21T19:45:09Z',
+        'updated_at'           => '2022-12-22T12:34:50Z',
+        'discarded_at'         => nil,
+        'discarded'            => false,
+        'interpolation'        => true,
+        'interpolation_params' => {
+          'area_code' => scenario2.area_code,
+          'end_years' => [2030, 2040, scenario2.end_year]
+        },
+        'owner'                => { 'id' => user.id, 'name' => user.name }
       })
     end
   end
@@ -83,6 +105,22 @@ RSpec.describe UpsertTransitionPath do
 
     it 'returns a Success' do
       expect(result).to be_success
+    end
+  end
+
+  context 'when a scenario is not accessible' do
+    before do
+      scenario1.delete_all_users
+      scenario1.reload.update(user: create(:user))
+      scenario1.reload.update(private: true)
+    end
+
+    it 'returns a Failure' do
+      expect(result).to be_failure
+    end
+
+    it 'returns an error message' do
+      expect(result.failure).to eq(scenario_ids: { scenario1.id => ['does not exist'] })
     end
   end
 


### PR DESCRIPTION
## Description

The create and update collections via the API has been fixed by bringing it closer in concept to a simple pass-thru towards MyETM. Yet a couple of actions are still happening on ETEngine to make the API more friendly:
- We do not need to use the `version` parameter, it can be used but otherwise it is simply defaulted from the settings.
- In the very same manner, the `interpolation` parameter can be used but otherwise it is simply defaulted to false.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #1664
