### PR TITLE
Prepare for local dev with Docker (ETLauncher)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,8 +19,9 @@ Rails.application.configure do
   # Enable server timing
   config.server_timing = true
 
-  # Enable hostname for puma-dev
-  config.hosts << 'etengine.test'
+  # Allow the etm-stack cross-app parent domain so the shared etm_sso SSO cookie can be scoped to
+  # a dotted parent the browser accepts
+  config.hosts << ENV.fetch('ETM_HOST_PARENT', '.local.energytransitionmodel.com')
 
   # Always use a memory store so that we don't reload datasets on every request.
   config.cache_store = :memory_store, { size: 512 * (1024**3) } # 512 Mb


### PR DESCRIPTION
#### Context

ETLauncher needs ETEngine to accept requests via `etengine.local.energytransitionmodel.com` for the shared SSO cookie to work, but Rails' host-authorization allowlist only permitted the old puma-dev hostname (`etengine.test`).

#### Implemented changes

* `config/environments/development.rb`: replaced the `etengine.test` (puma-dev) entry in `config.hosts` with `ENV.fetch('ETM_HOST_PARENT', '.local.energytransitionmodel.com')`, matching the same fix applied in my-etm

#### Related

This PR is part of an effort to deploy the ETM locally with docker with ETLauncher :
- my-etm: https://github.com/quintel/my-etm/pull/277
- etmodel: https://github.com/quintel/etmodel/pull/4748
- etengine: https://github.com/quintel/etengine/pull/1778 [This one]
- collections: https://github.com/quintel/multi-year-charts/pull/125

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
