### PR TITLE
Replace ctrl+enter with cmd+enter for mac on firefox

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -37,9 +37,9 @@ $(document).on("turbo:load", function () {
       cm.focus();
     }
 
-    // Ctrl+Enter submit on any CodeMirror instance
+    // Ctrl+Enter (Windows/Linux) or Cmd+Enter (Mac) submit on any CodeMirror instance
     cm.on("keydown", function (el, event) {
-      if (event.ctrlKey && event.keyCode === 13) {
+      if ((event.ctrlKey || event.metaKey) && event.keyCode === 13) {
         $(event.target).closest("form").submit();
       }
     });
@@ -138,12 +138,6 @@ $(document).on("turbo:load", function () {
       $('.edge-flows .nav-tabs a[href="' + selectedPeriod + '"]').click();
     }
   }
-
-  $(".gql-debug #query").keyup(function (event) {
-    if (event.ctrlKey && event.keyCode === 13) {
-      $(event.target).parent("form").submit();
-    }
-  });
 
   $(".gql-debug").on("submit", function () {
     $(".gql-debug button").attr("disabled", true);

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -37,9 +37,9 @@ $(document).on("turbo:load", function () {
       cm.focus();
     }
 
-    // Ctrl+Enter (Windows/Linux) or Cmd+Enter (Mac) submit on any CodeMirror instance
+    // Alt+Enter (Windows/Linux) or Option+Enter (Mac) submit on any CodeMirror instance
     cm.on("keydown", function (el, event) {
-      if ((event.ctrlKey || event.metaKey) && event.keyCode === 13) {
+      if (event.altKey && event.keyCode === 13) {
         $(event.target).closest("form").submit();
       }
     });

--- a/app/views/inspect/gqueries/test.html.haml
+++ b/app/views/inspect/gqueries/test.html.haml
@@ -12,7 +12,7 @@
         = button_tag class: 'btn btn-primary btn-large', type: 'submit' do
           Run GQL
           %span.hotkey
-            %kbd Ctrl/⌘
+            %kbd Alt/⌥
             %span.plus +
             %kbd ↩
         &nbsp;

--- a/app/views/inspect/gqueries/test.html.haml
+++ b/app/views/inspect/gqueries/test.html.haml
@@ -12,7 +12,7 @@
         = button_tag class: 'btn btn-primary btn-large', type: 'submit' do
           Run GQL
           %span.hotkey
-            %kbd Alt/⌥
+            %kbd Alt/Option
             %span.plus +
             %kbd ↩
         &nbsp;

--- a/app/views/inspect/gqueries/test.html.haml
+++ b/app/views/inspect/gqueries/test.html.haml
@@ -12,7 +12,7 @@
         = button_tag class: 'btn btn-primary btn-large', type: 'submit' do
           Run GQL
           %span.hotkey
-            %kbd Alt/Option
+            %kbd Alt/Opt
             %span.plus +
             %kbd ↩
         &nbsp;

--- a/app/views/inspect/gqueries/test.html.haml
+++ b/app/views/inspect/gqueries/test.html.haml
@@ -12,7 +12,7 @@
         = button_tag class: 'btn btn-primary btn-large', type: 'submit' do
           Run GQL
           %span.hotkey
-            %kbd Ctrl
+            %kbd Ctrl/⌘
             %span.plus +
             %kbd ↩
         &nbsp;

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -67,7 +67,7 @@
         = content_tag(:button, type: 'submit', name: 'commit', class: 'btn btn-primary btn-large') do
           Submit
           %span.hotkey
-            %kbd Ctrl/⌘
+            %kbd Alt/⌥
             %span.plus +
             %kbd ↩
 

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -67,7 +67,7 @@
         = content_tag(:button, type: 'submit', name: 'commit', class: 'btn btn-primary btn-large') do
           Submit
           %span.hotkey
-            %kbd Alt/Option
+            %kbd Alt/Opt
             %span.plus +
             %kbd ↩
 

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -67,7 +67,7 @@
         = content_tag(:button, type: 'submit', name: 'commit', class: 'btn btn-primary btn-large') do
           Submit
           %span.hotkey
-            %kbd Alt/⌥
+            %kbd Alt/Option
             %span.plus +
             %kbd ↩
 

--- a/app/views/inspect/scenarios/_form.html.haml
+++ b/app/views/inspect/scenarios/_form.html.haml
@@ -67,7 +67,7 @@
         = content_tag(:button, type: 'submit', name: 'commit', class: 'btn btn-primary btn-large') do
           Submit
           %span.hotkey
-            %kbd Ctrl
+            %kbd Ctrl/⌘
             %span.plus +
             %kbd ↩
 


### PR DESCRIPTION
#### Context
Because of Firefox issues with ctrl+enter (see: https://bugzilla.mozilla.org/show_bug.cgi?id=237027) I have extended the command to also accept cmd+enter. For me this works perfectly well and can be considered an MVP solution.

Note: ctrl+enter still acts as a right click for me. I also have that behaviour on other pages (e.g. gmail).

What do you think @mabijkerk ?

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
