### PR TITLE
Discard passthrough

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
@@ -192,7 +192,10 @@ Rails/UnknownEnv:
     - test
 
 # Don't require methods to be in separate spec files.
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/SpecFilePathSuffix:
   Enabled: false
 
 RSpec/ExampleLength:

--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -88,6 +88,7 @@ module Api
       def my_etm_client
         Faraday.new(url: Settings.identity.issuer) do |conn|
           conn.response(:json)
+          conn.response(:raise_error)
           conn.request(:json)
 
           if (auth_header = request.authorization.to_s[/\ABearer (.+)\z/, 1])

--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module V3
     class BaseController < ActionController::API

--- a/app/controllers/api/v3/collections_controller.rb
+++ b/app/controllers/api/v3/collections_controller.rb
@@ -25,6 +25,10 @@ module Api
         query = { page: params[:page], limit: params[:limit] }.compact.to_query
         response = my_etm_client.get("/api/v1/collections?#{query}")
         render json: response.body
+      rescue Faraday::ResourceNotFound
+        render_not_found
+      rescue Faraday::Error => e
+        handle_faraday_error(e)
       end
 
       def show
@@ -89,6 +93,18 @@ module Api
           render failure.to_response
         else
           render json: { errors: failure }, status: :unprocessable_content
+        end
+      end
+
+      def handle_faraday_error(error)
+        if error.response
+          status = error.response[:status]
+          body = error.response[:body]
+
+          render json: body, status:
+        else
+          render json: { errors: ['Failed to connect to MyETM'] },
+            status: :service_unavailable
         end
       end
 

--- a/app/controllers/api/v3/saved_scenarios_controller.rb
+++ b/app/controllers/api/v3/saved_scenarios_controller.rb
@@ -73,6 +73,18 @@ module Api
         render_not_found
       end
 
+      def discard
+        DiscardSavedScenario.new.call(
+          id: params.require(:id),
+          client: my_etm_client
+        ).either(
+          ->((data, *)) { render json: data },
+          ->(error)     { service_error_response(error) }
+        )
+      rescue Faraday::ResourceNotFound
+        render_not_found
+      end
+
       private
 
       def hydrate_scenarios(saved_scenarios)

--- a/app/controllers/api/v3/saved_scenarios_controller.rb
+++ b/app/controllers/api/v3/saved_scenarios_controller.rb
@@ -29,6 +29,10 @@ module Api
           data: hydrate_scenarios(data),
           links: {}
         }
+      rescue Faraday::ResourceNotFound
+        render_not_found
+      rescue Faraday::Error => e
+        handle_faraday_error(e)
       end
 
       def show
@@ -138,6 +142,18 @@ module Api
           render failure.to_response
         else
           render json: { errors: failure }, status: :unprocessable_content
+        end
+      end
+
+      def handle_faraday_error(error)
+        if error.response
+          status = error.response[:status]
+          body = error.response[:body]
+
+          render json: body, status:
+        else
+          render json: { errors: ['Failed to connect to MyETM'] },
+            status: :service_unavailable
         end
       end
     end

--- a/app/controllers/api/v3/saved_scenarios_controller.rb
+++ b/app/controllers/api/v3/saved_scenarios_controller.rb
@@ -15,6 +15,10 @@ module Api
         authorize!(:update, Scenario)
       end
 
+      before_action(only: %i[discard]) do
+        authorize!(:destroy, Scenario)
+      end
+
       def index
         query    = { page: params[:page], limit: params[:limit] }.compact.to_query
         response = my_etm_client.get("/api/v1/saved_scenarios?#{query}")
@@ -92,7 +96,7 @@ module Api
 
         scenarios = Scenario
           .accessible_by(current_ability)
-          .where(id: saved_scenarios.map { |s| s['scenario_id'] })
+          .where(id: saved_scenarios.pluck('scenario_id'))
           .includes(:scaler, :users)
           .index_by(&:id)
 
@@ -126,7 +130,7 @@ module Api
       end
 
       def saved_scenario_params
-        params.require(:saved_scenario).permit(:scenario_id, :title, :description, :private)
+        params.expect(saved_scenario: %i[scenario_id title description private])
       end
 
       def service_error_response(failure)

