### PR TITLE
Configure the worker to run over the internal network for collections invalidations

### DIFF
--- a/app/controllers/api/v3/scenarios_controller.rb
+++ b/app/controllers/api/v3/scenarios_controller.rb
@@ -616,6 +616,7 @@ module Api
       # Internal: triggers a webhooks to invalidate cached session data in
       # the Collections interface, if any user values were updated
       def trigger_update_webhooks
+        return unless response.successful?
         return if filtered_params[:scenario].blank?
 
         # Only trigger if user values were changed: @scenario.changed? is not working here

--- a/app/jobs/invalidate_collection_session_job.rb
+++ b/app/jobs/invalidate_collection_session_job.rb
@@ -1,24 +1,29 @@
 # frozen_string_literal: true
 
-# Triggers a webhook on Collections to clear all caches for the given session
-# and refresh any queries
+# Tells Collections that a session changed, so it drops its cached copy and refreshes any queries
 class InvalidateCollectionSessionJob < ApplicationJob
-  queue_as :default
-  # TODO: default now performs inline, but this is not optimal. Need a new queue type,
-  # to perform after update request finished - or that is more async.
+
+  queue_as :collections
+
+  OPEN_TIMEOUT = 1
+  READ_TIMEOUT = 2
 
   def perform(session)
-    InvalidateCollectionSessionJob.client.post(
-      "#{Settings.hooks.collections.session}/#{session.id}"
-    ) do |request|
-      request.headers['Content-Type'] = 'application/json'
-      request.body = { stamp: session.updated_at.utc.iso8601(6) }.to_json
-    end
+    url = Settings.collections_invalidate_url
+    return if url.blank?
+
+    client.post("#{url}/#{session.id}", payload(session), 'Content-Type' => 'application/json')
   rescue Faraday::Error => e
     Rails.logger.warn("Collections invalidation failed for session #{session.id}: #{e.message}")
   end
 
-  def self.client
-    Faraday.new(url: Settings.hooks.collections.base_url, request: { timeout: 5 })
+  private
+
+  def client
+    Faraday.new(request: { open_timeout: OPEN_TIMEOUT, timeout: READ_TIMEOUT })
+  end
+
+  def payload(session)
+    { stamp: session.updated_at.utc.iso8601(6) }.to_json
   end
 end

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -3,9 +3,13 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: "*"
+    - queues: "default"
       threads: 3
       processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+    - queues: "collections"
+      threads: 1
+      processes: 1
       polling_interval: 0.1
 
 development:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,9 @@ mailer:
   # E-mail address from which to send e-mails.
   from: "Energy Transition Model <info@energytransitionmodel.com>"
 
+# The endpoint where the Collections app is listening for invalidation notices
+collections_invalidate_url: <%= ENV['COLLECTIONS_INVALIDATE_URL'] %>
+
 # Authentication
 # --------------
 identity:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,7 +1,4 @@
 etmodel: http://localhost:3001
 
-hooks:
-  collections:
-    base_url: 'http://collections.local.energytransitionmodel.com:3005'
-    session: '/api/invalidate/sessions'
+collections_invalidate_url: http://collections:3005/api/invalidate/sessions
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -7,8 +7,3 @@ etmodel: https://energytransitionmodel.com
 identity:
   issuer: https://my.energytransitionmodel.com
   client_uri: https://engine.energytransitionmodel.com
-
-hooks:
-  collections:
-    base_url: 'https://collections.energytransitionmodel.com'
-    session: '/api/invalidate/sessions'

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -7,8 +7,3 @@ etmodel: https://beta.energytransitionmodel.com
 identity:
   issuer: <%= ENV.fetch('OPENID_ISSUER', 'https://beta.my.energytransitionmodel.com') %>
   client_uri: <%= ENV.fetch('IDENTITY_CLIENT_URI', 'https://beta.engine.energytransitionmodel.com') %>
-
-hooks:
-  collections:
-    base_url: 'https://beta-collections.energytransitionmodel.com'
-    session: '/api/invalidate/sessions'

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -11,7 +11,4 @@ identity:
 
 collections_url: http://collections.local.energytransitionmodel.com:3005
 
-hooks:
-  collections:
-    base_url: 'http://collections.local.energytransitionmodel.com:3005'
-    session: '/api/invalidate/sessions'
+collections_invalidate_url: http://collections:3005/api/invalidate/sessions

--- a/spec/requests/api/v3/update_scenario_spec.rb
+++ b/spec/requests/api/v3/update_scenario_spec.rb
@@ -123,7 +123,13 @@ describe 'Updating a scenario with API v3' do
   end
 
   context 'with update webhooks configured' do
-    ActiveJob::Base.queue_adapter = :test
+    around do |example|
+      was = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      example.run
+      ActiveJob::Base.queue_adapter = was
+    end
+
     let(:user) { create(:user) }
 
     context 'when user values were updated' do
@@ -139,10 +145,26 @@ describe 'Updating a scenario with API v3' do
     context 'when user values were not updated' do
       let(:params) { { scenario: { private: true } } }
 
-      it 'collections session invalidation was triggered' do
+      it 'collections session invalidation was not triggered' do
         expect { update_scenario(params:, headers: access_token_header(user, :delete)) }.not_to(
           have_enqueued_job(InvalidateCollectionSessionJob)
         )
+      end
+    end
+
+    context 'when the update was refused' do
+      let(:params) { { scenario: { user_values: { both_input: 150.0 } } } }
+
+      it 'collections session invalidation was not triggered' do
+        expect { update_scenario(params:, headers: access_token_header(user, :delete)) }.not_to(
+          have_enqueued_job(InvalidateCollectionSessionJob)
+        )
+      end
+
+      it 'was refused successfully' do
+        update_scenario(params:, headers: access_token_header(user, :delete))
+
+        expect(response.status).to eq(422)
       end
     end
   end


### PR DESCRIPTION
#### Context
The inline inputs MVP (#130) put a cache in the Collections server. Cache hits were served without calling ETEngine, which meant they were effectively unauthorised (keyed on the session and query list). This prompted some access changes:
- MYC: 
  - Cached answers belong to the cookie JWT that requested them 
  - The invalidation endpoint bounds the stamd it is given
  - Entries are evicted based on use (before was by write order, read did not count as use)
- Engine:
  - Take the invalidation address from ENV
  - Give the job its own queue and short deadline over the internal bridge
  - Refused update doesn't send an invalidation
- Ansible: 
  - Worker joins etm-internal

Note that the ansible roles **have not yet been run and should be before this is merged**

#### Related
[ETEngine](https://github.com/quintel/etengine/pull/1807)
[MYC](https://github.com/quintel/multi-year-charts/pull/132)
[Ansible](https://github.com/quintel/ansible/pull/122)

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review
