### PR TITLE
Use NastyCache for MeritOrder and Molecules to reduce cache round-trips

### DIFF
--- a/app/models/etsource/merit_order.rb
+++ b/app/models/etsource/merit_order.rb
@@ -1,5 +1,14 @@
 module Etsource
   class MeritOrder
+    CACHE_ATTRIBUTES = %i[
+      merit_order
+      hydrogen
+      heat_network_lt
+      heat_network_mt
+      heat_network_ht
+      agriculture_heat
+    ].freeze
+
     def initialize(etsource = Etsource::Base.instance)
       @etsource = etsource
     end
@@ -84,21 +93,35 @@ module Etsource
     #
     # Returns a hash.
     def import(attribute)
-      Rails.cache.fetch("#{attribute}_hash") do
-        mo_nodes = Atlas::EnergyNode.all.select(&attribute).sort_by(&:key)
-        mo_data  = {}
+      merit_order_cache[attribute]
+    end
 
-        mo_nodes.each do |node|
-          config = node.public_send(attribute)
-          type   = config.type.to_s
-          group  = config.group&.to_s
+    # Batches all MeritOrder cache reads into one SQL query per request, so
+    # subsequent fetch calls hit the LocalStore instead of the database.
+    def merit_order_cache
+      Thread.current[:merit_order_cache] ||= begin
+        cache_attr_by_key = CACHE_ATTRIBUTES.index_by { |a| "#{a}_hash" }
 
-          mo_data[type] ||= {}
-          mo_data[type][node.key.to_s] = group
-        end
-
-        mo_data
+        Rails.cache.fetch_multi(*cache_attr_by_key.keys) do |cache_key|
+          compute(cache_attr_by_key[cache_key])
+        end.transform_keys { |k| cache_attr_by_key[k] }
       end
+    end
+
+    def compute(attribute)
+      mo_nodes = Atlas::EnergyNode.all.select(&attribute).sort_by(&:key)
+      mo_data  = {}
+
+      mo_nodes.each do |node|
+        config = node.public_send(attribute)
+        type   = config.type.to_s
+        group  = config.group&.to_s
+
+        mo_data[type] ||= {}
+        mo_data[type][node.key.to_s] = group
+      end
+
+      mo_data
     end
   end
 end

--- a/app/models/etsource/merit_order.rb
+++ b/app/models/etsource/merit_order.rb
@@ -1,18 +1,5 @@
 module Etsource
   class MeritOrder
-    class << self
-      attr_accessor :cache
-    end
-
-    CACHE_ATTRIBUTES = %i[
-      merit_order
-      hydrogen
-      heat_network_lt
-      heat_network_mt
-      heat_network_ht
-      agriculture_heat
-    ].freeze
-
     def initialize(etsource = Etsource::Base.instance)
       @etsource = etsource
     end
@@ -97,39 +84,21 @@ module Etsource
     #
     # Returns a hash.
     def import(attribute)
-      merit_order_cache[attribute]
-    end
+      NastyCache.instance.fetch("#{attribute}_hash") do
+        mo_nodes = Atlas::EnergyNode.all.select(&attribute).sort_by(&:key)
+        mo_data  = {}
 
-    def self.reset_cache!
-      self.cache = nil
-    end
+        mo_nodes.each do |node|
+          config = node.public_send(attribute)
+          type   = config.type.to_s
+          group  = config.group&.to_s
 
-    # Batches all MeritOrder cache reads into one SQL query per request, so
-    # subsequent fetch calls are served from memory instead of the database.
-    def merit_order_cache
-      self.class.cache ||= begin
-        cache_attr_by_key = CACHE_ATTRIBUTES.index_by { |a| "#{a}_hash" }
+          mo_data[type] ||= {}
+          mo_data[type][node.key.to_s] = group
+        end
 
-        Rails.cache.fetch_multi(*cache_attr_by_key.keys) do |cache_key|
-          compute(cache_attr_by_key[cache_key])
-        end.transform_keys { |k| cache_attr_by_key[k] }
+        mo_data
       end