--- a/app/services/discard_saved_scenario.rb
+++ b/app/services/discard_saved_scenario.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-# Deletes a saved scenario in MyETM.
-class DeleteSavedScenario
+# Discards a saved scenario in MyETM (soft-delete).
+class DiscardSavedScenario
   include Dry::Monads[:result]
 
   def call(id:, client:)
-    Success(client.delete("/api/v1/saved_scenarios/#{id}").body)
+    Success(client.put("/api/v1/saved_scenarios/#{id}/discard").body)
   rescue Faraday::ResourceNotFound
     Failure(ServiceResponse.not_found)
   end

--- a/app/services/discard_saved_scenario.rb
+++ b/app/services/discard_saved_scenario.rb
@@ -6,6 +6,8 @@ class DiscardSavedScenario
 
   def call(id:, client:)
     Success(client.put("/api/v1/saved_scenarios/#{id}/discard").body)
+  rescue Faraday::UnprocessableEntityError => e
+    Failure(e.response[:body]['errors'])
   rescue Faraday::ResourceNotFound
     Failure(ServiceResponse.not_found)
   end

--- a/app/services/upsert_transition_path.rb
+++ b/app/services/upsert_transition_path.rb
@@ -22,8 +22,11 @@ class UpsertTransitionPath
   #
   # Returns the collection data from MyETM.
   def call(params:, ability:, client:)
-    scenarios = find_scenarios(ability, params[:scenario_ids])
-    yield validate_scenario_ids(params[:scenario_ids], scenarios)
+    # Extract scenario_ids from nested or flat params structure
+    scenario_ids = params.dig(:collection, :scenario_ids) || params[:scenario_ids]
+
+    scenarios = find_scenarios(ability, scenario_ids)
+    yield validate_scenario_ids(scenario_ids, scenarios)
 
     result = yield upsert_transition_path(client, full_params(params))
 
@@ -60,6 +63,12 @@ class UpsertTransitionPath
   end
 
   def full_params(params)
-    params.merge(version: Settings.version_tag)
+    if params[:collection].present?
+      # Nested params: add version inside :collection
+      params.merge(collection: params[:collection].merge(version: Settings.version_tag))
+    else
+      # Flat params: add version at top level
+      params.merge(version: Settings.version_tag)
+    end
   end
 end

--- a/app/services/upsert_transition_path.rb
+++ b/app/services/upsert_transition_path.rb
@@ -22,8 +22,7 @@ class UpsertTransitionPath
   #
   # Returns the collection data from MyETM.
   def call(params:, ability:, client:)
-    # Extract scenario_ids from nested or flat params structure
-    scenario_ids = params.dig(:collection, :scenario_ids) || params[:scenario_ids]
+    scenario_ids = params.dig(:collection, :scenario_ids)
 
     scenarios = find_scenarios(ability, scenario_ids)
     yield validate_scenario_ids(scenario_ids, scenarios)
@@ -63,12 +62,6 @@ class UpsertTransitionPath
   end
 
   def full_params(params)
-    if params[:collection].present?
-      # Nested params: add version inside :collection
-      params.merge(collection: params[:collection].merge(version: Settings.version_tag))
-    else
-      # Flat params: add version at top level
-      params.merge(version: Settings.version_tag)
-    end
+    params.merge(collection: params[:collection].merge(version: Settings.version_tag))
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,10 @@ Rails.application.routes.draw do
       end
 
       resources :saved_scenarios, except: %i[new edit] do
+        member do
+          put :discard
+        end
+
         resources :users, only: %i[index create update destroy], controller: 'saved_scenario_users' do
           collection do
             post :create

--- a/spec/requests/api/v3/collections_spec.rb
+++ b/spec/requests/api/v3/collections_spec.rb
@@ -94,6 +94,59 @@ describe Api::V3::CollectionsController, type: :controller do
         expect(JSON.parse(response.body)).to include('errors' => ['Invalid data'])
       end
     end
