### PR TITLE
Rename the emissions group to direct_emissions

### DIFF
--- a/app/models/qernel/node.rb
+++ b/app/models/qernel/node.rb
@@ -110,14 +110,14 @@ class Node
   attr_reader :sector_environment
   alias sector_environment? sector_environment
 
-  attr_reader :primary_energy_demand, :useful_demand, :final_demand_group, :non_energetic_use, :energy_import_export, :bio_resources_demand, :emissions
+  attr_reader :primary_energy_demand, :useful_demand, :final_demand_group, :non_energetic_use, :energy_import_export, :bio_resources_demand, :direct_emissions
   alias primary_energy_demand? primary_energy_demand
   alias useful_demand? useful_demand
   alias final_demand_group? final_demand_group
   alias non_energetic_use? non_energetic_use
   alias energy_import_export? energy_import_export
   alias bio_resources_demand? bio_resources_demand
-  alias emissions? emissions
+  alias direct_emissions? direct_emissions
 
   # --------- Initializing ----------------------------------------------------
 
@@ -187,7 +187,7 @@ class Node
     @non_energetic_use     = @groups.include? :non_energetic_use
     @energy_import_export  = @groups.include? :energy_import_export
     @bio_resources_demand  = @groups.include? :bio_resources_demand
-    @emissions             = @groups.include? :emissions
+    @direct_emissions      = @groups.include? :direct_emissions
 
     @recursive_factor_ignore = @groups.include? :recursive_factor_ignore
 

--- a/app/models/qernel/node_api/direct_emissions.rb
+++ b/app/models/qernel/node_api/direct_emissions.rb
@@ -16,18 +16,18 @@ module Qernel
     module DirectEmissions
       # Fossil CO2 content of all carriers entering the node.
       #
-      # @return [Float, nil] Total fossil CO2 content from input carriers in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Total fossil CO2 content from input carriers in kg, or nil if node is not in the direct_emissions group
       def direct_co2_input_content_carriers_fossil
-        with_emissions_node do
+        with_direct_emissions_node do
           sum_carbon_content(inputs.flat_map(&:edges), :fossil)
         end
       end
 
       # Fossil CO2 content of all carriers leaving the node.
       #
-      # @return [Float, nil] Total fossil CO2 content from output carriers in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Total fossil CO2 content from output carriers in kg, or nil if node is not in the direct_emissions group
       def direct_co2_output_content_carriers_fossil
-        with_emissions_node do
+        with_direct_emissions_node do
           sum_carbon_content(output_edges, :fossil)
         end
       end
@@ -37,9 +37,9 @@ module Qernel
       # Calculates net emissions after accounting for CO2 utilisation and CO2 capture.
       # Emissions = input carriers co2 + utilised co2 - captured co2 - output carriers co2
       #
-      # @return [Float, nil] Direct fossil CO2 emissions in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Direct fossil CO2 emissions in kg, or nil if node is not in the direct_emissions group
       def direct_co2_output_production_emissions_fossil
-        with_emissions_node do
+        with_direct_emissions_node do
           direct_co2_input_content_carriers_fossil      +
             direct_co2_input_utilisation_fossil         -
             direct_co2_output_production_capture_fossil -
@@ -49,18 +49,18 @@ module Qernel
 
       # Biogenic CO2 content of all carriers entering the node.
       #
-      # @return [Float, nil] Total biogenic CO2 content from input carriers in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Total biogenic CO2 content from input carriers in kg, or nil if node is not in the direct_emissions group
       def direct_co2_input_content_carriers_biogenic
-        with_emissions_node do
+        with_direct_emissions_node do
           sum_carbon_content(inputs.flat_map(&:edges), :biogenic)
         end
       end
 
       # Biogenic CO2 content of all carriers leaving the node.
       #
-      # @return [Float, nil] Total biogenic CO2 content from output carriers in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Total biogenic CO2 content from output carriers in kg, or nil if node is not in the direct_emissions group
       def direct_co2_output_content_carriers_biogenic
-        with_emissions_node do
+        with_direct_emissions_node do
           sum_carbon_content(output_edges, :biogenic)
         end
       end
@@ -72,9 +72,9 @@ module Qernel
       # Note: Unlike fossil emissions, biogenic CO2 utilisation is not included as
       # the model does not distinguish biogenic CO2 utilisation.
       #
-      # @return [Float, nil] Direct biogenic CO2 emissions in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Direct biogenic CO2 emissions in kg, or nil if node is not in the direct_emissions group
       def direct_co2_output_production_emissions_biogenic
-        with_emissions_node do
+        with_direct_emissions_node do
           direct_co2_input_content_carriers_biogenic      -
             direct_co2_output_production_capture_biogenic -
             direct_co2_output_content_carriers_biogenic
@@ -86,9 +86,9 @@ module Qernel
       # Calculates the amount of fossil CO2 captured based on the total CO2 available
       # (input content + utilised CO2 - output content) multiplied by the CCS capture rate.
       #
-      # @return [Float, nil] Fossil CO2 captured in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Fossil CO2 captured in kg, or nil if node is not in the direct_emissions group
       def direct_co2_output_production_capture_fossil
