### PR TITLE
Allow accesstokens from query string from etmodel passthru

### DIFF
--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -48,11 +48,19 @@ module Api
       # Returns the contents of the current token, if an Authorization header is set.
       def token
         return @token if @token
-        return nil if request.authorization.blank?
+        return nil if request.authorization.blank? && access_token_from_query.blank?
 
-        request.authorization.to_s.match(/\ABearer (.+)\z/) do |match|
-          return @token = ETEngine::TokenDecoder.decode(match[1])
+        @token = if request.authorization
+          request.authorization.to_s.match(/\ABearer (.+)\z/) do |match|
+            ETEngine::TokenDecoder.decode(match[1])
+          end
+        else
+          ETEngine::TokenDecoder.decode(access_token_from_query)
         end
+      end
+
+      def access_token_from_query
+        params.permit(:access_token)[:access_token]
       end
 
       # Returns the current user, if a token is set and is valid.


### PR DESCRIPTION
ETModels passthru was sending access tokens in the query string as they can't be set in proper headers. 
But the engine was not picking these up. This caused that result data csvs could not be downloaded for private scenarios in etmodel.


I added an extra clause that will check for a token in the query string.

Notifying @DorinevanderVlies 