### PR TITLE
Migration removing a offshore wind input key

### DIFF
--- a/db/migrate/20260115124236_remove_flh_of_energy_hydrogen_wind_turbine_offshore.rb
+++ b/db/migrate/20260115124236_remove_flh_of_energy_hydrogen_wind_turbine_offshore.rb
@@ -1,0 +1,18 @@
+require 'etengine/scenario_migration'
+
+class RemoveFlhOfEnergyHydrogenWindTurbineOffshore < ActiveRecord::Migration[7.1]
+  include ETEngine::ScenarioMigration
+
+  # Retired key
+  KEY = 'flh_of_energy_hydrogen_wind_turbine_offshore'.freeze
+
+  # As part of setting the FLH of dedicated hydrogen offshore wind with 'regular' offshore wind input is
+  # necessary to remove the input flh_of_energy_hydrogen_wind_turbine_offshore from existing scenarios. 
+  def up
+    migrate_scenarios do |scenario|
+
+      # Check if the key is set, then remove it
+      scenario.user_values.delete(KEY) if scenario.user_values.key?(KEY)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_12_094400) do
+ActiveRecord::Schema[7.1].define(version: 2026_01_15_124236) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
## Description

Migration removing a offshore wind input key as part of the task [MD-72](https://linear.app/quintel-i/issue/MD-72/set-flh-of-dedicated-hydrogen-offshore-wind-with-regular-offshore-wind)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation
- [x] Maintenance

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

References quintel/etsource#3196