-        with_emissions_node do
+        with_direct_emissions_node do
           calculate_capture(
             direct_co2_input_content_carriers_fossil +
               direct_co2_input_utilisation_fossil -
@@ -102,9 +102,9 @@ module Qernel
       # Calculates the amount of biogenic CO2 captured based on the total biogenic CO2
       # available (input content - output content) multiplied by the CCS capture rate.
       #
-      # @return [Float, nil] Biogenic CO2 captured in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Biogenic CO2 captured in kg, or nil if node is not in the direct_emissions group
       def direct_co2_output_production_capture_biogenic
-        with_emissions_node do
+        with_direct_emissions_node do
           calculate_capture(
             direct_co2_input_content_carriers_biogenic -
               direct_co2_output_content_carriers_biogenic
@@ -117,9 +117,9 @@ module Qernel
       # Calculates CO2 that is consumed as feedstock rather than emitted, based on the total
       # useful carrier output in MJ and the node's co2_utilisation_per_mj attribute.
       #
-      # @return [Float, nil] Total fossil CO2 utilised in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Total fossil CO2 utilised in kg, or nil if node is not in the direct_emissions group
       def direct_co2_input_utilisation_fossil
-        with_emissions_node do
+        with_direct_emissions_node do
           output_edges.sum { |edge| edge.net_demand || 0.0 } * (dataset_get(:co2_utilisation_per_mj) || 0.0)
         end
       end
@@ -138,9 +138,9 @@ module Qernel
       #
       # Input content + utilisation - output co2 content
       #
-      # @return [Float, nil] Direct fossil CO2 production in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Direct fossil CO2 production in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_co2_production
-        with_emissions_node do
+        with_direct_emissions_node do
           direct_co2_input_content_carriers_fossil  +
             direct_co2_input_utilisation_fossil     -
             direct_co2_output_content_carriers_fossil
@@ -151,9 +151,9 @@ module Qernel
       #
       # Sum of fossil and biogenic capture.
       #
-      # @return [Float, nil] Total CO2 captured in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Total CO2 captured in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_co2_capture
-        with_emissions_node do
+        with_direct_emissions_node do
           direct_co2_output_production_capture_fossil +
           direct_co2_output_production_capture_biogenic
         end
@@ -163,9 +163,9 @@ module Qernel
       #
       # Currently returns 0 as a placeholder
       #
-      # @return [Float, nil] Other GHG emissions in kg CO2-equivalent, or nil if node is not in emissions group
+      # @return [Float, nil] Other GHG emissions in kg CO2-equivalent, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_other_ghg_emissions
-        with_emissions_node do
+        with_direct_emissions_node do
           0.0
         end
       end
@@ -174,9 +174,9 @@ module Qernel
       #
       # Total co2 and other_ghg emissions - capture
       #
-      # @return [Float, nil] Total GHG emissions in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Total GHG emissions in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_total_ghg_emissions
-        with_emissions_node do
+        with_direct_emissions_node do
           direct_reporting_emissions_co2_production -
             direct_reporting_emissions_co2_capture  +
             direct_reporting_emissions_other_ghg_emissions
@@ -187,9 +187,9 @@ module Qernel
       #
       # Fossil CO2 input utilisation.
       #
-      # @return [Float, nil] CO2 utilisation in kg, or nil if node is not in emissions group
+      # @return [Float, nil] CO2 utilisation in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_co2_utilisation
-        with_emissions_node do
+        with_direct_emissions_node do
           direct_co2_input_utilisation_fossil
         end
       end
@@ -198,20 +198,20 @@ module Qernel
       #
       # Biogenic CO2 emissions from production.
       #
-      # @return [Float, nil] Biogenic CO2 emissions in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Biogenic CO2 emissions in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_biogenic_co2_emissions
-        with_emissions_node do
+        with_direct_emissions_node do
           direct_co2_output_production_emissions_biogenic
         end
       end
 
       private
 
-      # Yields the given block only if the node belongs to the :emissions group.
+      # Yields the given block only if the node belongs to the :direct_emissions group.
       #
-      # @return [Float, nil] Result of the block, or nil if node is not in emissions group
-      def with_emissions_node
-        yield if node.emissions?
+      # @return [Float, nil] Result of the block, or nil if node is not in the direct_emissions group
+      def with_direct_emissions_node
+        yield if node.direct_emissions?
       end
 
       # Sums carbon content across multiple edges.

--- a/app/models/qernel/node_api/molecule_emissions.rb
+++ b/app/models/qernel/node_api/molecule_emissions.rb
@@ -29,9 +29,9 @@ module Qernel
       # Excludes nodes in the CCUS captured group, as these represent capture
       # rather than production.
       #
-      # @return [Float, nil] CO2 production in kg, or nil if node is not in emissions group
+      # @return [Float, nil] CO2 production in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_co2_production
-        with_emissions_node do
+        with_direct_emissions_node do
           return 0.0 if node.ccus_captured?
           node.input(:co2) ? node.demand : 0.0
         end
@@ -43,9 +43,9 @@ module Qernel
       # For molecule nodes representing other GHG flows (CH4, N2O, etc.), the demand
       # represents the amount in kg CO2-equivalent/year.
       #
-      # @return [Float, nil] Other GHG emissions in kg CO2-equivalent, or nil if node is not in emissions group
+      # @return [Float, nil] Other GHG emissions in kg CO2-equivalent, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_other_ghg_emissions
-        with_emissions_node do
+        with_direct_emissions_node do
           node.input(:other_ghg) ? node.demand : 0.0
         end
       end
@@ -55,9 +55,9 @@ module Qernel
       # Returns the node demand for nodes in the CCUS captured group, which
       # represent CO2 removals from technological capture.
       #
-      # @return [Float, nil] CO2 capture in kg, or nil if node is not in emissions group
+      # @return [Float, nil] CO2 capture in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_co2_capture
-        with_emissions_node do
+        with_direct_emissions_node do
           node.ccus_captured? ? node.demand : 0.0
         end
       end
@@ -66,9 +66,9 @@ module Qernel
       #
       # Formula: CO2 production - CO2 capture + other GHG emissions
       #
-      # @return [Float, nil] Total GHG emissions in kg CO2-equivalent, or nil if node is not in emissions group
+      # @return [Float, nil] Total GHG emissions in kg CO2-equivalent, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_total_ghg_emissions
-        with_emissions_node do
+        with_direct_emissions_node do
           direct_reporting_emissions_co2_production -
             direct_reporting_emissions_co2_capture +
             direct_reporting_emissions_other_ghg_emissions
@@ -79,9 +79,9 @@ module Qernel
       #
       # Fossil CO2 input utilisation.
       #
-      # @return [Float, nil] CO2 utilisation in kg, or nil if node is not in emissions group
+      # @return [Float, nil] CO2 utilisation in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_co2_utilisation
-        with_emissions_node do
+        with_direct_emissions_node do
           0.0
         end
       end
@@ -90,20 +90,20 @@ module Qernel
       #
       # Biogenic CO2 emissions from production.
       #
-      # @return [Float, nil] Biogenic CO2 emissions in kg, or nil if node is not in emissions group
+      # @return [Float, nil] Biogenic CO2 emissions in kg, or nil if node is not in the direct_emissions group
       def direct_reporting_emissions_biogenic_co2_emissions
-        with_emissions_node do
+        with_direct_emissions_node do
           0.0
         end
       end
 
       private
 
-      # Yields the given block only if the node belongs to the :emissions group.
+      # Yields the given block only if the node belongs to the :direct_emissions group.
       #
-      # @return [Float, nil] Result of the block, or nil if node is not in emissions group
-      def with_emissions_node
-        yield if node.emissions?
+      # @return [Float, nil] Result of the block, or nil if node is not in the direct_emissions group
+      def with_direct_emissions_node
+        yield if node.direct_emissions?
       end
     end
   end

--- a/app/serializers/export/configured_csv_serializer.rb
+++ b/app/serializers/export/configured_csv_serializer.rb
@@ -44,16 +44,16 @@
 # raw display value of that column (ascending string comparison), regardless of whether the column is
 # included in `schema:`; a pair whose `order_by` cell is blank/`-` sorts last, and pairs tied on
 # `order_by` keep their relative mapping-file order. Each pair expands to the energy and molecule
-# nodes whose own `sector_label` and `use` match the pair AND which belong to the node's `:emissions`
+# nodes whose own `sector_label` and `use` match the pair AND which belong to the node's `:direct_emissions`
 # group (key-sorted). A pair with zero labelled nodes, or whose only matching nodes aren't in the
-# `:emissions` group, legally yields zero rows. Mapping-driven mode requires a `period:` (raises
+# `:direct_emissions` group, legally yields zero rows. Mapping-driven mode requires a `period:` (raises
 # ArgumentError at construction otherwise) and permits only the two column types below (any other
 # type raises UnsupportedColumnTypeError at construction):
 #
 # - "node_attribute": The value will be the result of calling the attribute named by `value:` in the
 #                     schema on node_api for each expanded node. `value:` may be any Ruby expression
 #                     evaluated on node_api via instance_eval. A nil result (e.g. a node not in the
-#                     :emissions group) renders as an empty string without evaluating `transform`.
+#                     :direct_emissions group) renders as an empty string without evaluating `transform`.
 #                     Otherwise, an optional `transform:` Ruby expression is evaluated with `value`
 #                     bound to the result of `value:`. For example:
 #                       transform: "value * 10e-6"
@@ -177,13 +177,13 @@ module Export
       end
     end
 
-    # The `:emissions`-group nodes of both live graphs whose (sector_label, use) matches `pair`.
+    # The `:direct_emissions`-group nodes of both live graphs whose (sector_label, use) matches `pair`.
     def nodes_for_pair(pair)
       nodes = [graph_interface.graph, graph_interface.molecules].flat_map do |graph|
         graph.sector_map.nodes_for_pair(pair)
       end
 
-      nodes.select(&:emissions?).sort_by { |node| node.node_api.key.to_s }
+      nodes.select(&:direct_emissions?).sort_by { |node| node.node_api.key.to_s }
     end
 
     def graph_interface

--- a/lib/graph_data_validation/spec/validation/emissions.rb
+++ b/lib/graph_data_validation/spec/validation/emissions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "emissions" do |dataset|
-  GraphDataValidation::NodeGroup.new(:emissions, dataset).each do |node|
+  GraphDataValidation::NodeGroup.new(:direct_emissions, dataset).each do |node|
     context "emissions for node #{node.key}" do
       it 'should balance for fossil' do
         expect((

--- a/spec/controllers/api/v3/exports_controller_spec.rb
+++ b/spec/controllers/api/v3/exports_controller_spec.rb
@@ -97,7 +97,7 @@ describe Api::V3::ExportController do
       )
     end
 
-    it 'renders Sector/Subsector as mapping lookups for a labelled, :emissions-group node' do
+    it 'renders Sector/Subsector as mapping lookups for a labelled, :direct_emissions-group node' do
       row = CSV.parse(response.body).find { |r| r[2] == 'm_waste' }
       expect(row).to eq(%w[Waste Non-specified m_waste co2 0.0 0.0 0.0 0.0])
     end
@@ -106,9 +106,9 @@ describe Api::V3::ExportController do
       expect(CSV.parse(response.body).flatten).not_to include('foo')
     end
 
-    it 'excludes a labelled node that is not in the :emissions group' do
+    it 'excludes a labelled node that is not in the :direct_emissions group' do
       # `bar`/`baz`/`lft`/`buildings_space_heating_demand` all carry a sector_label/use that
-      # matches an exported mapping row, but none is in the :emissions node group.
+      # matches an exported mapping row, but none is in the :direct_emissions node group.
       expect(CSV.parse(response.body).flatten).not_to include('bar', 'baz', 'lft', 'buildings_space_heating_demand')
     end
   end

--- a/spec/fixtures/etsource/graphs/energy/nodes/molecule_source/molecule_source.ad
+++ b/spec/fixtures/etsource/graphs/energy/nodes/molecule_source/molecule_source.ad
@@ -1,4 +1,4 @@
-- groups = [preset_demand, emissions]
+- groups = [preset_demand, direct_emissions]
 - preset_demand = 100.0
 - input.electricity = 0.75
 - input.natural_gas = 0.25

--- a/spec/fixtures/etsource/graphs/molecules/nodes/m_left.ad
+++ b/spec/fixtures/etsource/graphs/molecules/nodes/m_left.ad
@@ -1,3 +1,3 @@
-- groups = [emissions]
+- groups = [direct_emissions]
 - from_energy.source = molecule_source
 - input.co2 = 1.0

--- a/spec/fixtures/etsource/graphs/molecules/nodes/nosector/m_waste.ad
+++ b/spec/fixtures/etsource/graphs/molecules/nodes/nosector/m_waste.ad
@@ -1,3 +1,3 @@
-- groups = [emissions]
+- groups = [direct_emissions]
 - sector_label = waste_non_specified
 - use = non_energetic

--- a/spec/lib/graph_data_validation/node_group_spec.rb
+++ b/spec/lib/graph_data_validation/node_group_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GraphDataValidation::NodeGroup, :etsource_fixture do
   let(:gql) { Scenario.default.gql }
 
   context 'with an existing group key' do
-    let(:node_group) { described_class.new(:emissions, gql) }
+    let(:node_group) { described_class.new(:direct_emissions, gql) }
 
     it 'does not contains molecule nodes' do
       expect(node_group.any? {|n| n.is_a?(Qernel::NodeApi::MoleculeApi) } ).to be_falsey

--- a/spec/models/qernel/node_api/direct_emissions_spec.rb
+++ b/spec/models/qernel/node_api/direct_emissions_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:power_plant, groups: [:emissions])
+          builder.add(:power_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :power_plant, :coal, type: :share)
@@ -35,7 +35,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 200)
-          builder.add(:gas_plant, groups: [:emissions])
+          builder.add(:gas_plant, groups: [:direct_emissions])
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :gas_plant, :natural_gas, type: :share)
@@ -60,8 +60,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 50)
-          builder.add(:electric_heater, groups: [:emissions])
-          builder.add(:power_plant, groups: [:emissions])
+          builder.add(:electric_heater, groups: [:direct_emissions])
+          builder.add(:power_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :power_plant, :coal, type: :share)
@@ -94,7 +94,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:ccs_plant, groups: [:emissions], free_co2_factor: 0.85)
+          builder.add(:ccs_plant, groups: [:direct_emissions], free_co2_factor: 0.85)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :ccs_plant, :natural_gas, type: :share)
@@ -119,9 +119,9 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 50)
-          builder.add(:data_center, groups: [:emissions])
-          builder.add(:electricity_grid, groups: [:emissions])
-          builder.add(:coal_plant, groups: [:emissions])
+          builder.add(:data_center, groups: [:direct_emissions])
+          builder.add(:electricity_grid, groups: [:direct_emissions])
+          builder.add(:coal_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :coal_plant, :coal, type: :share)
@@ -161,7 +161,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:refinery, groups: [:emissions])
+          builder.add(:refinery, groups: [:direct_emissions])
           builder.add(:oil_extraction, groups: [:primary_energy_demand])
 
           builder.connect(:oil_extraction, :refinery, :crude_oil, type: :share)
