### PR TITLE
Block crawlers from the inspect pages and handle missing datasets by redirecting

### DIFF
--- a/app/controllers/inspect/gqueries_controller.rb
+++ b/app/controllers/inspect/gqueries_controller.rb
@@ -21,6 +21,9 @@ class Inspect::GqueriesController < Inspect::BaseController
         @result = @gql.query(params[:query].gsub(/\s/,''), nil, true)
       rescue Gql::CommandError => ex
         @error = ex
+      rescue Inspect::LazyGql::DatasetNotFoundError => e
+        flash[:error] = "This scenario uses an unsupported dataset (#{@api_scenario.area_code}). Please create a new scenario."
+        redirect_to inspect_root_path(api_scenario_id: '_')
       end
     end
   end
@@ -29,6 +32,9 @@ class Inspect::GqueriesController < Inspect::BaseController
     @result = @gql.query(@gquery, nil, true)
   rescue Gql::CommandError => e
     @error = e
+  rescue Inspect::LazyGql::DatasetNotFoundError => e
+    flash[:error] = "This scenario uses an unsupported dataset (#{@api_scenario.area_code}). Please create a new scenario."
+    redirect_to inspect_root_path(api_scenario_id: '_')
   end
 
   def result

--- a/app/controllers/inspect/lazy_gql.rb
+++ b/app/controllers/inspect/lazy_gql.rb
@@ -3,18 +3,30 @@ module Inspect
   #
   # Prevents calculating a scenario when it isn't needed.
   class LazyGql
+    class DatasetNotFoundError < StandardError; end
+
     def initialize(scenario)
       @scenario = scenario
       @gql = nil
     end
 
     def method_missing(name, *args, &block)
-      @gql ||= @scenario.gql(prepare: true)
+      @gql ||= initialize_gql
       @gql.public_send(name, *args, &block)
     end
 
     def respond_to_missing?(method_name)
       Gql::Gql.public_instance_methods.include?(method_name)
+    end
+
+    private
+
+    def initialize_gql
+      @scenario.gql(prepare: true)
+    rescue Atlas::DocumentNotFoundError => e
+      raise e unless e.message.match?(/could not find a dataset with the key/i)
+
+      raise DatasetNotFoundError, "Dataset '#{@scenario.area_code}' not found for scenario #{@scenario.id}"
     end
   end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,6 +9,7 @@
         = content_for(:title)
         \-
       EnergyTransitionModel
+    %meta{name: 'robots', content: 'noindex, nofollow'}
     = csrf_meta_tag
     = javascript_include_tag 'application'
     = stylesheet_link_tag 'application'

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,7 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-Agent: *
 # Disallow: /
+
+# Block crawlers from internal inspect/admin pages
+User-agent: *
+Disallow: /inspect/


### PR DESCRIPTION
#### Context
See [the issue](https://github.com/quintel/etengine/issues/1749) - the high http error rate warning on Grafana is being triggered often, likely due to webcrawlers accessing a scenario with area code "de", triggering the error:
`Atlas::DocumentNotFoundError (Could not find a dataset with the key "de")  `

#### Implemented changes
- Modified lazy_gql and gqueries controller to handle the Atlas::DocumentNotFoundError more gracefully, raise a relevant exception when a dataset is not found and redirect to the home of the inspect controller. The error should not bubble up to the Grafana/Sentry level now, and scenario/user retention policy should handle the outdated scenarios in the future.
- Modified robots.txt and application.html to block webcrawlers from indexing the inspect pages or accessing any inspect paths. There's no benefit I can see from allowing webcrawlers to access these pages.

#### Related
Closes #1749 
