### PR TITLE
Add Grafana deploy annotation to production pipeline

### DIFF
--- a/.semaphore/deploy_production.yml
+++ b/.semaphore/deploy_production.yml
@@ -23,8 +23,10 @@ blocks:
             - cache store
             - echo $SSH_FINGERPRINT >> ~/.ssh/known_hosts
             - 'ssh -i ~/.ssh/id_deploy "${SSH_USER}@${SSH_HOST}" -p $SSH_PORT "cd /var/www/etengine && ./deploy.sh"'
+            - curl -s -X POST https://quintel.grafana.net/api/annotations -H "Content-Type: application/json" -H "Authorization: Bearer $GRAFANA_API_TOKEN" -d "{\"text\": \"ETM ${SEMAPHORE_GIT_TAG_NAME:-$SEMAPHORE_GIT_SHA}\", \"tags\": [\"deploy\"]}"
       secrets:
         - name: Docker Hub credentials
         - name: Production SSH settings
+        - name: Grafana credentials
     run:
       when: branch = 'production'


### PR DESCRIPTION
#### Context

We recently instrumented our servers with Grafana. It would be helpful to use Grafana annotatations to visually parse what stats period falls within a specific release.

#### Implemented changes

At the end of the Semaphore deploy task for production, add the corresponding Grafana API call to create an annotation to identify the deploy moment. That should appear in the production dashboard graphs similarly to the following test:

<img width="2249" height="672" alt="image" src="https://github.com/user-attachments/assets/14ca4099-6d2d-48d4-817c-f78b30025510" />

## Checklist

- [x] I have tested these changes (To some extent, I haven't triggered a deploy though)
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
