### PR TITLE
Remove deprecated node attributes from NodeApi and bump atlas to latest SHA

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'ruby-progressbar'
 
 # own gems
 gem 'quintel_merit', ref: 'aae77e0', github: 'quintel/merit'
-gem 'atlas',         ref: '21a6046', github: 'quintel/atlas'
+gem 'atlas',         ref: '72dbea1', github: 'quintel/atlas' #TODO: Update to latest merge commit once Atlas branch is merged into master
 gem 'fever',         ref: '2afebd1', github: 'quintel/fever'
 gem 'refinery',      ref: '36b8e34', github: 'quintel/refinery'
 gem 'rubel',         ref: '9fe7010', github: 'quintel/rubel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/quintel/atlas.git
-  revision: 21a60468b711e700ec2964a4f3c9c942f5ba3c7b
-  ref: 21a6046
+  revision: 72dbea148d09aaae4b38361203f6e98bb29a9efb
+  ref: 72dbea1
   specs:
     atlas (1.0.0)
       activemodel (>= 7)

--- a/app/models/qernel/node_api/attributes.rb
+++ b/app/models/qernel/node_api/attributes.rb
@@ -59,10 +59,7 @@ module Qernel
         },
 
         :security_of_supply => {
-          :availability => ['', ''],
-          :part_load_operating_point => ['', ''],
-          :part_load_efficiency_penalty => ['', ''],
-          :forecasting_error => ['', '']
+          :availability => ['', '']
         },
 
         :misc => {


### PR DESCRIPTION
#### Context

Companion to quintel/atlas#192, which removes a set of deprecated node attributes from Atlas. With those attributes gone from the data model, the matching entries in ETEngine's node attribute registry are now orphaned: they generate dataset accessors that are never read and render empty rows in the inspect node detail page. This bumps Atlas to the version that drops the attributes and removes the leftover registry entries.


#### Implemented changes

- Removed the deprecated attributes from `Qernel::NodeApi::Attributes` (the `security_of_supply` group, but `availability` is kept as it is still a valid Atlas attribute):
  - `forecasting_error`
  - `part_load_operating_point`
  - `part_load_efficiency_penalty`
- Bumped the atlas gem to the commit that removes the deprecated attributes.

#### Related

References quintel/atlas#192.

Goes with pull requests:
- atlas: https://github.com/quintel/atlas/pull/194
- etengine: https://github.com/quintel/etengine/pull/1773 [This one]

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [ ] I have tagged the relevant people for review