+
+    context 'integration test without service mocking' do
+      before do
+        allow(UpsertTransitionPath).to receive(:new).and_call_original
+      end
+
+      context 'with successful creation' do
+        let(:admin_user) { create(:admin) }
+
+        before do
+          # Override user to be admin for this test
+          allow(controller).to receive_messages(current_user: admin_user, current_ability: Ability.new(admin_user))
+
+          allow(idp_client).to receive(:post)
+            .with('/api/v1/collections', hash_including(collection: hash_including(title: 'New Collection')))
+            .and_return(double(body: { 'id' => 1, 'title' => 'New Collection' }))
+
+          post :create, params: { title: 'New Collection' }
+        end
+
+        it 'responds successfully' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'returns the created data' do
+          parsed = response.parsed_body
+          expect(parsed).to include('id' => 1, 'title' => 'New Collection')
+        end
+      end
+
+      context 'with validation errors from MyETM' do
+        before do
+          error_response = {
+            body: { 'errors' => { 'title' => ['cannot be blank'] } },
+            status: 422
+          }
+          error = Faraday::UnprocessableEntityError.new(error_response)
+          allow(error).to receive(:response).and_return(error_response)
+          allow(idp_client).to receive(:post).and_raise(error)
+
+          post :create, params: { title: '' }
+        end
+
+        it 'responds with unprocessable entity' do
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'returns the error messages' do
+          parsed = response.parsed_body
+          expect(parsed['errors']).to eq({ 'title' => ['cannot be blank'] })
+        end
+      end
+    end
   end
 
   describe 'PUT #update' do
@@ -131,6 +184,54 @@ describe Api::V3::CollectionsController, type: :controller do
 
       it 'returns the errors' do
         expect(JSON.parse(response.body)).to include('errors' => ['Invalid data'])
+      end
+    end
+
+    context 'integration test without service mocking' do
+      before do
+        allow(UpsertTransitionPath).to receive(:new).and_call_original
+      end
+
+      context 'with successful update' do
+        before do
+          allow(idp_client).to receive(:put)
+            .with('/api/v1/collections/1', hash_including(collection: hash_including(title: 'Updated Collection')))
+            .and_return(double(body: { 'id' => 1, 'title' => 'Updated Collection' }))
+
+          put :update, params: { id: 1, title: 'Updated Collection' }
+        end
+
+        it 'responds successfully' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'returns the updated data' do
+          parsed = response.parsed_body
+          expect(parsed).to include('id' => 1, 'title' => 'Updated Collection')
+        end
+      end
+
+      context 'with validation errors from MyETM' do
+        before do
+          error_response = {
+            body: { 'errors' => { 'title' => ['cannot be blank'] } },
+            status: 422
+          }
+          error = Faraday::UnprocessableEntityError.new(error_response)
+          allow(error).to receive(:response).and_return(error_response)
+          allow(idp_client).to receive(:put).and_raise(error)
+
+          put :update, params: { id: 1, title: '' }
+        end
+
+        it 'responds with unprocessable entity' do
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'returns the error messages' do
+          parsed = response.parsed_body
+          expect(parsed['errors']).to eq({ 'title' => ['cannot be blank'] })
+        end
       end
     end
   end

--- a/spec/requests/api/v3/saved_scenarios_spec.rb
+++ b/spec/requests/api/v3/saved_scenarios_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Api::V3::SavedScenariosController, type: :controller do
@@ -7,10 +9,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
   let(:response_body) { { 'data' => [], 'links' => {} } }
 
   before do
-    allow(controller).to receive(:current_user).and_return(user)
-    allow(controller).to receive(:current_ability).and_return(Ability.new(user))
-    allow(controller).to receive(:authorize!).and_return(true)
-    allow(controller).to receive(:my_etm_client).and_return(idp_client)
+    allow(controller).to receive_messages(current_user: user, current_ability: Ability.new(user), authorize!: true, my_etm_client: idp_client)
 
     request.headers.merge!(access_token_header(user, :read))
   end
@@ -30,7 +29,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
     end
 
     it 'renders the JSON response' do
-      parsed = JSON.parse(response.body)
+      parsed = response.parsed_body
       expect(parsed).to include('data', 'links')
     end
   end
@@ -41,7 +40,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
 
       before do
         allow(idp_client).to receive(:get)
-          .with("/api/v1/saved_scenarios/1")
+          .with('/api/v1/saved_scenarios/1')
           .and_return(double(body: saved_scenario_data))
 
         get :show, params: { id: 1 }
