### PR TITLE
Inline inputs for collections MVP

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -39,6 +39,8 @@ module Api
 
       around_action :wrap_with_sentry_context, only: :update
 
+      after_action :trigger_update_webhooks, only: :update
+
       # GET /api/v3/scenarios
       #
       # Lists all scenarios belonging to the current user.
@@ -609,6 +611,17 @@ module Api
       # Returns the result of the block.
       def wrap_with_sentry_context(&)
         ScenarioSentryContext.with_context(@scenario, &)
+      end
+
+      # Internal: triggers a webhooks to invalidate cached session data in
+      # the Collections interface, if any user values were updated
+      def trigger_update_webhooks
+        return if filtered_params[:scenario].blank?
+
+        # Only trigger if user values were changed: @scenario.changed? is not working here
+        if filtered_params[:scenario][:user_values].present?
+          InvalidateCollectionSessionJob.perform_later(@scenario)
+        end
       end
     end
   end

--- a/app/jobs/invalidate_collection_session_job.rb
+++ b/app/jobs/invalidate_collection_session_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Triggers a webhook on Collections to clear all caches for the given session
+# and refresh any queries
+class InvalidateCollectionSessionJob < ApplicationJob
+  queue_as :default
+  # TODO: default now performs inline, but this is not optimal. Need a new queue type,
+  # to perform after update request finished - or that is more async.
+
+  def perform(session)
+    InvalidateCollectionSessionJob.client.post(
+      "#{Settings.hooks.collections.session}/#{session.id}"
+    )
+  end
+
+  def self.client
+    Faraday.new(url: Settings.hooks.collections.base_url)
+  end
+end

--- a/app/jobs/invalidate_collection_session_job.rb
+++ b/app/jobs/invalidate_collection_session_job.rb
@@ -10,7 +10,10 @@ class InvalidateCollectionSessionJob < ApplicationJob
   def perform(session)
     InvalidateCollectionSessionJob.client.post(
       "#{Settings.hooks.collections.session}/#{session.id}"
-    )
+    ) do |request|
+      request.headers['Content-Type'] = 'application/json'
+      request.body = { stamp: session.updated_at.utc.iso8601(6) }.to_json
+    end
   end
 
   def self.client

--- a/app/jobs/invalidate_collection_session_job.rb
+++ b/app/jobs/invalidate_collection_session_job.rb
@@ -14,9 +14,11 @@ class InvalidateCollectionSessionJob < ApplicationJob
       request.headers['Content-Type'] = 'application/json'
       request.body = { stamp: session.updated_at.utc.iso8601(6) }.to_json
     end
+  rescue Faraday::Error => e
+    Rails.logger.warn("Collections invalidation failed for session #{session.id}: #{e.message}")
   end
 
   def self.client
-    Faraday.new(url: Settings.hooks.collections.base_url)
+    Faraday.new(url: Settings.hooks.collections.base_url, request: { timeout: 5 })
   end
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,5 +3,5 @@ etmodel: http://localhost:3001
 hooks:
   collections:
     base_url: 'http://collections.local.energytransitionmodel.com:3005'
-    session: '/hooks/invalidate/session'
+    session: '/api/invalidate/sessions'
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,7 @@
 etmodel: http://localhost:3001
+
+hooks:
+  collections:
+    base_url: 'http://collections.local.energytransitionmodel.com:3005'
+    session: '/hooks/invalidate/session'
+

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -7,3 +7,8 @@ etmodel: https://energytransitionmodel.com
 identity:
   issuer: https://my.energytransitionmodel.com
   client_uri: https://engine.energytransitionmodel.com
+
+hooks:
+  collections:
+    base_url: 'http://collections.local.energytransitionmodel.com:3005'
+    session: '/hooks/invalidate/session'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -8,7 +8,8 @@ identity:
   issuer: https://my.energytransitionmodel.com
   client_uri: https://engine.energytransitionmodel.com
 
+# TODO: Collections invalidation is not wired up properly in this environment yet
 hooks:
   collections:
     base_url: 'http://collections.local.energytransitionmodel.com:3005'
-    session: '/hooks/invalidate/session'
+    session: '/api/invalidate/session'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -8,8 +8,7 @@ identity:
   issuer: https://my.energytransitionmodel.com
   client_uri: https://engine.energytransitionmodel.com
 
-# TODO: Collections invalidation is not wired up properly in this environment yet
 hooks:
   collections:
-    base_url: 'http://collections.local.energytransitionmodel.com:3005'
-    session: '/api/invalidate/session'
+    base_url: 'https://collections.energytransitionmodel.com'
+    session: '/api/invalidate/sessions'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -7,3 +7,8 @@ etmodel: https://beta.energytransitionmodel.com
 identity:
   issuer: <%= ENV.fetch('OPENID_ISSUER', 'https://beta.my.energytransitionmodel.com') %>
   client_uri: <%= ENV.fetch('IDENTITY_CLIENT_URI', 'https://beta.engine.energytransitionmodel.com') %>
+
+hooks:
+  collections:
+    base_url: 'http://collections.local.energytransitionmodel.com:3005'
+    session: '/hooks/invalidate/session'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -8,7 +8,8 @@ identity:
   issuer: <%= ENV.fetch('OPENID_ISSUER', 'https://beta.my.energytransitionmodel.com') %>
   client_uri: <%= ENV.fetch('IDENTITY_CLIENT_URI', 'https://beta.engine.energytransitionmodel.com') %>
 
+# TODO: Collections invalidation is not wired up in this environment yet
 hooks:
   collections:
     base_url: 'http://collections.local.energytransitionmodel.com:3005'
-    session: '/hooks/invalidate/session'
+    session: '/api/invalidate/session'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -8,8 +8,7 @@ identity:
   issuer: <%= ENV.fetch('OPENID_ISSUER', 'https://beta.my.energytransitionmodel.com') %>
   client_uri: <%= ENV.fetch('IDENTITY_CLIENT_URI', 'https://beta.engine.energytransitionmodel.com') %>
 
-# TODO: Collections invalidation is not wired up in this environment yet
 hooks:
   collections:
-    base_url: 'http://collections.local.energytransitionmodel.com:3005'
-    session: '/api/invalidate/session'
+    base_url: 'https://beta-collections.energytransitionmodel.com'
+    session: '/api/invalidate/sessions'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,9 +9,9 @@ identity:
   client_secret: client_secret_test
   client_uri: http://localhost:3000
 
-collections_url: http://localhost:3005
+collections_url: http://collections.local.energytransitionmodel.com:3005
 
 hooks:
   collections:
     base_url: 'http://collections.local.energytransitionmodel.com:3005'
-    session: '/hooks/invalidate/session'
+    session: '/api/invalidate/sessions'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,3 +10,8 @@ identity:
   client_uri: http://localhost:3000
 
 collections_url: http://localhost:3005
+
+hooks:
+  collections:
+    base_url: 'http://collections.local.energytransitionmodel.com:3005'
+    session: '/hooks/invalidate/session'

--- a/spec/requests/api/v3/update_scenario_spec.rb
+++ b/spec/requests/api/v3/update_scenario_spec.rb
@@ -121,4 +121,29 @@ describe 'Updating a scenario with API v3' do
       expect(scenario.scenario_version_tag.user.id).to eq(user.id)
     end
   end
+
+  context 'with update webhooks configured' do
+    ActiveJob::Base.queue_adapter = :test
+    let(:user) { create(:user) }
+
+    context 'when user values were updated' do
+      let(:params) { { scenario: { user_values: { bool: 0.0 } } } }
+
+      it 'collections session invalidation was triggered' do
+        expect { update_scenario(params:, headers: access_token_header(user, :delete)) }.to(
+          have_enqueued_job(InvalidateCollectionSessionJob)
+        )
+      end
+    end
+
+    context 'when user values were not updated' do
+      let(:params) { { scenario: { private: true } } }
+
+      it 'collections session invalidation was triggered' do
+        expect { update_scenario(params:, headers: access_token_header(user, :delete)) }.not_to(
+          have_enqueued_job(InvalidateCollectionSessionJob)
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### Context
This is part of the MVP for enhanced workflows for collections: inline editable inputs, and collection IDs in the collections app. Making it possible to edit inputs in Collections without opening ETModel.

Pending UI feedback and network use and cache enhancements in a follow up PR.

#### Implemented changes
Makes inputs inline editable, removing the need for the ETModel iframe.
Adds a cache for sessions, which is invalidated by a webhook originating from the engine, on session update. 
Use collection IDs instead of session IDs in the url

#### Related

Goes with pull requests
myetm -> quintel/myetm#308
etengine -> quintel/etengine#1806
etmodel -> quintel/etmodel#4807
collections -> quintel/multi-year-charts#130

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review

