### PR TITLE
Direct emissions 

### DIFF
--- a/app/serializers/export/configured_csv_serializer.rb
+++ b/app/serializers/export/configured_csv_serializer.rb
@@ -41,9 +41,10 @@
 # Mapping-driven mode: `rows: { require: <mapping column> }` selects every (sector label, use) pair
 # in the sector mapping (see Atlas::SectorMapping) whose cell in `require`'s column has a value, in
 # mapping-file order by default. An optional `order_by: <mapping column>` instead orders pairs by the
-# raw display value of that column (ascending string comparison), regardless of whether the column is
-# included in `schema:`; a pair whose `order_by` cell is blank/`-` sorts last, and pairs tied on
-# `order_by` keep their relative mapping-file order. Each pair expands to the energy and molecule
+# raw display value of that column (ascending, comparing digit runs by value so "2.B.10.a" follows
+# "2.B.8.a"), regardless of whether the column is included in `schema:`; a pair whose `order_by` cell
+# is blank/`-` sorts last, and pairs tied on `order_by` keep their relative mapping-file order.
+# Each pair expands to the energy and molecule
 # nodes whose own `sector_label` and `use` match the pair AND which belong to the node's `:direct_emissions`
 # group (key-sorted). A pair with zero labelled nodes, or whose only matching nodes aren't in the
 # `:direct_emissions` group, legally yields zero rows. Mapping-driven mode requires a `period:` (raises
@@ -59,7 +60,11 @@
 #                       transform: "value * 10e-6"
 #                       transform: "value ? :other_ghg : :co2"
 # - "sector_mapping": The value will be the raw display value of the mapping column named by `value:`,
-#                     for the row's pair. A `-`/blank mapping cell renders as an empty string.
+#                     for the row's pair. A `-`/blank mapping cell renders as `-`, the mapping's own
+#                     "no value" token (Atlas::SectorMapping::BLANK_CELL), so the exported cell reads
+#                     back the way it is written in the mapping. Note this is display only: such a
+#                     cell stays unqueryable, and a `-` in the `rows: require:` column still excludes
+#                     the pair from the export entirely.
 #
 # An unknown mapping column named by `require:`, `order_by:`, or a `sector_mapping` column's `value:`
 # raises Export::ConfiguredCSVSerializer::UnknownMappingColumnError at construction, naming the valid
@@ -74,6 +79,11 @@ module Export
 
     # Column types which may appear in a mapping-driven schema.
     MAPPING_COLUMN_TYPES = %w[node_attribute sector_mapping].freeze
+
+    # Width digit runs are zero-padded to in an `order_by` sort key. Any width wider than the
+    # longest run in the data orders those runs numerically; 10 covers far more than the codes
+    # being sorted (IPCC CRT numbers are one or two digits).
+    ORDER_DIGIT_WIDTH = 10
 
     # Represents the schema for a column in the CSV file.
     class Column
@@ -152,7 +162,8 @@ module Export
     end
 
     # Rows whose `require:` cell has a value, in mapping-file order. When `order_by:` is set, sorted
-    # by that column's raw value instead (blank/`-` last), with ties broken by mapping-file order.
+    # by that column's raw value instead (naturally; blank/`-` last), ties broken by mapping-file
+    # order.
     def eligible_rows
       rows = sectors.raw_rows.select { |raw_row| raw_row.cells[@membership_scheme] }
       return rows unless @order_scheme
@@ -162,7 +173,12 @@ module Export
 
     def order_key(raw_row, index)
       cell = raw_row.cells[@order_scheme]
-      [cell.nil? ? 1 : 0, cell.to_s, index]
+      [cell.nil? ? 1 : 0, natural_order_key(cell), index]
+    end
+
+    # Internal: A sort key comparing digit runs by value rather than character by character
+    def natural_order_key(value)
+      value.to_s.gsub(/\d+/) { |digits| digits.rjust(ORDER_DIGIT_WIDTH, '0') }
     end
 
     def serialize_mapping_column(column, raw_row, node)