@@ -52,7 +51,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
       end
 
       it 'renders the saved scenario data' do
-        parsed = JSON.parse(response.body)
+        parsed = response.parsed_body
         expect(parsed).to include('scenario_id' => scenario.id)
       end
     end
@@ -93,8 +92,8 @@ describe Api::V3::SavedScenariosController, type: :controller do
       before do
         allow(create_service).to receive(:call)
           .with(params: hash_including('scenario_id'),
-                ability: instance_of(Ability),
-                client: idp_client)
+            ability: instance_of(Ability),
+            client: idp_client)
           .and_return(Dry::Monads::Success([created_data, nil]))
 
         post :create, params: params
@@ -105,7 +104,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
       end
 
       it 'returns the created data' do
-        parsed = JSON.parse(response.body)
+        parsed = response.parsed_body
         expect(parsed).to include('title' => 'New Saved Scenario', 'scenario_id' => scenario.id)
       end
     end
@@ -123,7 +122,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
       end
 
       it 'returns the errors' do
-        parsed = JSON.parse(response.body)
+        parsed = response.parsed_body
         expect(parsed).to include('errors' => ['Invalid data'])
       end
     end
@@ -153,7 +152,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
       end
 
       it 'returns the updated data' do
-        parsed = JSON.parse(response.body)
+        parsed = response.parsed_body
         expect(parsed).to include('title' => 'Updated Saved Scenario', 'scenario_id' => scenario.id)
       end
     end
@@ -171,7 +170,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
       end
 
       it 'returns the errors' do
-        parsed = JSON.parse(response.body)
+        parsed = response.parsed_body
         expect(parsed).to include('errors' => ['Invalid data'])
       end
     end
@@ -198,7 +197,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
       end
 
       it 'returns the response data' do
-        parsed = JSON.parse(response.body)
+        parsed = response.parsed_body
         expect(parsed).to include('data', 'links')
       end
     end
@@ -228,7 +227,8 @@ describe Api::V3::SavedScenariosController, type: :controller do
       before do
         allow(discard_service).to receive(:call)
           .with(id: '1', client: idp_client)
-          .and_return(Dry::Monads::Success([{ 'message' => 'Scenario discarded successfully' }, nil]))
+          .and_return(Dry::Monads::Success([{ 'message' => 'Scenario discarded successfully' },
+                                            nil]))
 
         put :discard, params: { id: 1 }
       end
@@ -238,7 +238,7 @@ describe Api::V3::SavedScenariosController, type: :controller do
       end
 
       it 'returns the response data' do
-        parsed = JSON.parse(response.body)
+        parsed = response.parsed_body
         expect(parsed).to include('message' => 'Scenario discarded successfully')
       end
     end
@@ -253,6 +253,67 @@ describe Api::V3::SavedScenariosController, type: :controller do
 
       it 'responds with not found' do
         expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'authorization check' do
+      it 'calls authorize! with destroy permission' do
+        allow(discard_service).to receive(:call)
+          .with(id: '1', client: idp_client)
+          .and_return(Dry::Monads::Success([{ 'message' => 'Scenario discarded successfully' },
+                                            nil]))
+
+        expect(controller).to receive(:authorize!).with(:destroy, Scenario)
+
+        put :discard, params: { id: 1 }
+      end
+    end
+
+    context 'integration test without service mocking' do
+      before do
+        allow(DiscardSavedScenario).to receive(:new).and_call_original
+      end
+
+      context 'with successful discard' do
+        before do
+          allow(idp_client).to receive(:put)
+            .with('/api/v1/saved_scenarios/1/discard')
+            .and_return(double(body: { 'message' => 'Scenario discarded successfully' }))
+
+          put :discard, params: { id: 1 }
+        end
+
+        it 'responds successfully' do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'returns the response data' do
+          parsed = response.parsed_body
+          expect(parsed).to include('message' => 'Scenario discarded successfully')
+        end
+      end
+
+      context 'with validation errors from MyETM' do
+        before do
+          error_response = {
+            body: { 'errors' => { 'scenario' => ['already discarded'] } },
+            status: 422
+          }
+          error = Faraday::UnprocessableEntityError.new(error_response)
+          allow(error).to receive(:response).and_return(error_response)
+          allow(idp_client).to receive(:put).and_raise(error)
+
+          put :discard, params: { id: 1 }
+        end
+
+        it 'responds with unprocessable entity' do
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it 'returns the error messages' do
+          parsed = response.parsed_body
+          expect(parsed['errors']).to eq({ 'scenario' => ['already discarded'] })
+        end
       end
     end
   end

