### PR TITLE
Migration for dispatchable gas plants and update scheme

### DIFF
--- a/db/migrate/20260407120000_rename_gas_plant_inputs.rb
+++ b/db/migrate/20260407120000_rename_gas_plant_inputs.rb
@@ -1,0 +1,21 @@
+require 'etengine/scenario_migration'
+
+class RenameGasPlantInputs < ActiveRecord::Migration[7.0]
+  include ETEngine::ScenarioMigration
+
+  KEYS = {
+    'capacity_of_energy_power_combined_cycle_network_gas' => 'capacity_of_energy_power_combined_cycle_network_gas_dispatchable',
+    'capacity_of_energy_power_turbine_network_gas' => 'capacity_of_energy_power_turbine_network_gas_dispatchable',
+    'share_of_energy_power_combined_cycle_ccs_network_gas' => 'share_of_energy_power_combined_cycle_ccs_network_gas_dispatchable'
+  }.freeze
+
+  def up
+    migrate_scenarios do |scenario|
+      KEYS.each do |old_key, new_key|
+        if scenario.user_values.key?(old_key)
+          scenario.user_values[new_key] = scenario.user_values.delete(old_key)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_10_091042) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_07_120000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", limit: 191, null: false
     t.string "record_type", limit: 191, null: false


### PR DESCRIPTION
#### Context
For a certain project, the goal is to introduce two must-run gas-fired electricity plants, based on existing dispatchable gas-fired electricity plants. These are the CCGT gas plant and the gas turbine plant.

This means that the current CCGT gas plant and gas turbine plants will be renamed to dispatchable, including all related dependencies. Subsequently, duplicates of both plant types will be created and redefined as must-run.

Initially, this will only be implemented for the future year, meaning that no additional data needs to be read from the dataset.

#### Implemented changes
- Migration (for changed input names)

#### Related
- ETModel: https://github.com/quintel/etmodel/pull/4698
- ETSource: https://github.com/quintel/etsource/pull/3433
- ETEngine: https://github.com/quintel/etengine/pull/1734
- Documentation: https://github.com/quintel/documentation/pull/306
- Mechanical Turk: https://github.com/quintel/mechanical_turk/pull/217
- Multi-year-charts: https://github.com/quintel/multi-year-charts/pull/119
- ETDataset: https://github.com/quintel/etdataset/pull/1083

#### Review
Functional reviewer: @louispt1 
- The following (screenshot) came up during the migration. The migration itself was successful, but it may still need to be checked? 
<img width="490" height="309" alt="image" src="https://github.com/user-attachments/assets/e276dab7-ec48-46e3-b5fe-797174c119d0" />

Also tagging @kndehaan here!

## Checklist
- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review