@@ -190,8 +190,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:refinery, groups: [:emissions])
-          builder.add(:oil_blender, groups: [:emissions])
+          builder.add(:refinery, groups: [:direct_emissions])
+          builder.add(:oil_blender, groups: [:direct_emissions])
           builder.add(:conventional_oil, groups: [:primary_energy_demand], demand: 70)
           builder.add(:heavy_oil, groups: [:primary_energy_demand], demand: 30)
 
@@ -259,9 +259,9 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:buildings_space_heater_crude_oil, groups: [:emissions])
-          builder.add(:buildings_final_demand_for_space_heating_crude_oil, groups: [:emissions])
-          builder.add(:buildings_final_demand_crude_oil, groups: [:emissions])
+          builder.add(:buildings_space_heater_crude_oil, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_for_space_heating_crude_oil, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_crude_oil, groups: [:direct_emissions])
           builder.add(:crude_oil_producer, groups: [:primary_energy_demand])
 
           # Connect producer to final demand
@@ -346,9 +346,9 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:buildings_space_heater_crude_oil, groups: [:emissions])
-          builder.add(:buildings_final_demand_for_space_heating_crude_oil, groups: [:emissions])
-          builder.add(:oil_blender, groups: [:emissions])
+          builder.add(:buildings_space_heater_crude_oil, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_for_space_heating_crude_oil, groups: [:direct_emissions])
+          builder.add(:oil_blender, groups: [:direct_emissions])
           builder.add(:conventional_oil, groups: [:primary_energy_demand], demand: 70)
           builder.add(:heavy_oil, groups: [:primary_energy_demand], demand: 30)
 