--- a/spec/requests/api/v3/saved_scenarios_spec.rb
+++ b/spec/requests/api/v3/saved_scenarios_spec.rb
@@ -216,4 +216,44 @@ describe Api::V3::SavedScenariosController, type: :controller do
       end
     end
   end
+
+  describe 'PUT #discard' do
+    let(:discard_service) { instance_double(DiscardSavedScenario) }
+
+    before do
+      allow(DiscardSavedScenario).to receive(:new).and_return(discard_service)
+    end
+
+    context 'with a valid ID' do
+      before do
+        allow(discard_service).to receive(:call)
+          .with(id: '1', client: idp_client)
+          .and_return(Dry::Monads::Success([{ 'message' => 'Scenario discarded successfully' }, nil]))
+
+        put :discard, params: { id: 1 }
+      end
+
+      it 'responds successfully' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns the response data' do
+        parsed = JSON.parse(response.body)
+        expect(parsed).to include('message' => 'Scenario discarded successfully')
+      end
+    end
+
+    context 'with an invalid ID' do
+      before do
+        allow(discard_service).to receive(:call)
+          .and_raise(Faraday::ResourceNotFound)
+
+        put :discard, params: { id: 999 }
+      end
+
+      it 'responds with not found' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/spec/services/discard_saved_scenario_spec.rb
+++ b/spec/services/discard_saved_scenario_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe DiscardSavedScenario do
+  let(:result) do
+    described_class.new.call(id: 123, client:)
+  end
+
+  context 'when the scenario is discarded in MyETM' do
+    let(:client) do
+      Faraday.new do |builder|
+        builder.adapter(:test) do |stub|
+          stub.put('/api/v1/saved_scenarios/123/discard') do
+            [200, { 'Content-Type' => 'application/json' }, { 'message' => 'Scenario discarded successfully' }]
+          end
+        end
+      end
+    end
+
+    it 'returns a Success' do
+      expect(result).to be_success
+    end
+
+    it 'returns the response data' do
+      expect(result.value!).to eq({ 'message' => 'Scenario discarded successfully' })
+    end
+  end
+
+  context 'when the scenario is inaccessible in MyETM' do
+    let(:client) do
+      Faraday.new do |builder|
+        builder.adapter(:test) do |stub|
+          stub.put('/api/v1/saved_scenarios/123/discard') do
+            raise Faraday::ResourceNotFound
+          end
+        end
+      end
+    end
+
+    it 'returns a Failure' do
+      expect(result).to be_failure
+    end
+
+    it 'returns an error' do
+      expect(result.failure).to eq(ServiceResponse.not_found)
+    end
+  end
+end

--- a/spec/services/discard_saved_scenario_spec.rb
+++ b/spec/services/discard_saved_scenario_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe DiscardSavedScenario do
       Faraday.new do |builder|
         builder.adapter(:test) do |stub|
           stub.put('/api/v1/saved_scenarios/123/discard') do
-            [200, { 'Content-Type' => 'application/json' }, { 'message' => 'Scenario discarded successfully' }]
+            [200, { 'Content-Type' => 'application/json' },
+             { 'message' => 'Scenario discarded successfully' }]
           end
         end
       end
@@ -44,6 +45,32 @@ RSpec.describe DiscardSavedScenario do
 
     it 'returns an error' do
       expect(result.failure).to eq(ServiceResponse.not_found)
+    end
+  end
+
+  context 'when MyETM returns validation errors' do
+    let(:client) do
+      Faraday.new do |builder|
+        builder.adapter(:test) do |stub|
+          stub.put('/api/v1/saved_scenarios/123/discard') do
+            error_response = {
+              body: { 'errors' => { 'scenario' => ['already discarded'] } },
+              status: 422
+            }
+            error = Faraday::UnprocessableEntityError.new(error_response)
+            allow(error).to receive(:response).and_return(error_response)
+            raise error
+          end
+        end
+      end
+    end
+
+    it 'returns a Failure' do
+      expect(result).to be_failure
+    end
+
+    it 'returns the validation errors' do
+      expect(result.failure).to eq({ 'scenario' => ['already discarded'] })
     end
   end
 end