@@ -173,7 +189,7 @@ module Export
         value = column.transform.call(value) if column.transform
         value.to_s
       else # 'sector_mapping'; the only other type validate_mapping_config! admits
-        raw_row.cells[column.value.to_sym].to_s
+        (raw_row.cells[column.value.to_sym] || Atlas::SectorMapping::BLANK_CELL).to_s
       end
     end
 

--- a/spec/models/qernel/node_api/direct_emissions_spec.rb
+++ b/spec/models/qernel/node_api/direct_emissions_spec.rb
@@ -88,31 +88,6 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       end
     end
 
-    pending 'with CCS capture (free_co2_factor)' do
-      # Create a graph:
-      # [Gas Producer] -> [CCS Plant] -> [Terminus]
-      let(:builder) do
-        TestGraphBuilder.new.tap do |builder|
-          builder.add(:terminus, demand: 100)
-          builder.add(:ccs_plant, groups: [:direct_emissions], free_co2_factor: 0.85)
-          builder.add(:gas_producer, groups: [:primary_energy_demand])
-
-          builder.connect(:gas_producer, :ccs_plant, :natural_gas, type: :share)
-          builder.connect(:ccs_plant, :terminus, :electricity, type: :share)
-
-          builder.carrier_attrs(:natural_gas, co2_conversion_per_mj: 0.0564)
-        end
-      end
-
-      let(:graph) { builder.to_qernel }
-      let(:ccs_plant) { graph.node(:ccs_plant) }
-
-      it 'reduces emissions by capture rate' do
-        # 100 MJ * 0.0564 kg/MJ * (1 - 0.85) = 0.846 kg CO2
-        expect(ccs_plant).to have_query_value(:direct_co2_input_content_carriers_fossil, 0.846)
-      end
-    end
-
     context 'with multi-level supply chain' do
       # Create a graph:
       # [Coal Producer] -> [Coal Plant] -> [Electricity Grid] -> [Data Center] -> [Terminus]
@@ -561,6 +536,162 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
   end
 
   describe 'CO2 capture methods' do
