### PR TITLE
Block crawlers from the inspect pages and handle missing datasets 

### DIFF
--- a/app/controllers/api/v3/curves_controller.rb
+++ b/app/controllers/api/v3/curves_controller.rb
@@ -6,9 +6,7 @@ module Api
         render json: { errors: ['Scenario not found'] }, status: 404
       end
 
-      rescue_from Atlas::DocumentNotFoundError do |e|
-        raise(e) unless e.message.start_with?('Could not find a dataset')
-
+      rescue_from Etsource::DatasetNotFoundError do
         render(
           json: { errors: [
             'Scenario uses an unsupported area code and is no longer available: ' \
@@ -33,7 +31,7 @@ module Api
       # Downloads the hourly price of electricity according to the merit order.
       #
       # GET /api/v3/scenarios/:scenario_id/curves/electricity_price.csv
-      # GET /api/v3/scenarios/:scenario_id/curves/electricity_price.json 
+      # GET /api/v3/scenarios/:scenario_id/curves/electricity_price.json
       def electricity_price
         result = CarrierPriceCSVSerializer.new(
           @scenario.gql.future_graph.carrier(:electricity),

--- a/app/controllers/inspect/base_controller.rb
+++ b/app/controllers/inspect/base_controller.rb
@@ -6,6 +6,8 @@ class Inspect::BaseController < ApplicationController
 
   authorize_resource :class => false
 
+  rescue_from Inspect::LazyGql::DatasetNotFoundError, with: :handle_missing_dataset
+
   def redirect
     redirect_to inspect_root_path(:api_scenario_id => params[:api_scenario_id])
   end
@@ -33,5 +35,15 @@ class Inspect::BaseController < ApplicationController
     )
 
     redirect_to url_for(api_scenario_id: scenario.id)
+  end
+
+  # Handles scenarios with missing/unsupported datasets by redirecting to a new scenario
+  def handle_missing_dataset(exception)
+    Rails.logger.info(
+      "Scenario #{@api_scenario&.id} uses unsupported dataset '#{@api_scenario&.area_code}': #{exception.message}"
+    )
+
+    flash[:error] = "This scenario uses an unsupported dataset (#{@api_scenario&.area_code}). Please create a new scenario."
+    redirect_to inspect_root_path(api_scenario_id: '_')
   end
 end

--- a/app/controllers/inspect/base_controller.rb
+++ b/app/controllers/inspect/base_controller.rb
@@ -21,10 +21,6 @@ class Inspect::BaseController < ApplicationController
 
     @api_scenario = Scenario.find_for_calculation(params[:api_scenario_id])
     @gql = Inspect::LazyGql.new(@api_scenario)
-  rescue Atlas::DocumentNotFoundError => e
-    raise e unless e.message.match?(/could not find a dataset with the key/i)
-
-    start_scenario_and_redirect
   end
 
   # Starts a new scenario and redirects the user to their requested page for the

--- a/app/controllers/inspect/lazy_gql.rb
+++ b/app/controllers/inspect/lazy_gql.rb
@@ -3,18 +3,36 @@ module Inspect
   #
   # Prevents calculating a scenario when it isn't needed.
   class LazyGql
+    class DatasetNotFoundError < StandardError; end
+
     def initialize(scenario)
       @scenario = scenario
       @gql = nil
     end
 
     def method_missing(name, *args, &block)
-      @gql ||= @scenario.gql(prepare: true)
+      @gql ||= initialize_gql
       @gql.public_send(name, *args, &block)
     end
 
-    def respond_to_missing?(method_name)
-      Gql::Gql.public_instance_methods.include?(method_name)
+    def respond_to_missing?(method_name, include_private = false)
+      Gql::Gql.public_instance_methods.include?(method_name) || super
+    end
+
+    private
+
+    def initialize_gql
+      @scenario.gql(prepare: true)
+    rescue Atlas::DocumentNotFoundError, RuntimeError => e
+      raise e unless dataset_not_found_error?(e)
+
+      raise DatasetNotFoundError, "Dataset '#{@scenario.area_code}' not found for scenario #{@scenario.id}"
+    end
+
+    def dataset_not_found_error?(error)
+      error.message.match?(/could not find a dataset with the key/i) ||
+        error.message.match?(/no atlas data for/i) ||
+        (error.message.include?('dataset') && error.message.include?(@scenario.area_code))
     end
   end
 end

--- a/app/controllers/inspect/lazy_gql.rb
+++ b/app/controllers/inspect/lazy_gql.rb
@@ -23,16 +23,8 @@ module Inspect
 
     def initialize_gql
       @scenario.gql(prepare: true)
-    rescue Atlas::DocumentNotFoundError, RuntimeError => e
-      raise e unless dataset_not_found_error?(e)
-
+    rescue Etsource::DatasetNotFoundError
       raise DatasetNotFoundError, "Dataset '#{@scenario.area_code}' not found for scenario #{@scenario.id}"
-    end
-
-    def dataset_not_found_error?(error)
-      error.message.match?(/could not find a dataset with the key/i) ||
-        error.message.match?(/no atlas data for/i) ||
-        (error.message.include?('dataset') && error.message.include?(@scenario.area_code))
     end
   end
 end

--- a/app/models/etsource.rb
+++ b/app/models/etsource.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Etsource
+  # Raised when a dataset cannot be found in ETSource.
+  #
+  # This error is raised when attempting to load a dataset that doesn't exist,
+  # either because the Atlas dataset key is invalid or the .pack file is missing.
+  class DatasetNotFoundError < StandardError
+    attr_reader :dataset_key
+
+    def initialize(dataset_key, message = nil)
+      @dataset_key = dataset_key
+      super(message || "Dataset '#{dataset_key}' not found in ETSource")
+    end
+  end
+end

--- a/app/models/etsource/atlas_loader.rb
+++ b/app/models/etsource/atlas_loader.rb
@@ -28,7 +28,12 @@ module Etsource
       def load(dataset_key)
         location = data_path(dataset_key)
 
-        raise "No Atlas data for #{dataset_key.inspect} at #{location}" unless location.file?
+        unless location.file?
+          raise Etsource::DatasetNotFoundError.new(
+            dataset_key,
+            "No Atlas data for #{dataset_key.inspect} at #{location}"
+          )
+        end
 
         Atlas::ProductionMode.new(parse(location.read))
       end
@@ -47,7 +52,12 @@ module Etsource
       # Returns nothing.
       def calculate!(dataset_key)
         instrument("etsource.loader: atlas+ref(#{dataset_key.inspect})") do
-          dataset = Atlas::Dataset.find(dataset_key)
+          begin
+            dataset = Atlas::Dataset.find(dataset_key)
+          rescue Atlas::DocumentNotFoundError
+            raise Etsource::DatasetNotFoundError.new(dataset_key)
+          end
+
           runner  = Atlas::Runner.new(dataset)
 
           runner.calculate

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,6 +9,7 @@
         = content_for(:title)
         \-
       EnergyTransitionModel
+    %meta{name: 'robots', content: 'noindex, nofollow'}
     = csrf_meta_tag
     = javascript_include_tag 'application'
     = stylesheet_link_tag 'application'

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,7 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-Agent: *
 # Disallow: /
+
+# Block crawlers from internal inspect/admin pages
+User-agent: *
+Disallow: /inspect/

--- a/spec/controllers/inspect/gqueries_controller_spec.rb
+++ b/spec/controllers/inspect/gqueries_controller_spec.rb
@@ -56,5 +56,30 @@ describe Inspect::GqueriesController, :etsource_fixture do
         expect(response).to render_template(:show)
       end
     end
+
+    context 'when scenario has an unsupported dataset' do
+      let(:scenario_with_invalid_dataset) do
+        scenario = FactoryBot.create(:scenario, user: owner)
+        scenario.update_column(:area_code, 'de')
+        scenario
+      end
+
+      before do
+        # Mock the LazyGql to raise DatasetNotFoundError
+        allow_any_instance_of(Inspect::LazyGql).to receive(:query).and_raise(
+          Inspect::LazyGql::DatasetNotFoundError.new("Dataset 'de' not found for scenario #{scenario_with_invalid_dataset.id}")
+        )
+      end
+
+      it "redirects to new scenario with error message" do
+        request.headers.merge!(access_token_header(owner, :read))
+        get :show, params: { id: gquery.key, api_scenario_id: scenario_with_invalid_dataset.id }
+
+        expect(response).to redirect_to(inspect_root_path(api_scenario_id: '_'))
+        expect(flash[:error]).to match(/unsupported dataset/)
+        expect(flash[:error]).to include('de')
+      end
+    end
   end
+
 end

--- a/spec/controllers/inspect/lazy_gql_spec.rb
+++ b/spec/controllers/inspect/lazy_gql_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Inspect::LazyGql, :etsource_fixture do
+  let(:scenario) { FactoryBot.create(:scenario) }
+
+  describe '#method_missing' do
+    context 'when the dataset exists' do
+      it 'initializes GQL and forwards method calls' do
+        lazy_gql = Inspect::LazyGql.new(scenario)
+
+        expect(scenario).to receive(:gql).with(prepare: true).and_call_original
+        expect(lazy_gql.present_graph).to be_a(Qernel::Graph)
+      end
+
+      it 'only initializes GQL once' do
+        lazy_gql = Inspect::LazyGql.new(scenario)
+
+        expect(scenario).to receive(:gql).once.with(prepare: true).and_call_original
+
+        lazy_gql.present_graph
+        lazy_gql.future_graph
+      end
+    end
+
+    context 'when the dataset does not exist' do
+      let(:scenario_with_invalid_dataset) do
+        # Create scenario normally, then update area_code to bypass validation
+        scenario = FactoryBot.create(:scenario)
+        scenario.update_column(:area_code, 'de')
+        scenario
+      end
+
+      it 'raises DatasetNotFoundError' do
+        lazy_gql = Inspect::LazyGql.new(scenario_with_invalid_dataset)
+
+        expect do
+          lazy_gql.present_graph
+        end.to raise_error(Inspect::LazyGql::DatasetNotFoundError, /de/)
+      end
+
+      it 'includes scenario ID in error message' do
+        lazy_gql = Inspect::LazyGql.new(scenario_with_invalid_dataset)
+
+        expect do
+          lazy_gql.present_graph
+        end.to raise_error(Inspect::LazyGql::DatasetNotFoundError, /scenario #{scenario_with_invalid_dataset.id}/)
+      end
+    end
+
+    context 'when Atlas raises a non-dataset error' do
+      it 're-raises the original error' do
+        lazy_gql = Inspect::LazyGql.new(scenario)
+
+        allow(scenario).to receive(:gql).and_raise(
+          Atlas::DocumentNotFoundError.new('Could not find a gquery with the key "test"')
+        )
+
+        expect do
+          lazy_gql.present_graph
+        end.to raise_error(Atlas::DocumentNotFoundError, /gquery/)
+      end
+    end
+  end
+
+  describe '#respond_to_missing?' do
+    it 'responds to Gql::Gql public instance methods' do
+      lazy_gql = Inspect::LazyGql.new(scenario)
+
+      expect(lazy_gql.respond_to?(:present_graph)).to be true
+      expect(lazy_gql.respond_to?(:future_graph)).to be true
+      expect(lazy_gql.respond_to?(:query)).to be true
+    end
+
+    it 'does not respond to non-GQL methods' do
+      lazy_gql = Inspect::LazyGql.new(scenario)
+
+      expect(lazy_gql.respond_to?(:nonexistent_method)).to be false
+    end
+  end
+end

--- a/spec/models/etsource/atlas_loader_spec.rb
+++ b/spec/models/etsource/atlas_loader_spec.rb
@@ -67,7 +67,7 @@ module Etsource
 
         it 'raises an error when no such region exists' do
           expect { loader.load(:nope) }.
-            to raise_error(Atlas::DocumentNotFoundError)
+            to raise_error(Etsource::DatasetNotFoundError)
         end
       end # loading a dataset
     end # AtlasLoader::PreCalculated


### PR DESCRIPTION
#### Context
See [the issue](https://github.com/quintel/etengine/issues/1749) - the high http error rate warning on Grafana is being triggered often, likely due to webcrawlers accessing a scenario with area code "de", triggering the error:
`Atlas::DocumentNotFoundError (Could not find a dataset with the key "de")  `

#### Implemented changes
- Modified lazy_gql and gqueries controller to handle the Atlas::DocumentNotFoundError more gracefully, raise a relevant exception when a dataset is not found and redirect to the home of the inspect controller. The error should not bubble up to the Grafana/Sentry level now, and scenario/user retention policy should handle the outdated scenarios in the future.
- Modified robots.txt and application.html to block webcrawlers from indexing the inspect pages or accessing any inspect paths. There's no benefit I can see from allowing webcrawlers to access these pages.

#### Related
Closes #1749 
