### PR TITLE
Fix read_many for scaled inputs scenario updater

### DIFF
--- a/app/models/input/scaled_inputs.rb
+++ b/app/models/input/scaled_inputs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Input
   # An Input::Cache-compatible class which takes the cached values and scaled
   # min, max, and default values to fit a scenario which is scaled by using
@@ -23,5 +25,21 @@ class Input
 
       Scaler.call(input, scenario.scaler, values)
     end
-  end # ScaledInputs
+
+    # Public: Retrieves cached data for multiple inputs at once, with scaling applied.
+    #
+    # See Input::Cache#read_many
+    #
+    # scenario - A scenario with an area code and end year.
+    # inputs   - Array of inputs whose values are to be retrieved.
+    #
+    # Returns a hash of { input_key => cached_data }
+    def read_many(scenario, inputs)
+      inputs.each_with_object({}) do |input, results|
+        key = input.is_a?(Input) ? input.key : input.to_s
+        values = @cache.send(:values_for, input, @gql)
+        results[key] = Scaler.call(input, scenario.scaler, values)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
The new scenario updater did not take into account that Inputs::Cache defers to Input::ScaledInputs in the case of scaled datasets, and thus the `read_many` method implemented in Inputs:Cache was insufficient for the validation flow.

This PR resolves that issue by implementing read_many on ScaledInputs - retrieving cached data for multiple inputs at once, with scaling applied.

**NOTE:**
This issue was missed in both interactive testing and the scenario updater specs, in part because Inputs::Cache and Inputs::ScaledInputs are not currently tested. To thoroughly resolve this issue, we also need to write tests for these submodels, and re-assess if there are any other parts of the scenario update flow that need more robust testing.


Closes #1678 