+    context 'with a CCS plant whose output carries no CO2' do
+      # [Gas Producer] -> [CCS Plant] -> [Terminus]
+      #
+      # Electricity is given an explicit zero CO2 content, so the plant's output
+      # content is lower than its input content and the capture rate is applied
+      # to a non-zero amount. The other capture contexts all have output content
+      # equal to input content, which makes capture zero whatever the rate is.
+      let(:builder) do
+        TestGraphBuilder.new.tap do |builder|
+          builder.add(:terminus, demand: 100)
+          builder.add(:ccs_plant, groups: [:emissions], ccs_capture_rate: 0.85)
+          builder.add(:gas_producer, groups: [:primary_energy_demand])
+
+          builder.connect(:gas_producer, :ccs_plant, :natural_gas, type: :share)
+          builder.connect(:ccs_plant, :terminus, :electricity, type: :share)
+
+          builder.carrier_attrs(:natural_gas, co2_conversion_per_mj: 0.0564)
+          builder.carrier_attrs(:electricity, co2_conversion_per_mj: 0.0)
+        end
+      end
+
+      let(:graph) { builder.to_qernel }
+      let(:ccs_plant) { graph.node(:ccs_plant) }
+
+      it 'multiplies the available CO2 by the capture rate' do
+        # A (input): 100 MJ * 0.0564 kg/MJ = 5.64 kg
+        # C (output): 100 MJ * 0.0 kg/MJ   = 0.0 kg
+        # Captured: (A + B - C) * 0.85 = 5.64 * 0.85 = 4.794 kg
+        expect(ccs_plant).to have_query_value(:direct_co2_output_production_capture_fossil, 4.794)
+      end
+
+      it 'captures no biogenic CO2 (no biogenic input)' do
+        expect(ccs_plant).to have_query_value(:direct_co2_output_production_capture_biogenic, 0.0)
+      end
+
+      it 'reports production before capture' do
+        expect(ccs_plant).to have_query_value(:direct_reporting_emissions_co2_production, 5.64)
+      end
+
+      it 'reports total capture as fossil plus biogenic' do
+        expect(ccs_plant).to have_query_value(:direct_reporting_emissions_co2_capture, 4.794)
+      end
+
+      it 'leaves the uncaptured share as total GHG emissions' do
+        # 5.64 - 4.794 = 0.846 kg
+        expect(ccs_plant).to have_query_value(:direct_reporting_emissions_total_ghg_emissions, 0.846)
+      end
+    end
+
+    context 'with a BECCS plant whose output carries no biogenic CO2' do
+      # [Bio Producer] -> [BECCS Plant] -> [Terminus]
+      let(:builder) do
+        TestGraphBuilder.new.tap do |builder|
+          builder.add(:terminus, demand: 100)
+          builder.add(:beccs_plant, groups: [:emissions], ccs_capture_rate: 0.95)
+          builder.add(:bio_producer, groups: [:primary_energy_demand])
+
+          builder.connect(:bio_producer, :beccs_plant, :biogenic_waste, type: :share)
+          builder.connect(:beccs_plant, :terminus, :steam_hot_water, type: :share)
+
+          builder.carrier_attrs(:biogenic_waste, potential_co2_conversion_per_mj: 0.06)
+          builder.carrier_attrs(:steam_hot_water, potential_co2_conversion_per_mj: 0.0)
+        end
+      end
+
+      let(:graph) { builder.to_qernel }
+      let(:beccs_plant) { graph.node(:beccs_plant) }
+
+      it 'multiplies the available biogenic CO2 by the capture rate' do
+        # A (input): 100 MJ * 0.06 kg/MJ = 6.0 kg
+        # C (output): 100 MJ * 0.0 kg/MJ = 0.0 kg
+        # Captured: (A - C) * 0.95 = 5.7 kg
+        expect(beccs_plant).to have_query_value(:direct_co2_output_production_capture_biogenic, 5.7)
+      end
+
+      it 'leaves the uncaptured share as biogenic emissions' do
+        # 6.0 - 5.7 = 0.3 kg
+        expect(beccs_plant).to have_query_value(:direct_reporting_emissions_biogenic_co2_emissions, 0.3)
+      end
+    end
+
+    context 'with CCS plant capturing 85% of emissions' do
+      let(:builder) do
+        TestGraphBuilder.new.tap do |builder|
+          builder.add(:terminus, demand: 100)
+          builder.add(:ccs_plant, groups: [:direct_emissions], ccs_capture_rate: 0.85)
+          builder.add(:gas_producer, groups: [:primary_energy_demand])
+
+          builder.connect(:gas_producer, :ccs_plant, :natural_gas, type: :share)
+          builder.connect(:ccs_plant, :terminus, :electricity, type: :share)
+
+          builder.carrier_attrs(:natural_gas, co2_conversion_per_mj: 0.0564)
+          builder.carrier_attrs(:electricity, co2_conversion_per_mj: 0.0)
+        end
+      end
+
+      let(:graph) { builder.to_qernel }
+      let(:ccs_plant) { graph.node(:ccs_plant) }
+
+      it 'multiplies the available CO2 by the capture rate' do
+        # A (input): 100 MJ * 0.0564 kg/MJ = 5.64 kg
+        # C (output): 100 MJ * 0.0 kg/MJ   = 0.0 kg
+        # Captured: (A + B - C) * 0.85 = 5.64 * 0.85 = 4.794 kg
+        expect(ccs_plant).to have_query_value(:direct_co2_output_production_capture_fossil, 4.794)
+      end
+
+      it 'captures no biogenic CO2 (no biogenic input)' do
+        expect(ccs_plant).to have_query_value(:direct_co2_output_production_capture_biogenic, 0.0)
+      end
+
+      it 'reports production before capture' do
+        expect(ccs_plant).to have_query_value(:direct_reporting_emissions_co2_production, 5.64)
+      end
+
+      it 'reports total capture as fossil plus biogenic' do
+        expect(ccs_plant).to have_query_value(:direct_reporting_emissions_co2_capture, 4.794)
+      end
+
+      it 'leaves the uncaptured share as total GHG emissions' do
+        # 5.64 - 4.794 = 0.846 kg
+        expect(ccs_plant).to have_query_value(:direct_reporting_emissions_total_ghg_emissions, 0.846)
+      end
+    end
+
+    context 'with a BECCS plant whose output carries no biogenic CO2' do
+      # [Bio Producer] -> [BECCS Plant] -> [Terminus]
+      let(:builder) do
+        TestGraphBuilder.new.tap do |builder|
+          builder.add(:terminus, demand: 100)
+          builder.add(:beccs_plant, groups: [:emissions], ccs_capture_rate: 0.95)
+          builder.add(:bio_producer, groups: [:primary_energy_demand])
+
+          builder.connect(:bio_producer, :beccs_plant, :biogenic_waste, type: :share)
+          builder.connect(:beccs_plant, :terminus, :steam_hot_water, type: :share)
+
+          builder.carrier_attrs(:biogenic_waste, potential_co2_conversion_per_mj: 0.06)
+          builder.carrier_attrs(:steam_hot_water, potential_co2_conversion_per_mj: 0.0)
+        end
+      end
+
+      let(:graph) { builder.to_qernel }
+      let(:beccs_plant) { graph.node(:beccs_plant) }
+
+      it 'multiplies the available biogenic CO2 by the capture rate' do
+        # A (input): 100 MJ * 0.06 kg/MJ = 6.0 kg
+        # C (output): 100 MJ * 0.0 kg/MJ = 0.0 kg
+        # Captured: (A - C) * 0.95 = 5.7 kg
+        expect(beccs_plant).to have_query_value(:direct_co2_output_production_capture_biogenic, 5.7)
+      end
+
+      it 'leaves the uncaptured share as biogenic emissions' do
+        # 6.0 - 5.7 = 0.3 kg
+        expect(beccs_plant).to have_query_value(:direct_reporting_emissions_biogenic_co2_emissions, 0.3)
+      end
+    end
+
     context 'with CCS plant capturing 85% of emissions' do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|