@@ -457,9 +457,9 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:buildings_space_heater_crude_oil, groups: [:emissions])
-          builder.add(:buildings_final_demand_for_space_heating_crude_oil, groups: [:emissions])
-          builder.add(:buildings_final_demand_crude_oil, groups: [:emissions])
+          builder.add(:buildings_space_heater_crude_oil, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_for_space_heating_crude_oil, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_crude_oil, groups: [:direct_emissions])
           builder.add(:crude_oil_producer, groups: [:primary_energy_demand])
 
           # Connect producer to final demand
@@ -518,7 +518,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 0)
-          builder.add(:power_plant, groups: [:emissions])
+          builder.add(:power_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :power_plant, :coal, type: :share)
@@ -541,7 +541,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:consumer, groups: [:emissions])
+          builder.add(:consumer, groups: [:direct_emissions])
           builder.add(:producer, groups: [:primary_energy_demand])
 
           builder.connect(:producer, :consumer, :custom_carrier, type: :share)
@@ -565,7 +565,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:ccs_plant, groups: [:emissions], ccs_capture_rate: 0.85)
+          builder.add(:ccs_plant, groups: [:direct_emissions], ccs_capture_rate: 0.85)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :ccs_plant, :natural_gas, type: :share)
@@ -594,7 +594,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 200)
-          builder.add(:coal_plant, groups: [:emissions], ccs_capture_rate: 0.0)
+          builder.add(:coal_plant, groups: [:direct_emissions], ccs_capture_rate: 0.0)
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :coal_plant, :coal, type: :share)
@@ -620,7 +620,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 150)
-          builder.add(:plant, groups: [:emissions])
+          builder.add(:plant, groups: [:direct_emissions])
           builder.add(:producer, groups: [:primary_energy_demand])
 
           builder.connect(:producer, :plant, :natural_gas, type: :share)
