### PR TITLE
Update power-to-gas in data export

### DIFF
--- a/app/serializers/costs_parameters_serializer.rb
+++ b/app/serializers/costs_parameters_serializer.rb
@@ -350,7 +350,7 @@ class CostsParametersSerializer
   #
   # Has subtotal queries
   def costs_storage_and_conversion
-    %w[p2p p2g p2h storage]
+    %w[p2p electrolysis p2h storage]
   end
 
   # Internal: Carriers for which the costs_carriers group is valid

--- a/app/serializers/production_parameters_serializer.rb
+++ b/app/serializers/production_parameters_serializer.rb
@@ -40,7 +40,7 @@ class ProductionParametersSerializer
       @graph.group_nodes(:electricity_production) +
       @graph.group_nodes(:costs_production_dedicated_hydrogen_production) +
       @graph.group_nodes(:costs_infrastructure_hydrogen) +
-      @graph.group_nodes(:costs_storage_and_conversion_p2g) +
+      @graph.group_nodes(:costs_storage_and_conversion_electrolysis) +
       @graph.group_nodes(:costs_storage_and_conversion_p2h) +
       @graph.group_nodes(:costs_storage_and_conversion_p2p)
     ).uniq.sort_by(&:key)


### PR DESCRIPTION
#### Context
Power-to-gas was not yet renamed in Data export> Specifications Annual costs. 

#### Implemented changes
Rename costs_storage_and_conversion_p2g.

#### Related

Closes issue https://github.com/quintel/etsource/issues/3086

Goes with pull requests: 
- https://github.com/quintel/etmodel/pull/4707
- https://github.com/quintel/etengine/pull/1737
- https://github.com/quintel/documentation/pull/310
- https://github.com/quintel/etsource/pull/3439

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
