### PR TITLE
Add present year energy_flow data export

### DIFF
--- a/app/controllers/api/v3/export_controller.rb
+++ b/app/controllers/api/v3/export_controller.rb
@@ -17,11 +17,11 @@ module Api
         send_csv(ProductionParametersSerializer.new(@scenario), 'production_parameters.%d.csv')
       end
 
-      # GET /api/v3/scenarios/:id/energy_flow_future
+      # GET /api/v3/scenarios/:id/energy_flow
       #
       # Returns a CSV file containing the energetic inputs and outputs of every node in the future graph.
-      def energy_flow_future
-        send_csv(NodeFlowSerializer.new(@scenario.gql.future.graph, 'MJ'), 'energy_flow_future.%d.csv')
+      def energy_flow
+        send_csv(NodeFlowSerializer.new(@scenario.gql.future.graph, 'MJ'), 'energy_flow.%d.csv')
       end
 
       # GET /api/v3/scenarios/:id/energy_flow_present

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
         member do
           get :batch
           get :production_parameters,   to: 'export#production_parameters'
-          get :energy_flow_future,     to: 'export#energy_flow_future'
+          get :energy_flow,            to: 'export#energy_flow'
           get :energy_flow_present,    to: 'export#energy_flow_present'
           get :molecule_flow,          to: 'export#molecule_flow'
           get :costs_parameters,       to: 'export#costs_parameters'

--- a/spec/controllers/api/v3/exports_controller_spec.rb
+++ b/spec/controllers/api/v3/exports_controller_spec.rb
@@ -7,10 +7,10 @@ describe Api::V3::ExportController do
   let(:user) { create(:user) }
   let(:headers) { access_token_header(user, :write) }
 
-  describe 'GET energy_flow_future.csv' do
+  describe 'GET energy_flow.csv' do
     before do
       request.headers.merge!(headers)
-      get :energy_flow_future, params: { id: scenario.id }, format: :csv
+      get :energy_flow, params: { id: scenario.id }, format: :csv
     end
 
     it 'is successful' do
@@ -22,7 +22,7 @@ describe Api::V3::ExportController do
     end
 
     it 'sets the CSV filename' do
-      expect(response.headers['Content-Disposition']).to include("energy_flow_future.#{scenario.id}.csv")
+      expect(response.headers['Content-Disposition']).to include("energy_flow.#{scenario.id}.csv")
     end
 
     it 'renders the CSV' do


### PR DESCRIPTION
## Description

Add present year energy_flow data export.

This change requires ETEngine and ETmodel changes so is part of a two PR offensive:
- ETEngine: https://github.com/quintel/etengine/pull/1706 [this one]
- ETModel: https://github.com/quintel/etmodel/pull/4648

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

## Related Issues

Closes #1705