@@ -646,7 +646,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:bio_plant, groups: [:emissions], ccs_capture_rate: 0.90)
+          builder.add(:bio_plant, groups: [:direct_emissions], ccs_capture_rate: 0.90)
           builder.add(:bio_producer, groups: [:primary_energy_demand])
 
           builder.connect(:bio_producer, :bio_plant, :biogenic_waste, type: :share)
@@ -705,8 +705,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:gas_burner, groups: [:emissions])
-          builder.add(:network_gas_distributor, groups: [:emissions])
+          builder.add(:gas_burner, groups: [:direct_emissions])
+          builder.add(:network_gas_distributor, groups: [:direct_emissions])
           builder.add(:natural_gas_producer, groups: [:primary_energy_demand], demand: 70)
           builder.add(:green_gas_producer, groups: [:primary_energy_demand], demand: 30)
 
@@ -747,8 +747,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:electric_heater, groups: [:emissions])
-          builder.add(:coal_plant, groups: [:emissions])
+          builder.add(:electric_heater, groups: [:direct_emissions])
+          builder.add(:coal_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :coal_plant, :coal, type: :share)
@@ -781,8 +781,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 50)
-          builder.add(:steam_consumer, groups: [:emissions])
-          builder.add(:gas_chp, groups: [:emissions])
+          builder.add(:steam_consumer, groups: [:direct_emissions])
+          builder.add(:gas_chp, groups: [:direct_emissions])
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :gas_chp, :natural_gas, type: :share)
@@ -815,8 +815,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 75)
-          builder.add(:hot_water_heater, groups: [:emissions])
-          builder.add(:boiler, groups: [:emissions])
+          builder.add(:hot_water_heater, groups: [:direct_emissions])
+          builder.add(:boiler, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :boiler, :coal, type: :share)
@@ -849,7 +849,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 200)
-          builder.add(:data_center, groups: [:emissions])
+          builder.add(:data_center, groups: [:direct_emissions])
           builder.add(:electricity_import, groups: [:primary_energy_demand])
 
           builder.connect(:electricity_import, :data_center, :imported_electricity, type: :share)
@@ -923,7 +923,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:waste_burner, groups: [:emissions])
+          builder.add(:waste_burner, groups: [:direct_emissions])
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_waste_producer, :waste_burner, :biogenic_waste, type: :share)
@@ -948,8 +948,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 50)
-          builder.add(:electric_heater, groups: [:emissions])
-          builder.add(:waste_plant, groups: [:emissions])
+          builder.add(:electric_heater, groups: [:direct_emissions])
+          builder.add(:waste_plant, groups: [:direct_emissions])
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_waste_producer, :waste_plant, :biogenic_waste, type: :share)
@@ -986,8 +986,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:burner, groups: [:emissions])
-          builder.add(:biogenic_blender, groups: [:emissions])
+          builder.add(:burner, groups: [:direct_emissions])
+          builder.add(:biogenic_blender, groups: [:direct_emissions])
           builder.add(:wood_waste, groups: [:primary_energy_demand], demand: 60)
           builder.add(:green_waste, groups: [:primary_energy_demand], demand: 40)
 
@@ -1051,7 +1051,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 0)
-          builder.add(:waste_burner, groups: [:emissions])
+          builder.add(:waste_burner, groups: [:direct_emissions])
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_waste_producer, :waste_burner, :biogenic_waste, type: :share)
@@ -1074,7 +1074,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:consumer, groups: [:emissions])
+          builder.add(:consumer, groups: [:direct_emissions])
           builder.add(:producer, groups: [:primary_energy_demand])
 
           builder.connect(:producer, :consumer, :custom_carrier, type: :share)