--- a/spec/services/upsert_transition_path_spec.rb
+++ b/spec/services/upsert_transition_path_spec.rb
@@ -16,19 +16,28 @@ RSpec.describe UpsertTransitionPath do
     }.with_indifferent_access
   end
 
-  let(:params)  { { scenario_ids: [scenario1.id, scenario2.id], title: 'My transition path' } }
+  let(:params) do
+    {
+      collection: {
+        scenario_ids: [scenario1.id, scenario2.id],
+        title: 'My transition path'
+      }
+    }
+  end
   let(:ability) { Api::TokenAbility.new(token, user) }
 
   let(:url_base) { Collection.version.collections_url }
-  let(:url_slug)  { "#{params[:scenario_ids].join(',')},10" }
-  let(:url_query)  { "locale=#{I18n.locale}&title=#{ERB::Util.url_encode(params[:title])}" }
+  let(:url_slug)  { "#{params[:collection][:scenario_ids].join(',')},10" }
+  let(:url_query)  { "locale=#{I18n.locale}&title=#{ERB::Util.url_encode(params[:collection][:title])}" }
 
   let(:client) do
     Faraday.new do |builder|
       builder.adapter(:test) do |stub|
-        request_params = params.merge(
-          version: Settings.version_tag
-        )
+        request_params = {
+          collection: params[:collection].merge(
+            version: Settings.version_tag
+          )
+        }
 
         stub.put('/api/v1/collections/123', request_params) do
           [
@@ -36,9 +45,9 @@ RSpec.describe UpsertTransitionPath do
             { 'Content-Type' => 'application/json' },
             {
               'id'                   => 123,
-              'title'                => params[:title],
+              'title'                => params[:collection][:title],
               'version'              => 'latest',
-              'scenario_ids'         => params[:scenario_ids],
+              'scenario_ids'         => params[:collection][:scenario_ids],
               'saved_scenario_ids'   => [1],
               'collections_app_url'  => "#{:url_base}/#{:url_slug}?#{:url_query}",
               'created_at'           => '2022-12-21T19:45:09Z',
@@ -73,9 +82,9 @@ RSpec.describe UpsertTransitionPath do
     it 'returns the transition path data' do
       expect(result.value!).to eq({
         'id'                   => 123,
-        'title'                => 'My transition path',
+        'title'                => params[:collection][:title],
         'version'              => 'latest',
-        'scenario_ids'         => [scenario1.id, scenario2.id],
+        'scenario_ids'         => params[:collection][:scenario_ids],
         'saved_scenario_ids'   => [1],
         'collections_app_url'  => "#{:url_base}/#{:url_slug}?#{:url_query}",
         'created_at'           => '2022-12-21T19:45:09Z',
@@ -96,10 +105,12 @@ RSpec.describe UpsertTransitionPath do
     # Faraday will throw an error if it receives a parameter or value that it doesn't expect.
     let(:params) do
       {
-        scenario_ids: [scenario1.id, scenario2.id],
-        title: 'My transition path',
-        end_year: -2050,
-        extra: 'parameter'
+        collection: {
+          scenario_ids: [scenario1.id, scenario2.id],
+          title: 'My transition path',
+          end_year: -2050,
+          extra: 'parameter'
+        }
       }
     end
 


### PR DESCRIPTION
#### Context
- Added a discard endpoint on the saved scenarios controller which passes through to the myetm discard action.
- Updated the upsert transition path to handle nested params - we expect nested params everywhere else, and pyetm makes calls with nested params. This unifies the approach.
- Updated the my_etm_client to raise errors so error messages on saved scenario and collection endpoints passthrough from myetm to the API caller of etengine (in this case pyetm)
- Lots of spec

Note: Also updated the rubocop config so I could check my changes for issues

#### Related
Goes with [this myetm PR](https://github.com/quintel/my-etm/pull/269)

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed --> Docs still need to be updated
- [x] I have tagged the relevant people for review