--- a/spec/models/qernel/node_api/direct_emissions_spec.rb
+++ b/spec/models/qernel/node_api/direct_emissions_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:ccs_plant, groups: [:emissions], ccs_capture_rate: 0.85)
+          builder.add(:ccs_plant, groups: [:direct_emissions], ccs_capture_rate: 0.85)
           builder.add(:gas_producer, groups: [:primary_energy_demand])
 
           builder.connect(:gas_producer, :ccs_plant, :natural_gas, type: :share)
@@ -590,7 +590,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:beccs_plant, groups: [:emissions], ccs_capture_rate: 0.95)
+          builder.add(:beccs_plant, groups: [:direct_emissions], ccs_capture_rate: 0.95)
           builder.add(:bio_producer, groups: [:primary_energy_demand])
 
           builder.connect(:bio_producer, :beccs_plant, :biogenic_waste, type: :share)
@@ -665,7 +665,7 @@ RSpec.describe Qernel::NodeApi::DirectEmissions do
       let(:builder) do
         TestGraphBuilder.new.tap do |builder|
           builder.add(:terminus, demand: 100)
-          builder.add(:beccs_plant, groups: [:emissions], ccs_capture_rate: 0.95)
+          builder.add(:beccs_plant, groups: [:direct_emissions], ccs_capture_rate: 0.95)
           builder.add(:bio_producer, groups: [:primary_energy_demand])
 
           builder.connect(:bio_producer, :beccs_plant, :biogenic_waste, type: :share)

--- a/spec/serializers/export/configured_csv_serializer_spec.rb
+++ b/spec/serializers/export/configured_csv_serializer_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe Export::ConfiguredCSVSerializer do
           allow(gql.future.graph).to receive(:node).with(:node).and_return(
             instance_double(
               'Qernel::Node',
-              emissions?: true,
+              direct_emissions?: true,
               node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :node)
             )
           )