@@ -1102,9 +1102,9 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:buildings_space_heater_bio_crude, groups: [:emissions])
-          builder.add(:buildings_final_demand_for_space_heating_bio_crude, groups: [:emissions])
-          builder.add(:buildings_final_demand_bio_crude, groups: [:emissions])
+          builder.add(:buildings_space_heater_bio_crude, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_for_space_heating_bio_crude, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_bio_crude, groups: [:direct_emissions])
           builder.add(:bio_crude_producer, groups: [:primary_energy_demand])
 
           # Connect producer to final demand
@@ -1189,9 +1189,9 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:buildings_space_heater_bio_crude, groups: [:emissions])
-          builder.add(:buildings_final_demand_for_space_heating_bio_crude, groups: [:emissions])
-          builder.add(:bio_blender, groups: [:emissions])
+          builder.add(:buildings_space_heater_bio_crude, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_for_space_heating_bio_crude, groups: [:direct_emissions])
+          builder.add(:bio_blender, groups: [:direct_emissions])
           builder.add(:conventional_bio_oil, groups: [:primary_energy_demand], demand: 70)
           builder.add(:heavy_bio_oil, groups: [:primary_energy_demand], demand: 30)
 
@@ -1300,9 +1300,9 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:buildings_space_heater_bio_crude, groups: [:emissions])
-          builder.add(:buildings_final_demand_for_space_heating_bio_crude, groups: [:emissions])
-          builder.add(:buildings_final_demand_bio_crude, groups: [:emissions])
+          builder.add(:buildings_space_heater_bio_crude, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_for_space_heating_bio_crude, groups: [:direct_emissions])
+          builder.add(:buildings_final_demand_bio_crude, groups: [:direct_emissions])
           builder.add(:bio_crude_producer, groups: [:primary_energy_demand])
 
           # Connect producer to final demand
@@ -1370,8 +1370,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:consumer, groups: [:emissions])
-          builder.add(:mixed_blender, groups: [:emissions])
+          builder.add(:consumer, groups: [:direct_emissions])
+          builder.add(:mixed_blender, groups: [:direct_emissions])
           builder.add(:conventional_oil_producer, groups: [:primary_energy_demand], demand: 40)
           builder.add(:heavy_oil_producer, groups: [:primary_energy_demand], demand: 20)
           builder.add(:bio_oil_producer, groups: [:primary_energy_demand], demand: 40)
@@ -1483,7 +1483,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:consumer, groups: [:emissions])
+          builder.add(:consumer, groups: [:direct_emissions])
           builder.add(:bio_crude_producer, groups: [:primary_energy_demand])
 
           # Connect producer to consumer (NO skip group)
@@ -1530,7 +1530,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:processor, groups: [:emissions])
+          builder.add(:processor, groups: [:direct_emissions])
           builder.add(:biogenic_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_producer, :processor, :biogenic_waste, type: :share)
@@ -1565,8 +1565,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus_elec, demand: 60)
           builder.add(:terminus_heat, demand: 40)
-          builder.add(:chp_plant, groups: [:emissions])
-          builder.add(:waste_mix, groups: [:emissions])
+          builder.add(:chp_plant, groups: [:direct_emissions])
+          builder.add(:waste_mix, groups: [:direct_emissions])
           builder.add(:biogenic_producer, groups: [:primary_energy_demand], demand: 60)
           builder.add(:non_biogenic_producer, groups: [:primary_energy_demand], demand: 40)
 
@@ -1622,7 +1622,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:waste_burner, groups: [:emissions])
+          builder.add(:waste_burner, groups: [:direct_emissions])
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_waste_producer, :waste_burner, :biogenic_waste, type: :share)
@@ -1658,8 +1658,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:consumer, groups: [:emissions])
-          builder.add(:distributor, groups: [:emissions])
+          builder.add(:consumer, groups: [:direct_emissions])
+          builder.add(:distributor, groups: [:direct_emissions])
           builder.add(:biogenic_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_producer, :distributor, :biogenic_waste, type: :share)
@@ -1696,7 +1696,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:synfuel_plant, groups: [:emissions], co2_utilisation_per_mj: 0.02)
+          builder.add(:synfuel_plant, groups: [:direct_emissions], co2_utilisation_per_mj: 0.02)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :synfuel_plant, :natural_gas, type: :share)
@@ -1727,7 +1727,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:heat_consumer, demand: 60)
           builder.add(:electric_consumer, demand: 40)
-          builder.add(:chp_plant, groups: [:emissions], co2_utilisation_per_mj: 0.01)
+          builder.add(:chp_plant, groups: [:direct_emissions], co2_utilisation_per_mj: 0.01)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :chp_plant, :natural_gas, type: :share)
@@ -1756,7 +1756,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:power_plant, groups: [:emissions])
+          builder.add(:power_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :power_plant, :coal, type: :share)
@@ -1798,7 +1798,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 0)
-          builder.add(:synfuel_plant, groups: [:emissions], co2_utilisation_per_mj: 0.02)
+          builder.add(:synfuel_plant, groups: [:direct_emissions], co2_utilisation_per_mj: 0.02)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :synfuel_plant, :natural_gas, type: :share)
@@ -1823,7 +1823,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 50)
-          builder.add(:methanol_plant, groups: [:emissions], co2_utilisation_per_mj: 0.15)
+          builder.add(:methanol_plant, groups: [:direct_emissions], co2_utilisation_per_mj: 0.15)
           builder.add(:methanol_producer, groups: [:primary_energy_demand])
 
           builder.connect(:methanol_producer, :methanol_plant, :hydrogen, type: :share)