-    end
-
-    def compute(attribute)
-      mo_nodes = Atlas::EnergyNode.all.select(&attribute).sort_by(&:key)
-      mo_data  = {}
-
-      mo_nodes.each do |node|
-        config = node.public_send(attribute)
-        type   = config.type.to_s
-        group  = config.group&.to_s
-
-        mo_data[type] ||= {}
-        mo_data[type][node.key.to_s] = group
-      end
-
-      mo_data
     end
   end
 end

--- a/app/models/etsource/merit_order.rb
+++ b/app/models/etsource/merit_order.rb
@@ -1,5 +1,9 @@
 module Etsource
   class MeritOrder
+    class << self
+      attr_accessor :cache
+    end
+
     CACHE_ATTRIBUTES = %i[
       merit_order
       hydrogen
@@ -96,10 +100,14 @@ module Etsource
       merit_order_cache[attribute]
     end
 
+    def self.reset_cache!
+      self.cache = nil
+    end
+
     # Batches all MeritOrder cache reads into one SQL query per request, so
-    # subsequent fetch calls hit the LocalStore instead of the database.
+    # subsequent fetch calls are served from memory instead of the database.
     def merit_order_cache
-      Thread.current[:merit_order_cache] ||= begin
+      self.class.cache ||= begin
         cache_attr_by_key = CACHE_ATTRIBUTES.index_by { |a| "#{a}_hash" }
 
         Rails.cache.fetch_multi(*cache_attr_by_key.keys) do |cache_key|

--- a/app/models/etsource/molecules.rb
+++ b/app/models/etsource/molecules.rb
@@ -3,11 +3,6 @@
 module Etsource
   # Loads data relating to the calculation of molecule flows based on the energy graph.
   module Molecules
-    CACHE_KEYS = %w[
-      molecules.from_energy_keys
-      molecules.from_molecules_keys
-    ].freeze
-
     module_function
 
     # Internal: Computes the list of molecule graph nodes which have a molecule_conversion
@@ -17,7 +12,9 @@ module Etsource
     #
     # Returns an Array of Symbols.
     def from_energy_keys
-      molecule_cache['molecules.from_energy_keys']
+      NastyCache.instance.fetch('molecules.from_energy_keys') do
+        Atlas::MoleculeNode.all.select(&:from_energy).map(&:key).sort
+      end
     end
 
     # Internal: Computes the list of molecule graph nodes which have a molecule_conversion
@@ -27,21 +24,8 @@ module Etsource
     #
     # Returns an Array of Symbols.
     def from_molecules_keys
-      molecule_cache['molecules.from_molecules_keys']
-    end
-
-    def reset_cache!
-      @molecule_cache = nil
-    end
-
-    # Batches all Molecules cache reads into one SQL query per request, so
-    # subsequent fetch calls are served from memory instead of the database.
-    def molecule_cache
-      @molecule_cache ||= Rails.cache.fetch_multi(*CACHE_KEYS) do |key|
-        case key
-        when 'molecules.from_energy_keys'    then Atlas::MoleculeNode.all.select(&:from_energy).map(&:key).sort
-        when 'molecules.from_molecules_keys' then Atlas::EnergyNode.all.select(&:from_molecules).map(&:key).sort
-        end
+      NastyCache.instance.fetch('molecules.from_molecules_keys') do
+        Atlas::EnergyNode.all.select(&:from_molecules).map(&:key).sort
       end
     end
   end

--- a/app/models/etsource/molecules.rb
+++ b/app/models/etsource/molecules.rb
@@ -30,10 +30,14 @@ module Etsource
       molecule_cache['molecules.from_molecules_keys']
     end
 
+    def reset_cache!
+      @molecule_cache = nil
+    end
+
     # Batches all Molecules cache reads into one SQL query per request, so
-    # subsequent fetch calls hit the LocalStore instead of the database.
+    # subsequent fetch calls are served from memory instead of the database.
     def molecule_cache
-      Thread.current[:molecule_cache] ||= Rails.cache.fetch_multi(*CACHE_KEYS) do |key|
+      @molecule_cache ||= Rails.cache.fetch_multi(*CACHE_KEYS) do |key|
         case key
         when 'molecules.from_energy_keys'    then Atlas::MoleculeNode.all.select(&:from_energy).map(&:key).sort
         when 'molecules.from_molecules_keys' then Atlas::EnergyNode.all.select(&:from_molecules).map(&:key).sort

--- a/app/models/etsource/molecules.rb
+++ b/app/models/etsource/molecules.rb
@@ -3,6 +3,11 @@
 module Etsource
   # Loads data relating to the calculation of molecule flows based on the energy graph.
   module Molecules
+    CACHE_KEYS = %w[
+      molecules.from_energy_keys
+      molecules.from_molecules_keys
+    ].freeze
+
     module_function
 
     # Internal: Computes the list of molecule graph nodes which have a molecule_conversion
@@ -12,9 +17,7 @@ module Etsource
     #
     # Returns an Array of Symbols.
     def from_energy_keys
-      Rails.cache.fetch('molecules.from_energy_keys') do
-        Atlas::MoleculeNode.all.select(&:from_energy).map(&:key).sort
-      end
+      molecule_cache['molecules.from_energy_keys']
     end
 
     # Internal: Computes the list of molecule graph nodes which have a molecule_conversion
@@ -24,8 +27,17 @@ module Etsource
     #
     # Returns an Array of Symbols.
     def from_molecules_keys
-      Rails.cache.fetch('molecules.from_molecules_keys') do
-        Atlas::EnergyNode.all.select(&:from_molecules).map(&:key).sort
+      molecule_cache['molecules.from_molecules_keys']
+    end
+
+    # Batches all Molecules cache reads into one SQL query per request, so
+    # subsequent fetch calls hit the LocalStore instead of the database.
+    def molecule_cache
+      Thread.current[:molecule_cache] ||= Rails.cache.fetch_multi(*CACHE_KEYS) do |key|
+        case key
+        when 'molecules.from_energy_keys'    then Atlas::MoleculeNode.all.select(&:from_energy).map(&:key).sort
+        when 'molecules.from_molecules_keys' then Atlas::EnergyNode.all.select(&:from_molecules).map(&:key).sort
+        end
       end
     end
   end

--- a/app/models/nasty_cache.rb
+++ b/app/models/nasty_cache.rb
@@ -145,6 +145,11 @@ class NastyCache
     Merit::Curve.reader = Merit::Curve.reader.class.new
 
     @cache_store = {}
+
+    # Reset process-level memoization so the next request re-fetches from
+    # Rails.cache, which has just been cleared by expire_cache!
+    Etsource::MeritOrder.reset_cache!
+    Etsource::Molecules.reset_cache!
   end
 
   def expire_atlas!(options)

--- a/app/models/nasty_cache.rb
+++ b/app/models/nasty_cache.rb
@@ -145,11 +145,6 @@ class NastyCache
     Merit::Curve.reader = Merit::Curve.reader.class.new
 
     @cache_store = {}
-
-    # Reset process-level memoization so the next request re-fetches from
-    # Rails.cache, which has just been cleared by expire_cache!
-    Etsource::MeritOrder.reset_cache!
-    Etsource::Molecules.reset_cache!
   end
 
   def expire_atlas!(options)


### PR DESCRIPTION
#### Context

Since adopting Solid Cache, several controller actions that trigger a GQL calculation are flagged by Sentry as N+1 queries. This was not visible before because Memcached round-trips are cheap; with Solid Cache every cache operation is a SQL query.

#### Implemented changes

`MeritOrder` and `Molecules` previously used `Rails.cache.fetch` on every access. Since this data is purely derived from ETSource and never changes between imports, it is a better fit for `NastyCache`, which stores values in process memory and avoids a cache round-trip on every access.

`NastyCache` already handles invalidation correctly across all Puma workers: on ETSource import, `expire_local!` clears `@cache_store` on the importing process and `mark_expired!` writes a new timestamp to `Rails.cache`. Every other process detects the timestamp change on its next request via `initialize_request` and clears its own store.

#### Related

Closes quintel/etengine#1747

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [X] I have tagged the relevant people for review