### PR TITLE
Fix N+1 cache queries in CommitsController#index

### DIFF
--- a/app/controllers/etsource/commits_controller.rb
+++ b/app/controllers/etsource/commits_controller.rb
@@ -160,7 +160,9 @@ class Etsource::CommitsController < ApplicationController
 
   # Returns if an import is currently being performed.
   def import_in_progress?
+    return @import_in_progress unless @import_in_progress.nil?
+
     semaphore = Rails.cache.read(:etsi_semaphore)
-    semaphore && semaphore >= 3.minutes.ago
+    @import_in_progress = semaphore && semaphore >= 3.minutes.ago
   end
 end

--- a/app/models/etsource/commit.rb
+++ b/app/models/etsource/commit.rb
@@ -102,6 +102,10 @@ module Etsource
       @gcommit.sha
     end
 
+    def cache_key
+      "etsource/commit/#{sha}"
+    end
+
     #######
     private
     #######

--- a/app/views/etsource/commits/index.html.haml
+++ b/app/views/etsource/commits/index.html.haml
@@ -46,15 +46,15 @@
           = date.to_formatted_s(:long)
         - latest_sha = @etsource.get_latest_import_sha
         - commits.each do |commit|
-          - cache("etsource.commit.#{ commit.sha }") do
-            .commit{ id: "rev-#{ commit.sha }", class: latest_sha == commit.sha ? 'current' : '' }
-              .action
-                - if latest_sha == commit.sha
-                  .current ✓ &nbsp;Loaded&nbsp;
-                - elsif import_in_progress?
-                  .wait Please wait&hellip;
-                - elsif can_import?
-                  %a.import{ href: import_etsource_commit_path(:id => commit.sha) } Import
-                - else
-                  %span.wait Import disabled
+          .commit{ id: "rev-#{ commit.sha }", class: latest_sha == commit.sha ? 'current' : '' }
+            .action
+              - if latest_sha == commit.sha
+                .current ✓ &nbsp;Loaded&nbsp;
+              - elsif import_in_progress?
+                .wait Please wait&hellip;
+              - elsif can_import?
+                %a.import{ href: import_etsource_commit_path(:id => commit.sha) } Import
+              - else
+                %span.wait Import disabled
+            - cache(commit) do
               = render partial: 'commit', locals: { commit: commit.gcommit }


### PR DESCRIPTION
#### Context

The commits index page (/etsource/commits) is triggering N+1 Queries since moving to Solid Cache which made apparent that the caching was not optimal. Whether we move back to Memcache or stay in Solid Cache an optimization is warranted so the fix implemented is cache-backend agnostic.

#### Implemented changes

Two fixes:
- Memoize the etsi_semaphore result in `import_in_progress?` so it is
read from cache once per request instead of once per commit.
- Move action buttons outside the fragment cache block (they depend on
runtime state and should not be cached) and cache only the _commit
partial, which renders static git data that never changes. For this we also added the rails standard method
`cache_key` to `Etsource::Commit` to support `cache(commit)` in the view.

#### Related

Closes #1743

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