@@ -1853,7 +1853,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:synfuel_plant, groups: [:emissions], co2_utilisation_per_mj: 0.02)
+          builder.add(:synfuel_plant, groups: [:direct_emissions], co2_utilisation_per_mj: 0.02)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :synfuel_plant, :natural_gas, type: :share)
@@ -1913,7 +1913,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:methanol_plant, groups: [:emissions], co2_utilisation_per_mj: 0.08)
+          builder.add(:methanol_plant, groups: [:direct_emissions], co2_utilisation_per_mj: 0.08)
           builder.add(:hydrogen_producer, groups: [:primary_energy_demand])
 
           builder.connect(:hydrogen_producer, :methanol_plant, :hydrogen, type: :share)
@@ -1958,7 +1958,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:power_plant, groups: [:emissions])
+          builder.add(:power_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :power_plant, :coal, type: :share)
@@ -2006,7 +2006,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 80)
-          builder.add(:ccu_plant, groups: [:emissions], co2_utilisation_per_mj: 0.03)
+          builder.add(:ccu_plant, groups: [:direct_emissions], co2_utilisation_per_mj: 0.03)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :ccu_plant, :natural_gas, type: :share)
@@ -2048,8 +2048,8 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 50)
-          builder.add(:ccu_plant_2, groups: [:emissions], co2_utilisation_per_mj: 0.01)
-          builder.add(:ccu_plant_1, groups: [:emissions], co2_utilisation_per_mj: 0.02)
+          builder.add(:ccu_plant_2, groups: [:direct_emissions], co2_utilisation_per_mj: 0.01)
+          builder.add(:ccu_plant_1, groups: [:direct_emissions], co2_utilisation_per_mj: 0.02)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :ccu_plant_1, :natural_gas, type: :share)
@@ -2115,7 +2115,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:mixed_combustion_plant, groups: [:emissions])
+          builder.add(:mixed_combustion_plant, groups: [:direct_emissions])
           builder.add(:gas_producer, groups: [:primary_energy_demand], demand: 60)
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand], demand: 40)
 
@@ -2163,7 +2163,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 150)
-          builder.add(:waste_burner, groups: [:emissions])
+          builder.add(:waste_burner, groups: [:direct_emissions])
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_waste_producer, :waste_burner, :biogenic_waste, type: :share)
@@ -2211,7 +2211,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:ccs_mixed_plant, groups: [:emissions], ccs_capture_rate: 0.90)
+          builder.add(:ccs_mixed_plant, groups: [:direct_emissions], ccs_capture_rate: 0.90)
           builder.add(:gas_producer, groups: [:primary_energy_demand], demand: 50)
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand], demand: 50)
 
@@ -2276,7 +2276,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 200)
-          builder.add(:beccs_plant, groups: [:emissions], ccs_capture_rate: 0.95)
+          builder.add(:beccs_plant, groups: [:direct_emissions], ccs_capture_rate: 0.95)
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_waste_producer, :beccs_plant, :biogenic_waste, type: :share)
@@ -2321,7 +2321,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:coal_plant, groups: [:emissions])
+          builder.add(:coal_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :coal_plant, :coal, type: :share)
@@ -2364,7 +2364,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:coal_plant, groups: [:emissions])
+          builder.add(:coal_plant, groups: [:direct_emissions])
           builder.add(:coal_producer, groups: [:primary_energy_demand])
 
           builder.connect(:coal_producer, :coal_plant, :coal, type: :share)
@@ -2398,7 +2398,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:passthrough, groups: [:emissions])
+          builder.add(:passthrough, groups: [:direct_emissions])
           builder.add(:producer, groups: [:primary_energy_demand])
 
           builder.connect(:producer, :passthrough, :electricity, type: :share)
@@ -2440,7 +2440,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
   end
 
   describe '#ghg_carrier' do
-    let(:node) { Qernel::Node.new(key: :test_node, graph_name: :energy, groups: [:emissions]).with(demand: 100.0) }
+    let(:node) { Qernel::Node.new(key: :test_node, graph_name: :energy, groups: [:direct_emissions]).with(demand: 100.0) }
 
     context 'with a co2 input slot' do
       before do
@@ -2471,7 +2471,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:co2_utilisation_plant, groups: [:emissions], co2_utilisation_per_mj: 0.08)
+          builder.add(:co2_utilisation_plant, groups: [:direct_emissions], co2_utilisation_per_mj: 0.08)
           builder.add(:co2_source, groups: [:primary_energy_demand])
 
           builder.connect(:co2_source, :co2_utilisation_plant, :co2, type: :share)
@@ -2507,7 +2507,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:regular_plant, groups: [:emissions])
+          builder.add(:regular_plant, groups: [:direct_emissions])
           builder.add(:producer, groups: [:primary_energy_demand])
 
           builder.connect(:producer, :regular_plant, :natural_gas, type: :share)
@@ -2566,7 +2566,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:biogenic_plant, groups: [:emissions])
+          builder.add(:biogenic_plant, groups: [:direct_emissions])
           builder.add(:biogenic_waste_producer, groups: [:primary_energy_demand])
 
           builder.connect(:biogenic_waste_producer, :biogenic_plant, :biogenic_waste, type: :share)