--- a/spec/serializers/export/configured_csv_serializer_spec.rb
+++ b/spec/serializers/export/configured_csv_serializer_spec.rb
@@ -264,8 +264,14 @@ RSpec.describe Export::ConfiguredCSVSerializer do
       expect(serializer.data[1][2]).to eq('1.A.1')
     end
 
-    it 'renders a blank mapping cell as an empty string' do
-      expect(serializer.data[5]).to eq(['Other', 'lft', ''])
+    it 'renders a blank mapping cell as the mapping\'s own "-" token' do
+      expect(serializer.data[5]).to eq(%w[Other lft -])
+    end
+
+    it 'still excludes a pair whose require column carries "-"' do
+      # `industry_non_specified/energetic` has "-" in emissions_sector. Rendering "-" is display
+      # only; it must not make the pair eligible for export.
+      expect(serializer.data.flatten).not_to include('foo')
     end
 
     context 'with an isolated pair (stubbed Etsource::Sectors)' do
@@ -346,6 +352,50 @@ RSpec.describe Export::ConfiguredCSVSerializer do
 
         it 'sorts by the order_by value first, breaking ties by mapping-file order' do
           expect(serializer.data[1..].flatten).to eq(%w[node_c node_a node_b])
+        end
+      end
+
+      context 'with an "order_by" column holding multi-digit codes' do
+        # Real IPCC CRT code shapes. In mapping-file order the codes are 1-2, 10.a, 3-7..., 8.a;
+        # a character-by-character comparison would leave "2.B.10.a" second, between "2.B.1-2" and
+        # "2.B.3-7,8.b-g,9,10.b".
+        let(:codes) { ['2.B.1-2', '2.B.10.a', '2.B.3-7,8.b-g,9,10.b', '2.B.8.a'] }
+
+        let(:raw_rows) do
+          codes.each_with_index.map do |code, index|
+            Atlas::SectorMapping::RawRow.new(
+              [:"pair_#{index}", :energetic],
+              { emissions_sector: 'Industry', ipcc_crt_code: code }
+            )
+          end
+        end
+
+        let(:config) do
+          {
+            schema: [{ name: 'IPCC', type: 'sector_mapping', value: 'ipcc_crt_code' }],
+            rows: { require: 'emissions_sector', order_by: 'ipcc_crt_code' }
+          }
+        end
+
+        before do
+          allow(sectors).to receive(:mapping).and_return({ emissions_sector: {}, ipcc_crt_code: {} })
+          allow(sectors).to receive(:raw_rows).and_return(raw_rows)
+          allow(sectors).to receive(:node_index).with(:energy).and_return(
+            raw_rows.to_h { |raw_row| [raw_row.pair, [:node]] }
+          )
+          allow(gql.future.graph).to receive(:node).with(:node).and_return(
+            instance_double(
+              'Qernel::Node',
+              emissions?: true,
+              node_api: instance_double('Qernel::NodeApi::EnergyApi', key: :node)
+            )
+          )
+        end
+
+        it 'compares digit runs by value, not character by character' do
+          expect(serializer.data[1..].flatten).to eq(
+            ['2.B.1-2', '2.B.3-7,8.b-g,9,10.b', '2.B.8.a', '2.B.10.a']
+          )
         end
       end
 


### PR DESCRIPTION
#### Context
1. The direct emissions export left blank cells  for mapping categories blank - now they default to "-". (note you will need to checkout `emissions-ipcc` to see this behaviour, or update the mapping config).
2. I also noticed a bug in order_by which was ordering ipcc crt codes alphabetically, however that meant 2.10 was sorted before 2.2 and after 2.1. Now this issue is resolved.
3. A pending spec was removed and new spec was added to cover a CCS context where the plant's output carrier has explicitly zero CO2 content.

## Checklist

- [x] I have tested these changes
- [x] I have updated documentation as needed
- [x] I have tagged the relevant people for review