@@ -2601,7 +2601,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:fossil_plant, groups: [:emissions])
+          builder.add(:fossil_plant, groups: [:direct_emissions])
           builder.add(:fossil_producer, groups: [:primary_energy_demand])
 
           builder.connect(:fossil_producer, :fossil_plant, :natural_gas, type: :share)

--- a/spec/models/qernel/node_api/molecule_emissions_spec.rb
+++ b/spec/models/qernel/node_api/molecule_emissions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Qernel::NodeApi::MoleculeEmissions do
     let(:node) { Qernel::Node.new(key: :test_node, graph_name: :molecules, groups: node_groups).with(demand: node_demand) }
 
     let(:node_demand) { 1000.0 }
-    let(:node_groups) { [:emissions] }
+    let(:node_groups) { [:direct_emissions] }
 
     before do
       graph.add(node)
@@ -59,7 +59,7 @@ RSpec.describe Qernel::NodeApi::MoleculeEmissions do
       end
 
       context 'with a CCUS captured node (ccus_captured group)' do
-        let(:node_groups) { [:emissions, :ccus_captured] }
+        let(:node_groups) { [:direct_emissions, :ccus_captured] }
 
         before do
           allow(node).to receive(:input).with(:co2).and_return(double('slot'))
@@ -87,7 +87,7 @@ RSpec.describe Qernel::NodeApi::MoleculeEmissions do
       end
 
       context 'with a CCUS captured node (ccus_captured group)' do
-        let(:node_groups) { [:emissions, :ccus_captured] }
+        let(:node_groups) { [:direct_emissions, :ccus_captured] }
         let(:node_demand) { 750.0 }
 
         it 'returns the node demand (includes CCUS captured as capture)' do
@@ -170,7 +170,7 @@ RSpec.describe Qernel::NodeApi::MoleculeEmissions do
       end
 
       context 'with a CCUS captured node' do
-        let(:node_groups) { [:emissions, :ccus_captured] }
+        let(:node_groups) { [:direct_emissions, :ccus_captured] }
         let(:node_demand) { 400.0 }
 
         before do

--- a/spec/serializers/export/configured_csv_serializer_spec.rb
+++ b/spec/serializers/export/configured_csv_serializer_spec.rb
@@ -156,29 +156,29 @@ RSpec.describe Export::ConfiguredCSVSerializer do
     let(:node_bar) do
       instance_double(
         'Qernel::Node',
-        emissions?: true,
+        direct_emissions?: true,
         node_api: instance_double(
           'Qernel::NodeApi::EnergyApi', key: :bar, direct_reporting_emissions_co2_production: nil
         )
       )
     end
     let(:node_baz) do
-      instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :baz))
+      instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :baz))
     end
     let(:node_foo) do
-      instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :foo))
+      instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :foo))
     end
     let(:node_buildings) do
       instance_double(
-        'Qernel::Node', emissions?: true,
+        'Qernel::Node', direct_emissions?: true,
         node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :buildings_space_heating_demand)
       )
     end
     let(:node_lft) do
-      instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :lft))
+      instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :lft))
     end
     let(:node_waste) do
-      instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::MoleculeApi', key: :m_waste))
+      instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::MoleculeApi', key: :m_waste))
     end
 
     let(:energy_nodes) do
@@ -232,8 +232,8 @@ RSpec.describe Export::ConfiguredCSVSerializer do
       end
     end
 
-    context 'when a labelled node is not in the :emissions group' do
-      before { allow(node_baz).to receive(:emissions?).and_return(false) }
+    context 'when a labelled node is not in the :direct_emissions group' do
+      before { allow(node_baz).to receive(:direct_emissions?).and_return(false) }
 
       it 'excludes it, even though its pair matches an exported row' do
         expect(serializer.data.flatten).not_to include('baz')
@@ -289,10 +289,10 @@ RSpec.describe Export::ConfiguredCSVSerializer do
         end
 
         let(:node_z) do
-          instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :z_node))
+          instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :z_node))
         end
         let(:node_a) do
-          instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :a_node))
+          instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :a_node))
         end
 
         before do
@@ -323,13 +323,13 @@ RSpec.describe Export::ConfiguredCSVSerializer do
         end
 
         let(:node_a) do
-          instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :node_a))
+          instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :node_a))
         end
         let(:node_b) do
-          instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :node_b))
+          instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :node_b))
         end
         let(:node_c) do
-          instance_double('Qernel::Node', emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :node_c))
+          instance_double('Qernel::Node', direct_emissions?: true, node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :node_c))
         end
 
         before do
@@ -349,7 +349,7 @@ RSpec.describe Export::ConfiguredCSVSerializer do
         end
       end
 
-      context 'when a node_attribute value is nil (node not in the :emissions group)' do
+      context 'when a node_attribute value is nil (node not in the :direct_emissions group)' do
         let(:config) do
           {
             schema: [
@@ -364,7 +364,7 @@ RSpec.describe Export::ConfiguredCSVSerializer do
         let(:node_bar) do
           instance_double(
             'Qernel::Node',
-            emissions?: true,
+            direct_emissions?: true,
             node_api: instance_double(
               'Qernel::NodeApi::EnergyApi', key: :bar, direct_reporting_emissions_co2_production: nil
             )


### PR DESCRIPTION
#### Context
Rename the `emissions` group to `direct_emissions`

Goes with:
- https://github.com/quintel/etengine/pull/1785
- https://github.com/quintel/etsource/pull/3464
- https://github.com/quintel/documentation/pull/347

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
